### PR TITLE
change type of tree because of reddeer upstream change

### DIFF
--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/dialog/preferences/SearchingForRuntimesDialog.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/dialog/preferences/SearchingForRuntimesDialog.java
@@ -9,7 +9,7 @@ import org.jboss.reddeer.swt.condition.ShellWithTextIsActive;
 import org.jboss.reddeer.swt.impl.button.CheckBox;
 import org.jboss.reddeer.swt.impl.button.PushButton;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
-import org.jboss.reddeer.swt.impl.tree.DefaultTree;
+import org.jboss.reddeer.swt.impl.tree.ShellTree;
 import org.jboss.reddeer.swt.wait.WaitWhile;
 import org.jboss.tools.runtime.as.ui.bot.test.entity.Runtime;
 
@@ -52,6 +52,6 @@ public class SearchingForRuntimesDialog {
 	}
 	
 	private List<TreeItem> getRuntimesTreeItems(){
-		return new DefaultTree().getAllItems();
+		return new ShellTree().getAllItems();
 	}
 }


### PR DESCRIPTION
I have refactored DefaultTree and DefaultTreeItem into ShellTree/ViewTree and ShellTreeItem/ViewTreeItem. Runtime bot tests were dependent on DefaultTree -> needed to modify
