### PR TITLE
Update parent pom reference to version 4.1.0.Alpha2-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0.Alpha1-SNAPSHOT</version>
+		<version>4.1.0.Alpha2-SNAPSHOT</version>
 		<relativePath>../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>


### PR DESCRIPTION
Update to the latest version. We had 4.1.0.Alpha1-SNAPSHOT which
recently stopped working because it points to now non-existent
TP 4.30.5.Alpha-SNAPSHOT. We should be using parent
4.1.0.Alpha2-SNAPSHOT until 4.1.0.Alpha2 is released and then
we'll move to that.
