### PR TITLE
Use a juno-compatible version of reddeer and unify the repo definition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,19 @@
 	<version>4.0.0-SNAPSHOT</version>
 	<name>integration-tests.all</name>
 	<packaging>pom</packaging>
+	<properties>
+		<reddeer.site>http://download.jboss.org/jbosstools/updates/stable/juno/core/reddeer/0.2.0/</reddeer.site>
+	</properties>
 	<modules>
 		<module>tests</module>
 	</modules>
+        <repositories>
+                <repository>
+                        <id>reddeer-juno-stable-site</id>
+                        <url>${reddeer.site}</url>
+                        <layout>p2</layout>
+                </repository>
+        </repositories>
+
 </project>
 

--- a/tests/org.jboss.tools.archives.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.archives.ui.bot.test/pom.xml
@@ -86,17 +86,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	<repositories>
-		<repository>
-      		<id>red_deer</id>
-      		<url>http://p2-reddeer.rhcloud.com/master</url>
-      		<layout>p2</layout>
-      		<snapshots>
-         		<enabled>true</enabled>
-      		</snapshots>
-      		<releases>
-         		<enabled>true</enabled>
-     		</releases>
-   		</repository>
-	</repositories>
 </project>

--- a/tests/org.jboss.tools.bpel.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.bpel.ui.bot.test/pom.xml
@@ -16,23 +16,10 @@
 	  <systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
 	  <surefire.timeout>10800</surefire.timeout>
 	  <testClass>org.jboss.tools.bpel.ui.bot.test.suite.AllTests</testClass>
-	  <reddeer.site>http://download.jboss.org/jbosstools/builds/staging/RedDeer_master/all/repo</reddeer.site>
 	  <jbtis.site>http://download.jboss.org/jbosstools/updates/integration/juno/integration-stack/aggregate/4.0.0</jbtis.site>
 	</properties>
 
 	<repositories>
-	  <!-- Red Deer Repository -->
-	  <repository>
-	    <id>red_deer</id>
-	    <url>${reddeer.site}</url>
-	    <layout>p2</layout>
-	    <snapshots>
-	      <enabled>true</enabled>
-	    </snapshots>
-	    <releases>
-	      <enabled>true</enabled>
-	    </releases>
-	  </repository>
 	  <!-- JBTIS Repository -->
 	  <repository>
 	    <id>jbtis</id>

--- a/tests/org.jboss.tools.bpmn2.itests/pom.xml
+++ b/tests/org.jboss.tools.bpmn2.itests/pom.xml
@@ -16,24 +16,11 @@
 	<properties>
 		<systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.skip=false -Dtest.configurations.dir=resources/</systemProperties>
 		<surefire.timeout>3600</surefire.timeout>
-		<reddeer.site>http://download.jboss.org/jbosstools/builds/staging/RedDeer_master/all/repo</reddeer.site>
 		<jbtis.site>http://download.jboss.org/jbosstools/updates/integration/juno/integration-stack/aggregate/4.0.0</jbtis.site>
 		<eclipse.graphiti.site>http://download.eclipse.org/graphiti/updates/0.9.0</eclipse.graphiti.site>
 	</properties>
 
 	<repositories>
-		<!-- Red Deer Repository -->
-		<repository>
-			<id>red_deer</id>
-			<url>${reddeer.site}</url>
-			<layout>p2</layout>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-		</repository>
 		<!-- JBTIS Repository -->
 		<repository>
 			<id>jbtis</id>

--- a/tests/org.jboss.tools.cdi.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.bot.test/pom.xml
@@ -105,17 +105,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	<repositories>
-		<repository>
-      		<id>red_deer</id>
-      		<url>http://p2-reddeer.rhcloud.com/master</url>
-      		<layout>p2</layout>
-      		<snapshots>
-         		<enabled>true</enabled>
-      		</snapshots>
-      		<releases>
-         		<enabled>true</enabled>
-     		</releases>
-   		</repository>
-	</repositories>
 </project>

--- a/tests/org.jboss.tools.cdi.reddeer/pom.xml
+++ b/tests/org.jboss.tools.cdi.reddeer/pom.xml
@@ -13,17 +13,4 @@
 
 	<packaging>eclipse-test-plugin</packaging>
 
-	<repositories>
-		<repository>
-      		<id>red_deer</id>
-      		<url>http://p2-reddeer.rhcloud.com/master</url>
-      		<layout>p2</layout>
-      		<snapshots>
-         		<enabled>true</enabled>
-      		</snapshots>
-      		<releases>
-         		<enabled>true</enabled>
-     		</releases>
-   		</repository>
-	</repositories>
 </project>

--- a/tests/org.jboss.tools.drools.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.drools.ui.bot.test/pom.xml
@@ -14,23 +14,10 @@
     <properties>
         <systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.skip=false -Dtest.configurations.dir=resources/</systemProperties>
         <surefire.timeout>3600</surefire.timeout>
-	<reddeer.site>http://download.jboss.org/jbosstools/builds/staging/RedDeer_master/all/repo</reddeer.site>
 	<jbtis.site>http://download.jboss.org/jbosstools/updates/integration/juno/integration-stack/aggregate/4.0.0</jbtis.site>
     </properties>
 
     <repositories>
-      <!-- Red Deer Repository -->
-      <repository>
-	<id>red_deer</id>
-	<url>${reddeer.site}</url>
-	<layout>p2</layout>
-	<snapshots>
-	  <enabled>true</enabled>
-	</snapshots>
-	<releases>
-	  <enabled>true</enabled>
-	</releases>
-      </repository>
       <!-- JBTIS Repository -->
       <repository>
 	<id>jbtis</id>

--- a/tests/org.jboss.tools.esb.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.esb.ui.bot.test/pom.xml
@@ -15,24 +15,11 @@
 	<properties>
 	  <swtbot.test.properties.file>./swtbot.properties</swtbot.test.properties.file>
 	  <systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.properties.file=${swtbot.test.properties.file}</systemProperties>
-	  <reddeer.site>http://download.jboss.org/jbosstools/builds/staging/RedDeer_master/all/repo</reddeer.site>
 	  <jbtis.site>http://download.jboss.org/jbosstools/updates/integration/juno/integration-stack/aggregate/4.0.0</jbtis.site>
 	  <test.class>AllTests</test.class>
 	</properties>
 
 	<repositories>
-	  <!-- Red Deer Repository -->
-	  <repository>
-	    <id>red_deer</id>
-	    <url>${reddeer.site}</url>
-	    <layout>p2</layout>
-	    <snapshots>
-	      <enabled>true</enabled>
-	    </snapshots>
-	    <releases>
-	      <enabled>true</enabled>
-	    </releases>
-	  </repository>
 	  <!-- JBTIS Repository -->
 	  <repository>
 	    <id>jbtis</id>

--- a/tests/org.jboss.tools.hibernate.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.hibernate.ui.bot.test/pom.xml
@@ -17,21 +17,6 @@
 		<systemProperties>${integrationTestsSystemProperties} -Dtest.configurations.dir=${project.basedir}/properties/</systemProperties>
 	</properties>
 		
-	<repositories>
-		<!--  RedDeer master repository -->
-		<repository>
-			<id>red_deer</id>
-			<!-- replace url value with any RedDeer update site you require -->
-			<url>http://p2-reddeer.rhcloud.com/master</url>
-			<layout>p2</layout>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-		</repository>
-	</repositories>
 	<build>
 		<plugins>
 			<plugin>

--- a/tests/org.jboss.tools.jbpm.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.jbpm.ui.bot.test/pom.xml
@@ -13,23 +13,10 @@
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
 	  <systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
-	  <reddeer.site>http://download.jboss.org/jbosstools/builds/staging/RedDeer_master/all/repo</reddeer.site>
 	  <jbtis.site>http://download.jboss.org/jbosstools/updates/integration/juno/integration-stack/aggregate/4.0.0</jbtis.site>
 	</properties>
 
 	<repositories>
-	  <!-- Red Deer Repository -->
-	  <repository>
-	    <id>red_deer</id>
-	    <url>${reddeer.site}</url>
-	    <layout>p2</layout>
-	    <snapshots>
-	      <enabled>true</enabled>
-	    </snapshots>
-	    <releases>
-	      <enabled>true</enabled>
-	    </releases>
-	  </repository>
 	  <!-- JBTIS Repository -->
 	  <repository>
 	    <id>jbtis</id>

--- a/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
@@ -230,17 +230,4 @@
 		</plugins>
 	</build>
 	
-	<repositories>
-		<repository>
-			<id>red_deer</id>
-			<url>http://p2-reddeer.rhcloud.com/master/</url>
-			<layout>p2</layout>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-		</repository>
-	</repositories>
 </project>

--- a/tests/org.jboss.tools.modeshape.rest.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.modeshape.rest.ui.bot.test/pom.xml
@@ -16,23 +16,10 @@
 	  <systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.properties.file=./swtbot.properties</systemProperties>
 	  <surefire.timeout>10800</surefire.timeout>
 	  <testClass>ModeshapeAllTests</testClass>
-	  <reddeer.site>http://download.jboss.org/jbosstools/builds/staging/RedDeer_master/all/repo</reddeer.site>
 	  <jbtis.site>http://download.jboss.org/jbosstools/updates/integration/juno/integration-stack/aggregate/4.0.0</jbtis.site>
 	</properties>
 
 	<repositories>
-	  <!-- Red Deer Repository -->
-	  <repository>
-	    <id>red_deer</id>
-	    <url>${reddeer.site}</url>
-	    <layout>p2</layout>
-	    <snapshots>
-	      <enabled>true</enabled>
-	    </snapshots>
-	    <releases>
-	      <enabled>true</enabled>
-	    </releases>
-	  </repository>
 	  <!-- JBTIS Repository -->
 	  <repository>
 	    <id>jbtis</id>

--- a/tests/org.jboss.tools.mylyn.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.mylyn.ui.bot.test/pom.xml
@@ -17,20 +17,6 @@
         <systemProperties>${integrationTestsSystemProperties}</systemProperties>
     </properties>
     
-	<repositories>
-		<repository>
-			<id>red_deer</id>
-			<url>http://p2-reddeer.rhcloud.com/master</url>
-			<layout>p2</layout>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-		</repository>
-	</repositories>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/tests/org.jboss.tools.openshift.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/pom.xml
@@ -19,21 +19,6 @@
 		<surefire.timeout>10800</surefire.timeout>
 	</properties>
 
-	<repositories>
-		<repository>
-			<id>red_deer</id>
-			<!-- replace url value with any RedDeer update site you require -->
-			<url>http://p2-reddeer.rhcloud.com/stable</url>
-			<layout>p2</layout>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-		</repository>
-	</repositories>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/pom.xml
@@ -39,20 +39,6 @@
 		</pluginRepository>
 	</pluginRepositories>
 
-	<repositories>
-			<repository>
-				<id>red_deer</id>
-				<url>http://p2-reddeer.rhcloud.com/master/</url>
-				<layout>p2</layout>
-				<snapshots>
-					<enabled>true</enabled>
-				</snapshots>
-				<releases>
-					<enabled>true</enabled>
-				</releases>
-			</repository>
-		</repositories>
-			
 	<build>
 		<plugins>
 			<plugin>

--- a/tests/org.jboss.tools.teiid.reddeer/pom.xml
+++ b/tests/org.jboss.tools.teiid.reddeer/pom.xml
@@ -13,17 +13,4 @@
 
 	<packaging>eclipse-plugin</packaging>
 
-	<repositories>
-		<repository>
-      		<id>red_deer</id>
-      		<url>http://p2-reddeer.rhcloud.com/master</url>
-      		<layout>p2</layout>
-      		<snapshots>
-         		<enabled>true</enabled>
-      		</snapshots>
-      		<releases>
-         		<enabled>true</enabled>
-     		</releases>
-   		</repository>
-	</repositories>
 </project>

--- a/tests/org.jboss.tools.ws.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.ws.ui.bot.test/pom.xml
@@ -82,17 +82,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	<repositories>
-		<repository>
-      		<id>red_deer</id>
-      		<url>http://p2-reddeer.rhcloud.com/master</url>
-      		<layout>p2</layout>
-      		<snapshots>
-         		<enabled>true</enabled>
-      		</snapshots>
-      		<releases>
-         		<enabled>true</enabled>
-     		</releases>
-   		</repository>
-	</repositories>
 </project>

--- a/tests/org.teiid.designer.ui.bot.test/pom.xml
+++ b/tests/org.teiid.designer.ui.bot.test/pom.xml
@@ -17,23 +17,10 @@
 	  <test.package>org.teiid.designer.ui.bot.test.suite</test.package>
 	  <test.class>AllTests</test.class>
 	  <jdbc.dir>${requirementsDirectory}/lib</jdbc.dir>
-	  <reddeer.site>http://download.jboss.org/jbosstools/builds/staging/RedDeer_master/all/repo</reddeer.site>
 	  <jbtis.site>http://download.jboss.org/jbosstools/updates/integration/juno/integration-stack/aggregate/4.0.0</jbtis.site>
 	</properties>
 
 	<repositories>
-	  <!-- Red Deer Repository -->
-	  <repository>
-	    <id>red_deer</id>
-	    <url>${reddeer.site}</url>
-	    <layout>p2</layout>
-	    <snapshots>
-	      <enabled>true</enabled>
-	    </snapshots>
-	    <releases>
-	      <enabled>true</enabled>
-	    </releases>
-	  </repository>
 	  <!-- JBTIS Repository -->
 	  <repository>
 	    <id>jbtis</id>


### PR DESCRIPTION
This commit introduces the reddeer p2 repo in the root pom.xml.
It uses a build of the repo compatible with juno.
Also, the reddeer repo definition is now unified - all separate
definitions in different test plugins have been removed.
