### PR TITLE
JBIDE-12973 remove reddeer repo definitions from test poms

### DIFF
--- a/tests/org.jboss.tools.archives.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.archives.ui.bot.test/pom.xml
@@ -86,17 +86,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	<repositories>
-		<repository>
-      		<id>red_deer</id>
-      		<url>http://p2-reddeer.rhcloud.com/master</url>
-      		<layout>p2</layout>
-      		<snapshots>
-         		<enabled>true</enabled>
-      		</snapshots>
-      		<releases>
-         		<enabled>true</enabled>
-     		</releases>
-   		</repository>
-	</repositories>
 </project>

--- a/tests/org.jboss.tools.cdi.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.bot.test/pom.xml
@@ -105,17 +105,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	<repositories>
-		<repository>
-      		<id>red_deer</id>
-      		<url>http://p2-reddeer.rhcloud.com/master</url>
-      		<layout>p2</layout>
-      		<snapshots>
-         		<enabled>true</enabled>
-      		</snapshots>
-      		<releases>
-         		<enabled>true</enabled>
-     		</releases>
-   		</repository>
-	</repositories>
 </project>

--- a/tests/org.jboss.tools.cdi.reddeer/pom.xml
+++ b/tests/org.jboss.tools.cdi.reddeer/pom.xml
@@ -13,17 +13,4 @@
 
 	<packaging>eclipse-test-plugin</packaging>
 
-	<repositories>
-		<repository>
-      		<id>red_deer</id>
-      		<url>http://p2-reddeer.rhcloud.com/master</url>
-      		<layout>p2</layout>
-      		<snapshots>
-         		<enabled>true</enabled>
-      		</snapshots>
-      		<releases>
-         		<enabled>true</enabled>
-     		</releases>
-   		</repository>
-	</repositories>
 </project>

--- a/tests/org.jboss.tools.hibernate.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.hibernate.ui.bot.test/pom.xml
@@ -17,21 +17,6 @@
 		<systemProperties>${integrationTestsSystemProperties} -Dtest.configurations.dir=${project.basedir}/properties/</systemProperties>
 	</properties>
 		
-	<repositories>
-		<!--  RedDeer master repository -->
-		<repository>
-			<id>red_deer</id>
-			<!-- replace url value with any RedDeer update site you require -->
-			<url>http://p2-reddeer.rhcloud.com/master</url>
-			<layout>p2</layout>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-		</repository>
-	</repositories>
 	<build>
 		<plugins>
 			<plugin>

--- a/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
@@ -230,17 +230,4 @@
 		</plugins>
 	</build>
 	
-	<repositories>
-		<repository>
-			<id>red_deer</id>
-			<url>http://p2-reddeer.rhcloud.com/master/</url>
-			<layout>p2</layout>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-		</repository>
-	</repositories>
 </project>

--- a/tests/org.jboss.tools.mylyn.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.mylyn.ui.bot.test/pom.xml
@@ -16,20 +16,6 @@
         <systemProperties>${integrationTestsSystemProperties}</systemProperties>
     </properties>
     
-	<repositories>
-		<repository>
-			<id>red_deer</id>
-			<url>http://p2-reddeer.rhcloud.com/master</url>
-			<layout>p2</layout>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-		</repository>
-	</repositories>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/pom.xml
@@ -39,20 +39,6 @@
 		</pluginRepository>
 	</pluginRepositories>
 
-	<repositories>
-			<repository>
-				<id>red_deer</id>
-				<url>http://p2-reddeer.rhcloud.com/master/</url>
-				<layout>p2</layout>
-				<snapshots>
-					<enabled>true</enabled>
-				</snapshots>
-				<releases>
-					<enabled>true</enabled>
-				</releases>
-			</repository>
-		</repositories>
-			
 	<build>
 		<plugins>
 			<plugin>

--- a/tests/org.jboss.tools.teiid.reddeer/pom.xml
+++ b/tests/org.jboss.tools.teiid.reddeer/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+/?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -13,17 +13,4 @@
 
 	<packaging>eclipse-test-plugin</packaging>
 
-	<repositories>
-		<repository>
-      		<id>red_deer</id>
-      		<url>http://p2-reddeer.rhcloud.com/master</url>
-      		<layout>p2</layout>
-      		<snapshots>
-         		<enabled>true</enabled>
-      		</snapshots>
-      		<releases>
-         		<enabled>true</enabled>
-     		</releases>
-   		</repository>
-	</repositories>
 </project>

--- a/tests/org.jboss.tools.ws.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.ws.ui.bot.test/pom.xml
@@ -82,17 +82,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	<repositories>
-		<repository>
-      		<id>red_deer</id>
-      		<url>http://p2-reddeer.rhcloud.com/master</url>
-      		<layout>p2</layout>
-      		<snapshots>
-         		<enabled>true</enabled>
-      		</snapshots>
-      		<releases>
-         		<enabled>true</enabled>
-     		</releases>
-   		</repository>
-	</repositories>
 </project>

--- a/tests/org.teiid.designer.ui.bot.test/pom.xml
+++ b/tests/org.teiid.designer.ui.bot.test/pom.xml
@@ -18,21 +18,6 @@
 	  <jdbc.dir>${requirementsDirectory}/lib</jdbc.dir>
 	</properties>
 	
-	<!-- Red Deer Repository -->
-	<repositories>
-	  <repository>
-	    <id>red_deer</id>
-	    <url>http://p2-reddeer.rhcloud.com/master</url>
-	    <layout>p2</layout>
-	    <snapshots>
-	      <enabled>true</enabled>
-	    </snapshots>
-	    <releases>
-	      <enabled>true</enabled>
-	    </releases>
-	  </repository>
-	</repositories>
-
 	<build>
 	  <plugins>
 	    <!-- Install AS and Teiid -->


### PR DESCRIPTION
Now that RedDeer gets published to download.jboss.org and the repo is
defined in our tests/pom.xml, it is no longer necessary to add
the repo from the different poms.
