### PR TITLE
Add property integrationTestsSystemProperties

### DIFF
--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/pom.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/pom.xml
@@ -18,7 +18,7 @@
 		<maven.test.failure.ignore>true</maven.test.failure.ignore>
 		<requirementsDirectory>${project.build.directory}/requirements</requirementsDirectory>
 		<runtimesProperties></runtimesProperties>
-		<systemProperties>${runtimesProperties} -Dorg.eclipse.swtbot.screenshots.dir=${project.build.directory}/screenshots</systemProperties>
+		<systemProperties>${integrationTestsSystemProperties} ${runtimesProperties} -Dorg.eclipse.swtbot.screenshots.dir=${project.build.directory}/screenshots</systemProperties>
 	</properties>
 
 	<profiles>

--- a/tests/org.jboss.tools.archives.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.archives.ui.bot.test/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<coverage.filter>org.jboss.ide.eclipse.archives.ui*</coverage.filter>
 		<emma.instrument.bundles>org.jboss.ide.eclipse.archives.ui</emma.instrument.bundles>
-		<systemProperties>-Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
+		<systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
 		<suiteClass>org.jboss.tools.archives.ui.bot.test.ArchivesAllBotTests</suiteClass>
 	</properties>
 	<profiles>

--- a/tests/org.jboss.tools.bpel.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.bpel.ui.bot.test/pom.xml
@@ -13,7 +13,7 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
-		<systemProperties>-Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
+		<systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
 		<surefire.timeout>10800</surefire.timeout>
 		<testClass>org.jboss.tools.bpel.ui.bot.test.suite.BPELAllTest</testClass>
 	</properties>

--- a/tests/org.jboss.tools.cdi.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.bot.test/pom.xml
@@ -13,7 +13,7 @@
 
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
-		<systemProperties>-Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
+		<systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
 		<surefire.timeout>10800</surefire.timeout>
 	</properties>
 

--- a/tests/org.jboss.tools.cdi.seam3.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.seam3.bot.test/pom.xml
@@ -12,7 +12,7 @@
 	
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
-		<systemProperties>-Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
+		<systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
 		<surefire.timeout>10800</surefire.timeout>
 		<suiteClass>org.jboss.tools.cdi.seam3.bot.test.CDISeam3AllBotTests</suiteClass>
 	</properties>

--- a/tests/org.jboss.tools.central.test.ui.bot/pom.xml
+++ b/tests/org.jboss.tools.central.test.ui.bot/pom.xml
@@ -17,10 +17,10 @@
 	<properties>
 		<jbosstools.test.jbossas.home>${requirementsDirectory}/jboss-as-7.1.1.Final</jbosstools.test.jbossas.home>
 		<jbosstools.test.eap.6.0.home>${requirementsDirectory}/jboss-eap-6.0</jbosstools.test.eap.6.0.home>
-		<!-- for debugging ucomment and comment next line <systemProperties>-Xdebug 
+		<!-- for debugging ucomment and comment next line <systemProperties>${integrationTestsSystemProperties} -Xdebug 
 			-Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=y -Djbosstools.test.jbossas.home=${jbosstools.test.jbossas.home} 
 			-Dswtbot.test.properties.file=${swtbot.properties}</systemProperties> -->
-		<systemProperties>-Djbosstools.test.jbossas.home=${jbosstools.test.jbossas.home} -Djbosstools.test.eap.6.0.home=${jbosstools.test.eap.6.0.home} -Dtest.configurations.dir=${test.configurations.dir} -Deap.maven.config.file=${eap.maven.config.file} -Dorg.jboss.tools.tests.skipPrivateRequirements=${skipPrivateRequirements}</systemProperties>
+		<systemProperties>${integrationTestsSystemProperties} -Djbosstools.test.jbossas.home=${jbosstools.test.jbossas.home} -Djbosstools.test.eap.6.0.home=${jbosstools.test.eap.6.0.home} -Dtest.configurations.dir=${test.configurations.dir} -Deap.maven.config.file=${eap.maven.config.file} -Dorg.jboss.tools.tests.skipPrivateRequirements=${skipPrivateRequirements}</systemProperties>
 		<surefire.timeout>10800</surefire.timeout>
 	</properties>
 

--- a/tests/org.jboss.tools.drools.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.drools.ui.bot.test/pom.xml
@@ -12,7 +12,7 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>eclipse-test-plugin</packaging>
     <properties>
-        <systemProperties>-Dswtbot.test.skip=false -Dtest.configurations.dir=resources/</systemProperties>
+        <systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.skip=false -Dtest.configurations.dir=resources/</systemProperties>
         <surefire.timeout>3600</surefire.timeout>
     </properties>
     <build>

--- a/tests/org.jboss.tools.esb.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.esb.ui.bot.test/pom.xml
@@ -16,7 +16,7 @@
 		<jbosstools.test.jbossesb.home>${requirementsDirectory}/jbossesb-4.11</jbosstools.test.jbossesb.home>
 		<jbosstools.test.jbosssoa.home>${requirementsDirectory}/jboss-soa-p-5/jboss-as</jbosstools.test.jbosssoa.home>
 		<swtbot.test.properties.file>./org.jboss.tools.esb.ui.bot.test.properties</swtbot.test.properties.file>
-		<systemProperties>-Djbosstools.test.jbossesb.home=${jbosstools.test.jbossesb.home} -Djbosstools.test.jbosssoa.home=${jbosstools.test.jbosssoa.home} -Dswtbot.test.properties.file=${swtbot.test.properties.file}
+		<systemProperties>${integrationTestsSystemProperties} -Djbosstools.test.jbossesb.home=${jbosstools.test.jbossesb.home} -Djbosstools.test.jbosssoa.home=${jbosstools.test.jbosssoa.home} -Dswtbot.test.properties.file=${swtbot.test.properties.file}
 		</systemProperties>
 	</properties>
 

--- a/tests/org.jboss.tools.forge.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.forge.ui.bot.test/pom.xml
@@ -14,7 +14,7 @@
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
 		<jbosstools.test.jboss-as.home>${requirementsDirectory}/jboss-as-7.1.1.Final</jbosstools.test.jboss-as.home>
-		<systemProperties>-DJAVA_HOME=${JAVA_HOME} -Dtest.configurations.dir=resources/properties -Djbosstools.test.jboss-as.home=${jbosstools.test.jboss-as.home}</systemProperties>
+		<systemProperties>${integrationTestsSystemProperties} -DJAVA_HOME=${JAVA_HOME} -Dtest.configurations.dir=resources/properties -Djbosstools.test.jboss-as.home=${jbosstools.test.jboss-as.home}</systemProperties>
 	</properties>
 
 	<profiles>

--- a/tests/org.jboss.tools.freemarker.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.freemarker.ui.bot.test/pom.xml
@@ -12,7 +12,9 @@
 	<version>4.0.0-SNAPSHOT</version>
 
 	<packaging>eclipse-test-plugin</packaging>
-	
+	<properties>
+        <systemProperties>${integrationTestsSystemProperties}</systemProperties>
+    </properties>
 	<build>
 		<plugins>
 			<plugin>

--- a/tests/org.jboss.tools.hibernate.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.hibernate.ui.bot.test/pom.xml
@@ -14,7 +14,7 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
-		<systemProperties>-Dtest.configurations.dir=${project.basedir}/properties/</systemProperties>
+		<systemProperties>${integrationTestsSystemProperties} -Dtest.configurations.dir=${project.basedir}/properties/</systemProperties>
 	</properties>
 		
 	<repositories>

--- a/tests/org.jboss.tools.jbpm.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.jbpm.ui.bot.test/pom.xml
@@ -12,7 +12,7 @@
 	<version>4.5.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
-		<systemProperties>-Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
+		<systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
 	</properties>
 	<build>
 		<plugins>

--- a/tests/org.jboss.tools.jsf.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.jsf.ui.bot.test/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <jbosstools.test.jboss-as.home>${requirementsDirectory}/jboss-as-7.0.2.Final</jbosstools.test.jboss-as.home>
     <org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location>${requirementsDirectory}/richfaces-4.2.1.Final/artifacts/ui/richfaces-components-ui-4.2.1.Final.jar</org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location>
-    <systemProperties>-Dtest.configurations.dir=resources/properties/ -Djbosstools.test.jboss-as.home=${jbosstools.test.jboss-as.home} -Dorg.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location=${org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location}</systemProperties>
+    <systemProperties>${integrationTestsSystemProperties} -Dtest.configurations.dir=resources/properties/ -Djbosstools.test.jboss-as.home=${jbosstools.test.jboss-as.home} -Dorg.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location=${org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location}</systemProperties>
     <test.suite.class>org.jboss.tools.jsf.ui.bot.test.JSFAllBotTests</test.suite.class>
   </properties>
   <build>

--- a/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
@@ -13,7 +13,7 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 		<properties>
-			<systemProperties>-Dhsqldb.driver=${requirementsDirectory}/hsqldb/hsqldb-1.8.0.10.jar -Djbosstools.test.jboss.home.7.1=${requirementsDirectory}/jboss-as-7.1.1.Final -Djbosstools.test.seam.2.2.0.home=${requirementsDirectory}/jboss-seam-2.2.0.GA -Djbosstools.test.seam.2.3.0.home=${requirementsDirectory}/jboss-seam-2.3.0</systemProperties>
+			<systemProperties>${integrationTestsSystemProperties} -Dhsqldb.driver=${requirementsDirectory}/hsqldb/hsqldb-1.8.0.10.jar -Djbosstools.test.jboss.home.7.1=${requirementsDirectory}/jboss-as-7.1.1.Final -Djbosstools.test.seam.2.2.0.home=${requirementsDirectory}/jboss-seam-2.2.0.GA -Djbosstools.test.seam.2.3.0.home=${requirementsDirectory}/jboss-seam-2.3.0</systemProperties>
 		</properties>
 	<build>
 		<plugins>

--- a/tests/org.jboss.tools.modeshape.rest.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.modeshape.rest.ui.bot.test/pom.xml
@@ -15,7 +15,7 @@
 	<properties>
 		<coverage.filter>org.jboss.tools.modeshape.rest.ui*</coverage.filter>
 		<emma.instrument.bundles>org.jboss.tools.modeshape.rest</emma.instrument.bundles>
-        <systemProperties>-Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
+        <systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
 	</properties>
 	
 <build>

--- a/tests/org.jboss.tools.mylyn.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.mylyn.ui.bot.test/pom.xml
@@ -13,7 +13,10 @@
 	<version>4.0.0-SNAPSHOT</version>
 
 	<packaging>eclipse-test-plugin</packaging>
-
+    <properties>
+        <systemProperties>${integrationTestsSystemProperties}</systemProperties>
+    </properties>
+    
 	<repositories>
 		<repository>
 			<id>red_deer</id>

--- a/tests/org.jboss.tools.openshift.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/pom.xml
@@ -15,7 +15,7 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
-		<systemProperties>-Dtest.configurations.dir=${configurations.dir}</systemProperties>
+		<systemProperties>${integrationTestsSystemProperties} -Dtest.configurations.dir=${configurations.dir}</systemProperties>
 		<surefire.timeout>10800</surefire.timeout>
 	</properties>
 

--- a/tests/org.jboss.tools.portlet.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.portlet.ui.bot.test/pom.xml
@@ -20,7 +20,7 @@
 		<jbosstools.test.jboss-seam-2.0.home>${requirementsDirectory}/jboss-seam-2.0.1.GA</jbosstools.test.jboss-seam-2.0.home>
 		<jbosstools.test.jboss-portlet-bridge.home>${requirementsDirectory}</jbosstools.test.jboss-portlet-bridge.home>
 		<configurations.dir>resources/project_config_files</configurations.dir>
-		<systemProperties>-Djbosstools.test.jboss-gatein.home=${jbosstools.test.jboss-gatein.home} -Djbosstools.test.jboss-seam-2.2.home=${jbosstools.test.jboss-seam-2.2.home} -Djbosstools.test.jboss-portal.home=${jbosstools.test.jboss-portal.home} -Djbosstools.test.jboss-seam-2.0.home=${jbosstools.test.jboss-seam-2.0.home} -Djbosstools.test.jboss-portlet-bridge.home=${jbosstools.test.jboss-portlet-bridge.home} -Dtest.configurations.dir=${configurations.dir}  -Dorg.eclipse.swtbot.screenshots.dir=${project.build.directory}/screenshots</systemProperties>
+		<systemProperties>${integrationTestsSystemProperties} -Djbosstools.test.jboss-gatein.home=${jbosstools.test.jboss-gatein.home} -Djbosstools.test.jboss-seam-2.2.home=${jbosstools.test.jboss-seam-2.2.home} -Djbosstools.test.jboss-portal.home=${jbosstools.test.jboss-portal.home} -Djbosstools.test.jboss-seam-2.0.home=${jbosstools.test.jboss-seam-2.0.home} -Djbosstools.test.jboss-portlet-bridge.home=${jbosstools.test.jboss-portlet-bridge.home} -Dtest.configurations.dir=${configurations.dir}  -Dorg.eclipse.swtbot.screenshots.dir=${project.build.directory}/screenshots</systemProperties>
 		<test.class>org.jboss.tools.portlet.ui.bot.test.AllTestsSuite</test.class>
 		<surefire.timeout>7200</surefire.timeout>
 	</properties>

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/pom.xml
@@ -20,6 +20,7 @@
 		<jboss-seam-2.3>${requirementsDirectory}/jboss-seam-2.3.0.Final/</jboss-seam-2.3>
 		<test.class>org.jboss.tools.runtime.as.ui.bot.test.ProjectTestsSuite</test.class>
 		<surefire.timeout>7200</surefire.timeout>
+		<systemProperties>${integrationTestsSystemProperties}</systemProperties>
 	</properties>
 
 	<profiles>

--- a/tests/org.jboss.tools.seam.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.seam.ui.bot.test/pom.xml
@@ -11,6 +11,11 @@
 	<version>4.0.0-SNAPSHOT</version>
 	
 	<packaging>eclipse-test-plugin</packaging>
+	
+	<properties>
+        <systemProperties>${integrationTestsSystemProperties}</systemProperties>
+    </properties>
+    
 	<build>
 		<plugins>
 			<plugin>

--- a/tests/org.jboss.tools.struts.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.struts.ui.bot.test/pom.xml
@@ -14,7 +14,7 @@
 
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
-		<systemProperties>-Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
+		<systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
 		<suiteClass>org.jboss.tools.struts.ui.bot.test.StrutsAllBotTests</suiteClass>
 	</properties>
 	<profiles>

--- a/tests/org.jboss.tools.vpe.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.vpe.ui.bot.test/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <jbosstools.test.jboss-as.home>${requirementsDirectory}/jboss-as-7.0.2.Final</jbosstools.test.jboss-as.home>
     <org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location>${requirementsDirectory}/richfaces-4.2.1.Final/artifacts/ui/richfaces-components-ui-4.2.1.Final.jar</org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location>
-    <systemProperties>-Dswtbot.test.skip=false -Dtest.configurations.dir=resources/properties/ -Djbosstools.test.jboss-as.home=${jbosstools.test.jboss-as.home} -Dorg.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location=${org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location}</systemProperties>
+    <systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.skip=false -Dtest.configurations.dir=resources/properties/ -Djbosstools.test.jboss-as.home=${jbosstools.test.jboss-as.home} -Dorg.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location=${org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location}</systemProperties>
     <test.suite.class>org.jboss.tools.vpe.ui.bot.test.VPEStableSubsetBotTests</test.suite.class>
   </properties>
   <build>

--- a/tests/org.jboss.tools.ws.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.ws.ui.bot.test/pom.xml
@@ -15,7 +15,7 @@
 
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
-		<systemProperties>-Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
+		<systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
 		<surefire.timeout>10800</surefire.timeout>
 	</properties>
 	<profiles>

--- a/tests/org.teiid.designer.ui.bot.test/pom.xml
+++ b/tests/org.teiid.designer.ui.bot.test/pom.xml
@@ -13,7 +13,7 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
-	  <systemProperties>-Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
+	  <systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
 	  <test.class>org.teiid.designer.ui.bot.test.suite.TeiidDesignerAllTests</test.class>
 	  <jdbc.dir>${requirementsDirectory}/lib</jdbc.dir>
 	</properties>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -15,6 +15,8 @@
         <properties>
             <surefire.timeout>7200</surefire.timeout>
             <memoryOptions2>-XX:MaxPermSize=512m</memoryOptions2>
+            <swt.bot.test.record.screencast>false</swt.bot.test.record.screencast>
+            <integrationTestsSystemProperties>-Dswt.bot.test.record.screencast=${swt.bot.test.record.screencast}</integrationTestsSystemProperties>
         </properties>
 
 	<modules>


### PR DESCRIPTION
Add property integrationTestsSystemProperties to store some default tycho properties for integration tests

Currently only sets property swt.bot.test.record.screencast to false but also enable setting of this property from command line
