### PR TITLE
Installing the Juno performance patches change some dialog strings

### DIFF
--- a/tests/org.jboss.tools.mylyn.ui.bot.test/src/org/jboss/tools/mylyn/ui/bot/test/MylynBugzillaQueryTest.java
+++ b/tests/org.jboss.tools.mylyn.ui.bot.test/src/org/jboss/tools/mylyn/ui/bot/test/MylynBugzillaQueryTest.java
@@ -180,7 +180,20 @@ public class MylynBugzillaQueryTest {
 		List<TreeItem> featureItems = FeatureTree.getAllItems();
 		TestSupport.selectTreeItem(featureItems, "Task List", log);
 		Bot.get().sleep(TimePeriod.LONG.getSeconds());
-		new PushButton("OK").click();
+		
+		/* Slightly different text after update for 
+		 * http://wiki.eclipse.org/Platform_UI/Juno_Performance_Investigation
+		 * installed - see: 
+		 * https://issues.jboss.org/browse/JBDS-2441
+		 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=385272
+		 */
+		try {
+			new PushButton("OK").click();
+		}
+		catch (org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException E) {
+			new PushButton("ok").click();
+		}		
+		
 		Bot.get().sleep(TimePeriod.LONG.getSeconds());
 
 		/*

--- a/tests/org.jboss.tools.mylyn.ui.bot.test/src/org/jboss/tools/mylyn/ui/bot/test/TestSupport.java
+++ b/tests/org.jboss.tools.mylyn.ui.bot.test/src/org/jboss/tools/mylyn/ui/bot/test/TestSupport.java
@@ -76,8 +76,20 @@ public class TestSupport {
 		ViewTree FeatureTree = new ViewTree();
 		List<TreeItem> featureItems = FeatureTree.getAllItems();
 		selectTreeItem(featureItems, "Task Repositories", log);
-		new PushButton("OK").click();
 		
+		/* Slightly different text after update for 
+		 * http://wiki.eclipse.org/Platform_UI/Juno_Performance_Investigation
+		 * installed - see:
+		 * https://issues.jboss.org/browse/JBDS-2441
+		 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=385272
+		 */
+		try {
+			new PushButton("OK").click();
+		}
+		catch (org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException E) {
+			new PushButton("ok").click();
+		}
+				
 		Bot.get().sleep(30000l);
 		
 		ViewTree RepoTree = new ViewTree();


### PR DESCRIPTION
https://issues.jboss.org/browse/JBDS-2441
https://bugs.eclipse.org/bugs/show_bug.cgi?id=385272

I am seeing a new issue caused by installing the Eclipse Juno SR1 UI Optimization Patches - see attached screenshots - Some dialogs have uppercase letters replaced with lowercase letters - for example, "OK" becomes "ok" and "Cancel" becomes "cancel"

Changed the Mylyn test code to workaround this change
