### PR TITLE
JBIDE-12973 Remove the only reddeer version reference found in a manifes...

### DIFF
--- a/tests/org.jboss.tools.freemarker.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.freemarker.ui.bot.test/META-INF/MANIFEST.MF
@@ -9,11 +9,11 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.swtbot.go;bundle-version="2.0.5",
  org.jboss.ide.eclipse.freemarker;bundle-version="1.2.0",
  org.jboss.tools.ui.bot.ext;bundle-version="3.2.0",
- org.jboss.reddeer.direct;bundle-version="0.2.0",
- org.jboss.reddeer.eclipse;bundle-version="0.2.0",
- org.jboss.reddeer.jface;bundle-version="0.2.0",
- org.jboss.reddeer.junit;bundle-version="0.2.0",
- org.jboss.reddeer.swt;bundle-version="0.2.0",
- org.jboss.reddeer.workbench;bundle-version="0.2.0"
+ org.jboss.reddeer.direct,
+ org.jboss.reddeer.eclipse,
+ org.jboss.reddeer.jface,
+ org.jboss.reddeer.junit,
+ org.jboss.reddeer.swt,
+ org.jboss.reddeer.workbench
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6


### PR DESCRIPTION
...t

This was discussed with jpeterka (it's his test). We agreed that it is no
longer necessary to specify the version since we the version will be given
by the repo definition in the root pom.
