### PR TITLE
ImportHelper not working correctly with JBDS 7.0.0 Alpha2

### DIFF
--- a/tests/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/helper/ImportHelper.java
+++ b/tests/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/helper/ImportHelper.java
@@ -34,7 +34,7 @@ public class ImportHelper {
 		dlgBot.button(IDELabel.Button.NEXT).click();
 		
 		dlgBot.radio(0).click();
-		dlgBot.text().setText(path);
+		dlgBot.comboBox().setText(path);
 		dlgBot.radio(1).click();
 		dlgBot.radio(0).click();
 		dlgBot.button("Select All").click();


### PR DESCRIPTION
Reason of that is change of ui component where the name of project is entered. In previous version it was textbox. Now it is combobox
