### PR TITLE
Update tycho plugin version in site/pom.xml.

### DIFF
--- a/site/pom.xml
+++ b/site/pom.xml
@@ -33,7 +33,7 @@
 			<plugin>
 				<groupId>org.jboss.tools.tycho-plugins</groupId>
 				<artifactId>repository-utils</artifactId>
-				<version>0.0.1-SNAPSHOT</version>
+				<version>0.16.0.CR1</version>
 				<executions>
 					<execution>
 						<id>generate-facade</id>


### PR DESCRIPTION
As per Nick's email, I'm updating the tycho plugin version used
for update site building. The old version - 0.0.1-SNAPSHOT -
got purged from Nexus, so we need to use the newer version.

Please merge this into both branches:
4.0.x and master
