### PR TITLE
JBQA-7293 Add maven debug profile to parent pom and clean it up from tes...

### DIFF
--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/pom.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/pom.xml
@@ -18,7 +18,7 @@
 		<maven.test.failure.ignore>true</maven.test.failure.ignore>
 		<requirementsDirectory>${project.build.directory}/requirements</requirementsDirectory>
 		<runtimesProperties></runtimesProperties>
-		<systemProperties>${additionalSystemProperties} ${runtimesProperties} -Dorg.eclipse.swtbot.screenshots.dir=${project.build.directory}/screenshots</systemProperties>
+		<systemProperties>${runtimesProperties} -Dorg.eclipse.swtbot.screenshots.dir=${project.build.directory}/screenshots</systemProperties>
 	</properties>
 
 	<profiles>

--- a/tests/org.jboss.tools.archives.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.archives.ui.bot.test/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<coverage.filter>org.jboss.ide.eclipse.archives.ui*</coverage.filter>
 		<emma.instrument.bundles>org.jboss.ide.eclipse.archives.ui</emma.instrument.bundles>
-		<systemProperties>${additionalSystemProperties} -Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
+		<systemProperties>-Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
 		<suiteClass>org.jboss.tools.archives.ui.bot.test.ArchivesAllBotTests</suiteClass>
 	</properties>
 	<profiles>

--- a/tests/org.jboss.tools.bpel.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.bpel.ui.bot.test/pom.xml
@@ -13,7 +13,7 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
-		<systemProperties>${additionalSystemProperties} -Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
+		<systemProperties>-Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
 		<surefire.timeout>10800</surefire.timeout>
 		<testClass>org.jboss.tools.bpel.ui.bot.test.suite.BPELAllTest</testClass>
 	</properties>

--- a/tests/org.jboss.tools.cdi.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.bot.test/pom.xml
@@ -13,8 +13,7 @@
 
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
-		<systemProperties>${additionalSystemProperties}
-			-Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
+		<systemProperties>-Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
 		<surefire.timeout>10800</surefire.timeout>
 	</properties>
 

--- a/tests/org.jboss.tools.cdi.seam3.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.seam3.bot.test/pom.xml
@@ -12,17 +12,11 @@
 	
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
-		<systemProperties>${additionalSystemProperties} -Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
+		<systemProperties>-Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
 		<surefire.timeout>10800</surefire.timeout>
 		<suiteClass>org.jboss.tools.cdi.seam3.bot.test.CDISeam3AllBotTests</suiteClass>
 	</properties>
 	<profiles>
-		<profile>
-			<id>debug</id>
-			<properties>
-				<additionalSystemProperties>-Xdebug -Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=y</additionalSystemProperties>
-			</properties>
-		</profile>
 		<profile>
 			<id>jenkins</id>
 			<properties>

--- a/tests/org.jboss.tools.central.test.ui.bot/pom.xml
+++ b/tests/org.jboss.tools.central.test.ui.bot/pom.xml
@@ -20,7 +20,7 @@
 		<!-- for debugging ucomment and comment next line <systemProperties>-Xdebug 
 			-Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=y -Djbosstools.test.jbossas.home=${jbosstools.test.jbossas.home} 
 			-Dswtbot.test.properties.file=${swtbot.properties}</systemProperties> -->
-		<systemProperties>${additionalSystemProperties} -Djbosstools.test.jbossas.home=${jbosstools.test.jbossas.home} -Djbosstools.test.eap.6.0.home=${jbosstools.test.eap.6.0.home} -Dtest.configurations.dir=${test.configurations.dir} -Deap.maven.config.file=${eap.maven.config.file} -Dorg.jboss.tools.tests.skipPrivateRequirements=${skipPrivateRequirements}</systemProperties>
+		<systemProperties>-Djbosstools.test.jbossas.home=${jbosstools.test.jbossas.home} -Djbosstools.test.eap.6.0.home=${jbosstools.test.eap.6.0.home} -Dtest.configurations.dir=${test.configurations.dir} -Deap.maven.config.file=${eap.maven.config.file} -Dorg.jboss.tools.tests.skipPrivateRequirements=${skipPrivateRequirements}</systemProperties>
 		<surefire.timeout>10800</surefire.timeout>
 	</properties>
 

--- a/tests/org.jboss.tools.drools.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.drools.ui.bot.test/pom.xml
@@ -12,7 +12,7 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>eclipse-test-plugin</packaging>
     <properties>
-        <systemProperties>${additionalSystemProperties} -Dswtbot.test.skip=false -Dtest.configurations.dir=resources/</systemProperties>
+        <systemProperties>-Dswtbot.test.skip=false -Dtest.configurations.dir=resources/</systemProperties>
         <surefire.timeout>3600</surefire.timeout>
     </properties>
     <build>

--- a/tests/org.jboss.tools.dummy.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.dummy.ui.bot.test/pom.xml
@@ -14,10 +14,6 @@
 
 	<packaging>eclipse-test-plugin</packaging>
 	
-	<properties>
-			<systemProperties>${additionalSystemProperties}</systemProperties>
-	</properties>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/tests/org.jboss.tools.esb.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.esb.ui.bot.test/pom.xml
@@ -16,7 +16,7 @@
 		<jbosstools.test.jbossesb.home>${requirementsDirectory}/jbossesb-4.11</jbosstools.test.jbossesb.home>
 		<jbosstools.test.jbosssoa.home>${requirementsDirectory}/jboss-soa-p-5/jboss-as</jbosstools.test.jbosssoa.home>
 		<swtbot.test.properties.file>./org.jboss.tools.esb.ui.bot.test.properties</swtbot.test.properties.file>
-		<systemProperties>${additionalSystemProperties} -Djbosstools.test.jbossesb.home=${jbosstools.test.jbossesb.home} -Djbosstools.test.jbosssoa.home=${jbosstools.test.jbosssoa.home} -Dswtbot.test.properties.file=${swtbot.test.properties.file}
+		<systemProperties>-Djbosstools.test.jbossesb.home=${jbosstools.test.jbossesb.home} -Djbosstools.test.jbosssoa.home=${jbosstools.test.jbosssoa.home} -Dswtbot.test.properties.file=${swtbot.test.properties.file}
 		</systemProperties>
 	</properties>
 

--- a/tests/org.jboss.tools.forge.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.forge.ui.bot.test/pom.xml
@@ -14,7 +14,7 @@
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
 		<jbosstools.test.jboss-as.home>${requirementsDirectory}/jboss-as-7.1.1.Final</jbosstools.test.jboss-as.home>
-		<systemProperties>${additionalSystemProperties} -DJAVA_HOME=${JAVA_HOME} -Dtest.configurations.dir=resources/properties -Djbosstools.test.jboss-as.home=${jbosstools.test.jboss-as.home}</systemProperties>
+		<systemProperties>-DJAVA_HOME=${JAVA_HOME} -Dtest.configurations.dir=resources/properties -Djbosstools.test.jboss-as.home=${jbosstools.test.jboss-as.home}</systemProperties>
 	</properties>
 
 	<profiles>

--- a/tests/org.jboss.tools.hibernate.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.hibernate.ui.bot.test/pom.xml
@@ -14,7 +14,7 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
-		<systemProperties>${additionalSystemProperties} -Dtest.configurations.dir=${project.basedir}/properties/</systemProperties>
+		<systemProperties>-Dtest.configurations.dir=${project.basedir}/properties/</systemProperties>
 	</properties>
 		
 	<repositories>

--- a/tests/org.jboss.tools.jbpm.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.jbpm.ui.bot.test/pom.xml
@@ -12,7 +12,7 @@
 	<version>4.5.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
-		<systemProperties>${additionalSystemProperties} -Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
+		<systemProperties>-Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
 	</properties>
 	<build>
 		<plugins>

--- a/tests/org.jboss.tools.jsf.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.jsf.ui.bot.test/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <jbosstools.test.jboss-as.home>${requirementsDirectory}/jboss-as-7.0.2.Final</jbosstools.test.jboss-as.home>
     <org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location>${requirementsDirectory}/richfaces-4.2.1.Final/artifacts/ui/richfaces-components-ui-4.2.1.Final.jar</org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location>
-    <systemProperties>${additionalSystemProperties} -Dtest.configurations.dir=resources/properties/ -Djbosstools.test.jboss-as.home=${jbosstools.test.jboss-as.home} -Dorg.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location=${org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location}</systemProperties>
+    <systemProperties>-Dtest.configurations.dir=resources/properties/ -Djbosstools.test.jboss-as.home=${jbosstools.test.jboss-as.home} -Dorg.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location=${org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location}</systemProperties>
     <test.suite.class>org.jboss.tools.jsf.ui.bot.test.JSFAllBotTests</test.suite.class>
   </properties>
   <build>

--- a/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
@@ -14,7 +14,7 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 		<properties>
-			<systemProperties>${additionalSystemProperties} -Djbosstools.test.jboss.home.7.1=${requirementsDirectory}/jboss-as-7.1.1.Final -Djbosstools.test.seam.2.2.0.home=${requirementsDirectory}/jboss-seam-2.2.0.GA -Djbosstools.test.seam.2.3.0.home=${requirementsDirectory}/jboss-seam-2.3.0</systemProperties>
+			<systemProperties>-Djbosstools.test.jboss.home.7.1=${requirementsDirectory}/jboss-as-7.1.1.Final -Djbosstools.test.seam.2.2.0.home=${requirementsDirectory}/jboss-seam-2.2.0.GA -Djbosstools.test.seam.2.3.0.home=${requirementsDirectory}/jboss-seam-2.3.0</systemProperties>
 		</properties>
 	<build>
 		<plugins>

--- a/tests/org.jboss.tools.modeshape.rest.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.modeshape.rest.ui.bot.test/pom.xml
@@ -15,7 +15,7 @@
 	<properties>
 		<coverage.filter>org.jboss.tools.modeshape.rest.ui*</coverage.filter>
 		<emma.instrument.bundles>org.jboss.tools.modeshape.rest</emma.instrument.bundles>
-        <systemProperties>${additionalSystemProperties} -Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
+        <systemProperties>-Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
 	</properties>
 	
 <build>

--- a/tests/org.jboss.tools.openshift.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/pom.xml
@@ -15,7 +15,7 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
-		<systemProperties>${additionalSystemProperties} -Dtest.configurations.dir=${configurations.dir}</systemProperties>
+		<systemProperties>-Dtest.configurations.dir=${configurations.dir}</systemProperties>
 		<surefire.timeout>10800</surefire.timeout>
 	</properties>
 

--- a/tests/org.jboss.tools.portlet.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.portlet.ui.bot.test/pom.xml
@@ -20,7 +20,7 @@
 		<jbosstools.test.jboss-seam-2.0.home>${requirementsDirectory}/jboss-seam-2.0.1.GA</jbosstools.test.jboss-seam-2.0.home>
 		<jbosstools.test.jboss-portlet-bridge.home>${requirementsDirectory}</jbosstools.test.jboss-portlet-bridge.home>
 		<configurations.dir>resources/project_config_files</configurations.dir>
-		<systemProperties>${additionalSystemProperties} -Djbosstools.test.jboss-gatein.home=${jbosstools.test.jboss-gatein.home} -Djbosstools.test.jboss-seam-2.2.home=${jbosstools.test.jboss-seam-2.2.home} -Djbosstools.test.jboss-portal.home=${jbosstools.test.jboss-portal.home} -Djbosstools.test.jboss-seam-2.0.home=${jbosstools.test.jboss-seam-2.0.home} -Djbosstools.test.jboss-portlet-bridge.home=${jbosstools.test.jboss-portlet-bridge.home} -Dtest.configurations.dir=${configurations.dir}  -Dorg.eclipse.swtbot.screenshots.dir=${project.build.directory}/screenshots</systemProperties>
+		<systemProperties>-Djbosstools.test.jboss-gatein.home=${jbosstools.test.jboss-gatein.home} -Djbosstools.test.jboss-seam-2.2.home=${jbosstools.test.jboss-seam-2.2.home} -Djbosstools.test.jboss-portal.home=${jbosstools.test.jboss-portal.home} -Djbosstools.test.jboss-seam-2.0.home=${jbosstools.test.jboss-seam-2.0.home} -Djbosstools.test.jboss-portlet-bridge.home=${jbosstools.test.jboss-portlet-bridge.home} -Dtest.configurations.dir=${configurations.dir}  -Dorg.eclipse.swtbot.screenshots.dir=${project.build.directory}/screenshots</systemProperties>
 		<test.class>org.jboss.tools.portlet.ui.bot.test.AllTestsSuite</test.class>
 		<surefire.timeout>7200</surefire.timeout>
 	</properties>

--- a/tests/org.jboss.tools.struts.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.struts.ui.bot.test/pom.xml
@@ -14,7 +14,7 @@
 
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
-		<systemProperties>${additionalSystemProperties} -Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
+		<systemProperties>-Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
 		<suiteClass>org.jboss.tools.struts.ui.bot.test.StrutsAllBotTests</suiteClass>
 	</properties>
 	<profiles>

--- a/tests/org.jboss.tools.vpe.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.vpe.ui.bot.test/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <jbosstools.test.jboss-as.home>${requirementsDirectory}/jboss-as-7.0.2.Final</jbosstools.test.jboss-as.home>
     <org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location>${requirementsDirectory}/richfaces-4.2.1.Final/artifacts/ui/richfaces-components-ui-4.2.1.Final.jar</org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location>
-    <systemProperties>${additionalSystemProperties} -Dswtbot.test.skip=false -Dtest.configurations.dir=resources/properties/ -Djbosstools.test.jboss-as.home=${jbosstools.test.jboss-as.home} -Dorg.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location=${org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location}</systemProperties>
+    <systemProperties>-Dswtbot.test.skip=false -Dtest.configurations.dir=resources/properties/ -Djbosstools.test.jboss-as.home=${jbosstools.test.jboss-as.home} -Dorg.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location=${org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location}</systemProperties>
     <test.suite.class>org.jboss.tools.vpe.ui.bot.test.VPEStableSubsetBotTests</test.suite.class>
   </properties>
   <build>

--- a/tests/org.jboss.tools.ws.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.ws.ui.bot.test/pom.xml
@@ -15,7 +15,7 @@
 
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
-		<systemProperties>${additionalSystemProperties} -Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
+		<systemProperties>-Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
 		<surefire.timeout>10800</surefire.timeout>
 	</properties>
 	<profiles>

--- a/tests/org.teiid.designer.ui.bot.test/pom.xml
+++ b/tests/org.teiid.designer.ui.bot.test/pom.xml
@@ -14,7 +14,7 @@
 
 
 	<properties>
-		<systemProperties>${additionalSystemProperties} -Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
+		<systemProperties>-Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
 		<test.class>org.teiid.designer.ui.bot.test.suite.TeiidDesignerAllTests</test.class>
 	</properties>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -12,11 +12,6 @@
 	<name>integration-tests.tests</name>
 	<packaging>pom</packaging>
 
-	<properties>
-		<additionalSystemProperties></additionalSystemProperties>
-		<systemProperties>${additionalSystemProperties}</systemProperties>
-	</properties>
-
 	<modules>
 		<module>org.jboss.ide.eclipse.as.ui.bot.test</module>
 		<module>org.jboss.tools.archives.ui.bot.test</module>
@@ -44,13 +39,5 @@
 		<module>org.jboss.tools.ws.ui.bot.test</module>
 	</modules>
 	
-	<profiles>
-		<profile>
-			<id>debug</id>
-			<properties>
-				<additionalSystemProperties>-Xdebug -Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=y </additionalSystemProperties>
-			</properties>
-		</profile>
-	</profiles>
 </project>
 


### PR DESCRIPTION
...ts poms

This is a second attempt. I finally put the debug profile in jbosstools-build/parent/pom.xml and so now I'm removing it from everywhere else again. The use of ${additionalSystemProperties} is no longer needed. To use the debug profile simply add -P debug to your maven call.
