### PR TITLE
JBIDE-13770 Update integration-tests plugin versions to 4.1 in master

### DIFF
--- a/features/org.jboss.tools.itests.feature/pom.xml
+++ b/features/org.jboss.tools.itests.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
                 <groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>features</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.itests.features</groupId>
 	<artifactId>org.jboss.tools.itests.feature</artifactId>

--- a/features/org.jboss.tools.itests.soa.feature/pom.xml
+++ b/features/org.jboss.tools.itests.soa.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>features</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.itests.soa.features</groupId>
 	<artifactId>org.jboss.tools.itests.soa.feature</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>integration-tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.integration-tests</groupId>
 	<artifactId>features</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>integration-tests</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 	<name>integration-tests.all</name>
 	<packaging>pom</packaging>
 	<!-- 

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>integration-tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.integration-tests</groupId>
 	<artifactId>site</artifactId>

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Bot tests for AS component
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.ui.bot.test;singleton:=true
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.ide.eclipse.as.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/pom.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.tests</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.ui.bot.test</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<packaging>eclipse-test-plugin</packaging>
 

--- a/tests/org.jboss.tools.archives.reddeer/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.archives.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Archive Reddeer
 Bundle-SymbolicName: org.jboss.tools.archives.reddeer
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.archives.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.archives.reddeer/pom.xml
+++ b/tests/org.jboss.tools.archives.reddeer/pom.xml
@@ -3,13 +3,13 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-        <groupId>org.jboss.tools.integration-tests</groupId>
+        	<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.archives</groupId>
 	<artifactId>org.jboss.tools.archives.reddeer</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<packaging>eclipse-test-plugin</packaging>
 

--- a/tests/org.jboss.tools.archives.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.archives.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: org.jboss.tools.archives.ui.bot.test
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.archives.ui.bot.test.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.swtbot.eclipse.core;bundle-version="2.0.0",

--- a/tests/org.jboss.tools.archives.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.archives.ui.bot.test/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
                 <groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.archives.tests</groupId>
 	<artifactId>org.jboss.tools.archives.ui.bot.test</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
 		<coverage.filter>org.jboss.ide.eclipse.archives.ui*</coverage.filter>

--- a/tests/org.jboss.tools.bpel.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.bpel.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
                 <groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.bpel.tests</groupId>
 	<artifactId>org.jboss.tools.bpel.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.cdi.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.cdi.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: CDI SWTBot Test
 Bundle-SymbolicName: org.jboss.tools.cdi.bot.test
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.cdi.bot.test.PluginActivator
 Export-Package: 
  org.jboss.tools.cdi.bot.test,

--- a/tests/org.jboss.tools.cdi.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.bot.test/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
                 <groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.cdi.tests</groupId>
 	<artifactId>org.jboss.tools.cdi.bot.test</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>

--- a/tests/org.jboss.tools.cdi.reddeer/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.cdi.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: CDI Reddeer
 Bundle-SymbolicName: org.jboss.tools.cdi.reddeer
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.cdi.reddeer.Activator
 Export-Package: 
  org.jboss.tools.cdi.reddeer.cdi.ui,

--- a/tests/org.jboss.tools.cdi.reddeer/pom.xml
+++ b/tests/org.jboss.tools.cdi.reddeer/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
         <groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.cdi</groupId>
 	<artifactId>org.jboss.tools.cdi.reddeer</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<packaging>eclipse-test-plugin</packaging>
 

--- a/tests/org.jboss.tools.cdi.seam3.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.cdi.seam3.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: org.jboss.tools.cdi.seam3.bot.test
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.cdi.seam3.bot.test.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.swtbot.eclipse.core;bundle-version="2.0.0",

--- a/tests/org.jboss.tools.cdi.seam3.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.seam3.bot.test/pom.xml
@@ -4,11 +4,11 @@
 	<parent>
         <groupId>org.jboss.tools.integration-tests</groupId>
  		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
  	</parent>
  	<groupId>org.jboss.tools.cdi.tests</groupId>
  	<artifactId>org.jboss.tools.cdi.seam3.bot.test</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 	
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>

--- a/tests/org.jboss.tools.central.test.ui.bot/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.central.test.ui.bot/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.jboss.tools.central.test.ui.bot
 Bundle-SymbolicName: org.jboss.tools.central.test.ui.bot;singleton:=true
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/tests/org.jboss.tools.central.test.ui.bot/pom.xml
+++ b/tests/org.jboss.tools.central.test.ui.bot/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
                 <groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.central.tests</groupId>
 	<artifactId>org.jboss.tools.central.test.ui.bot</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>

--- a/tests/org.jboss.tools.deltaspike.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.deltaspike.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Deltaspike bot tests
 Bundle-SymbolicName: org.jboss.tools.deltaspike.ui.bot.test
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.deltaspike.ui.bot.test.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.swtbot.eclipse.core;bundle-version="2.0.0",

--- a/tests/org.jboss.tools.deltaspike.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.deltaspike.ui.bot.test/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.deltaspike.tests</groupId>
 	<artifactId>org.jboss.tools.deltaspike.ui.bot.test</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>

--- a/tests/org.jboss.tools.drools.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.drools.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.tools.integration-tests</groupId>
         <artifactId>tests</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
     <groupId>org.jboss.tools</groupId>
     <artifactId>org.jboss.tools.drools.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.dummy.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.dummy.ui.bot.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Eclipse-RegisterBuddy: org.apache.log4j
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: org.jboss.tools.dummy.ui.bot.test
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.dummy.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.dummy.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.dummy.ui.bot.test/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jboss.tools.tests.tests</groupId>
 	<artifactId>org.jboss.tools.dummy.ui.bot.test</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<packaging>eclipse-test-plugin</packaging>
 	

--- a/tests/org.jboss.tools.esb.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.esb.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.esb.tests</groupId>
 	<artifactId>org.jboss.tools.esb.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.forge.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.forge.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.jboss.tools.forge.ui.bot.test
 Bundle-SymbolicName: org.jboss.tools.forge.ui.bot.test;singleton:=true
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: J2SE-1.5

--- a/tests/org.jboss.tools.forge.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.forge.ui.bot.test/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.forge.tests</groupId>
 	<artifactId>org.jboss.tools.forge.ui.bot.test</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 	
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>

--- a/tests/org.jboss.tools.freemarker.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.freemarker.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Freemarker UI Bot Test
 Bundle-SymbolicName: org.jboss.tools.freemarker.ui.bot.test
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.freemarker.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.freemarker.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.freemarker.ui.bot.test/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.freemarker.tests</groupId>
 	<artifactId>org.jboss.tools.freemarker.ui.bot.test</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>

--- a/tests/org.jboss.tools.hibernate.reddeer/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.hibernate.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer API for Hibernate UI Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.reddeer
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.hibernate.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.hibernate.reddeer/pom.xml
+++ b/tests/org.jboss.tools.hibernate.reddeer/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.tests</groupId>
 	<artifactId>org.jboss.tools.hibernate.reddeer</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<packaging>eclipse-plugin</packaging>
 

--- a/tests/org.jboss.tools.hibernate.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.hibernate.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.jboss.tools.hibernate.ui.bot.test
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.hibernate.ui.bot.testcase.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.hibernate.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.hibernate.ui.bot.test/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.tests</groupId>
 	<artifactId>org.jboss.tools.hibernate.ui.bot.test</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<packaging>eclipse-test-plugin</packaging>
 

--- a/tests/org.jboss.tools.jbpm.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.jbpm.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.jbpm.tests</groupId>
 	<artifactId>org.jboss.tools.jbpm.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.jsf.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.jsf.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JSF UI SWTBot Tests
 Bundle-SymbolicName: org.jboss.tools.jsf.ui.bot.test
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.jsf.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.jsf.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.jsf.ui.bot.test/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.jboss.tools.integration-tests</groupId>
     <artifactId>tests</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.1.0-SNAPSHOT</version>
   </parent>
   <groupId>org.jboss.tools.jsf.tests</groupId>
   <artifactId>org.jboss.tools.jsf.ui.bot.test</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.1.0-SNAPSHOT</version>
 
   <packaging>eclipse-test-plugin</packaging>
   <properties>

--- a/tests/org.jboss.tools.jst.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.jst.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JST UI SWTBot Tests
 Bundle-SymbolicName: org.jboss.tools.jst.ui.bot.test;singleton:=true
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.ui.bot.test.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.swtbot.eclipse.finder;bundle-version="2.0.0",

--- a/tests/org.jboss.tools.jst.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.jst.ui.bot.test/pom.xml
@@ -4,11 +4,11 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.jst.tests</groupId>
 	<artifactId>org.jboss.tools.jst.ui.bot.test</artifactId> 
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 	
 	<packaging>eclipse-plugin</packaging>
 	<properties>

--- a/tests/org.jboss.tools.maven.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.maven.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss Maven Integration Tests
 Bundle-SymbolicName: org.jboss.tools.maven.ui.bot.test;singleton:=true
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.maven.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.resources,

--- a/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.maven.tests</groupId>
 	<artifactId>org.jboss.tools.maven.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.modeshape.rest.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.modeshape.rest.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
                 <groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.tests</groupId>
 	<artifactId>org.jboss.tools.modeshape.rest.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.mylyn.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.mylyn.ui.bot.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Eclipse-RegisterBuddy: org.apache.log4j
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: org.jboss.tools.mylyn.ui.bot.test
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.mylyn.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.mylyn.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.mylyn.ui.bot.test/pom.xml
@@ -4,12 +4,12 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jboss.tools.tests.tests</groupId>
 	<artifactId>org.jboss.tools.mylyn.ui.bot.test</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<packaging>eclipse-test-plugin</packaging>
     <properties>

--- a/tests/org.jboss.tools.openshift.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: OpenShift SWTBot Tests
 Bundle-SymbolicName: org.jboss.tools.openshift.ui.bot.test
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.openshift.ui.bot.test.Activator
 Bundle-Vendor: Red Hat
 Require-Bundle: org.eclipse.ui,

--- a/tests/org.jboss.tools.openshift.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.openshift.tests</groupId>
 	<artifactId>org.jboss.tools.openshift.ui.bot.test</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<packaging>eclipse-test-plugin</packaging>
 

--- a/tests/org.jboss.tools.portlet.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.portlet.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Portal Tests
 Bundle-SymbolicName: org.jboss.tools.portlet.ui.bot.test;singleton:=true
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: 
  JBoss by Red Hat

--- a/tests/org.jboss.tools.portlet.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.portlet.ui.bot.test/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.portlet.tests</groupId>
 	<artifactId>org.jboss.tools.portlet.ui.bot.test</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<packaging>eclipse-test-plugin</packaging>
 

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Runtime Test
 Bundle-SymbolicName: org.jboss.tools.runtime.as.ui.bot.test;singleton:=true
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: 
  JBoss by Red Hat

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.runtime.as.ui.bot.test</groupId>
 	<artifactId>org.jboss.tools.runtime.as.ui.bot.test</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<packaging>eclipse-test-plugin</packaging>
 

--- a/tests/org.jboss.tools.seam.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.seam.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Seam UI SWTBot Tests
 Bundle-SymbolicName: org.jboss.tools.seam.ui.bot.test;singleton:=true
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.seam.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.seam.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.seam.ui.bot.test/pom.xml
@@ -4,11 +4,11 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.seam.tests</groupId>
 	<artifactId>org.jboss.tools.seam.ui.bot.test</artifactId> 
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 	
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>

--- a/tests/org.jboss.tools.teiid.reddeer/pom.xml
+++ b/tests/org.jboss.tools.teiid.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
         <groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.teiid</groupId>
 	<artifactId>org.jboss.tools.teiid.reddeer</artifactId>

--- a/tests/org.jboss.tools.ui.bot.ext.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.ui.bot.ext.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for SWTBot extensions
 Bundle-SymbolicName: org.jboss.tools.ui.bot.ext.test
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.ui.bot.ext.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.ui.bot.ext.test/pom.xml
+++ b/tests/org.jboss.tools.ui.bot.ext.test/pom.xml
@@ -4,12 +4,12 @@
 	<parent>
        <groupId>org.jboss.tools.integration-tests</groupId>
        <artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
     </parent>
     
 	<groupId>org.jboss.tools.tests.tests</groupId>
 	<artifactId>org.jboss.tools.ui.bot.ext.test</artifactId> 
-       <version>4.0.0-SNAPSHOT</version>
+       <version>4.1.0-SNAPSHOT</version>
 	
 	<packaging>eclipse-test-plugin</packaging>
   

--- a/tests/org.jboss.tools.ui.bot.ext/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.ui.bot.ext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Ext
 Bundle-SymbolicName: org.jboss.tools.ui.bot.ext
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-ClassPath: .,
  resources/drv/hsqldb.jar
 Bundle-Activator: org.jboss.tools.ui.bot.ext.Activator

--- a/tests/org.jboss.tools.ui.bot.ext/pom.xml
+++ b/tests/org.jboss.tools.ui.bot.ext/pom.xml
@@ -4,11 +4,11 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.tests.plugins</groupId>
 	<artifactId>org.jboss.tools.ui.bot.ext</artifactId> 
-	<version>4.0.0-SNAPSHOT</version>	
+	<version>4.1.0-SNAPSHOT</version>	
 	<packaging>eclipse-plugin</packaging>
 	<dependencies>
 		<dependency>

--- a/tests/org.jboss.tools.vpe.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.vpe.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: VPE UI SWTBot Tests
 Bundle-SymbolicName: org.jboss.tools.vpe.ui.bot.test
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.vpe.ui.bot.test.Activator
 Bundle-Vendor: JBoss by Red Hat
 Require-Bundle: org.eclipse.ui,

--- a/tests/org.jboss.tools.vpe.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.vpe.ui.bot.test/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.jboss.tools.integration-tests</groupId>
     <artifactId>tests</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.1.0-SNAPSHOT</version>
   </parent>
   <groupId>org.jboss.tools.vpe.tests</groupId>
   <artifactId>org.jboss.tools.vpe.ui.bot.test</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.1.0-SNAPSHOT</version>
 
   <packaging>eclipse-test-plugin</packaging>
   <properties>

--- a/tests/org.jboss.tools.ws.reddeer/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.ws.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: WS Reddeer
 Bundle-SymbolicName: org.jboss.tools.ws.reddeer
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.ws.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.ws.reddeer/pom.xml
+++ b/tests/org.jboss.tools.ws.reddeer/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
         <groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws</groupId>
 	<artifactId>org.jboss.tools.ws.reddeer</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<packaging>eclipse-test-plugin</packaging>
 

--- a/tests/org.jboss.tools.ws.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.ws.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: WebService SWTBot Tests
 Bundle-SymbolicName: org.jboss.tools.ws.ui.bot.test
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: org.jboss.tools.ws.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.ws.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.ws.ui.bot.test/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.tests</groupId>
 	<artifactId>org.jboss.tools.ws.ui.bot.test</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>

--- a/tests/org.teiid.designer.ui.bot.test/pom.xml
+++ b/tests/org.teiid.designer.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
                 <groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>org.teiid.designer.ui.bot.test</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>integration-tests</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.integration-tests</groupId>
 	<artifactId>tests</artifactId>


### PR DESCRIPTION
This is something that we should have done when master became JBT 4.1.x.
So let's at least do it now. Right now most test plugins are version
4.0.0-SNAPSHOT in both master and jbosstools-4.0.x branch.
I verified that everything can be built.
