### PR TITLE
Added back missing new SOA project test

### DIFF
--- a/tests/org.jboss.tools.esb.ui.bot.test/src/org/jboss/tools/esb/ui/bot/tests/ESBAllBotTests.java
+++ b/tests/org.jboss.tools.esb.ui.bot.test/src/org/jboss/tools/esb/ui/bot/tests/ESBAllBotTests.java
@@ -32,6 +32,7 @@ import org.junit.runners.Suite.SuiteClasses;
 	CreateRuntimeFromSOA.class,
 	NewProjectUsingRuntime.class,
 	NewProjectUsingBundledInEAP.class,
+	NewProjectUsingBundledInSOA.class,
 	Editing.class,
 	HelloWorld.class,	
 	HelloWorldAction.class,


### PR DESCRIPTION
The test that would have caught https://issues.jboss.org/browse/JBIDE-13080 was not listed in the test suite class. 
