### PR TITLE
Improves waiting for active shells when adding class path variable

### DIFF
--- a/tests/org.jboss.tools.jsf.ui.bot.test/src/org/jboss/tools/jsf/ui/bot/test/smoke/PropertiesEditorTest.java
+++ b/tests/org.jboss.tools.jsf.ui.bot.test/src/org/jboss/tools/jsf/ui/bot/test/smoke/PropertiesEditorTest.java
@@ -128,8 +128,8 @@ public class PropertiesEditorTest extends JSFAutoTestCase{
     assertNotEnabled(bot.button(IDELabel.Button.UP));
     // Update Property Directly
     propTable.select(newPropertyIndex);
-    final String updatedPropertyName = "updPropName";
-    final String updatedPropertyValue = "updPropValue";
+    final String updatedPropertyName = "updpropname";
+    final String updatedPropertyValue = "updpropvalue";
     propTable.select(newPropertyIndex);
     propTable.setFocus();
     bot.sleep(Timing.time2S());

--- a/tests/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/helper/BuildPathHelper.java
+++ b/tests/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/helper/BuildPathHelper.java
@@ -21,6 +21,7 @@ import org.jboss.tools.ui.bot.ext.SWTBotExt;
 import org.jboss.tools.ui.bot.ext.SWTEclipseExt;
 import org.jboss.tools.ui.bot.ext.SWTUtilExt;
 import org.jboss.tools.ui.bot.ext.Timing;
+import org.jboss.tools.ui.bot.ext.condition.ActiveShellTitleMatches;
 import org.jboss.tools.ui.bot.ext.types.IDELabel;
 
 /**
@@ -101,8 +102,11 @@ public class BuildPathHelper {
 		}
 		bot.clickButton(IDELabel.Button.OK).click();
 		String result = TableHelper.getSelectionText(bot.table());
+		bot.waitUntil(new ActiveShellTitleMatches(bot, "Preferences \\(Filtered\\)"),Timing.time3S());
 		bot.clickButton(IDELabel.Button.OK).click();
+		bot.waitUntil(new ActiveShellTitleMatches(bot, IDELabel.Shell.NEW_VARIABLE_CLASS_PATH_ENTRY),Timing.time3S());
 		bot.clickButton(IDELabel.Button.OK).click();
+		bot.waitUntil(new ActiveShellTitleMatches(bot, IDELabel.Shell.PROPERTIES_FOR + " " + projectName),Timing.time3S());
 		bot.clickButton(IDELabel.Button.OK).click();
 		new SWTUtilExt(bot).waitForNonIgnoredJobs();
 		return result;


### PR DESCRIPTION
Use just lower case strings for PropertiesEditorTest
