### PR TITLE
Fix in the label for EAP 6.1 runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bin/
 target/
+.idea/
+*.iml

--- a/tests/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/gen/ActionItem.java
+++ b/tests/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/gen/ActionItem.java
@@ -1888,7 +1888,7 @@ public static String getItemString(IActionItem item) {
 			* represents item : JBoss Enterprise Middleware->JBoss Enterprise Application Platform 6.1
 			*/
 			public static final IServer LABEL = new IServer() {
-				public String getName() { return "JBoss Enterprise Application Platform 6.1 (Tech Preview)";}
+				public String getName() { return "JBoss Enterprise Application Platform 6.1";}
 				public List<String> getGroupPath() {
 					List<String> l = new Vector<String>();
 					l.add("JBoss Enterprise Middleware");
@@ -10735,7 +10735,7 @@ public static String getItemString(IActionItem item) {
 			* represents item : JBoss Enterprise Middleware->JBoss Enterprise Application Platform 6.1 Runtime
 			*/
 			public static final IServerRuntime LABEL = new IServerRuntime() {
-				public String getName() { return "JBoss Enterprise Application Platform 6.1 Runtime (Tech Preview)";}
+				public String getName() { return "JBoss Enterprise Application Platform 6.1 Runtime";}
 				public List<String> getGroupPath() {
 					List<String> l = new Vector<String>();
 					l.add("JBoss Enterprise Middleware");


### PR DESCRIPTION
Removed (Tech Preview) from the name of EAP 6.1.x server as it is invalid causing SWTBot to fail.
