### PR TITLE
Fix string of no-server message in server view (again)

### DIFF
--- a/tests/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/view/ServersView.java
+++ b/tests/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/view/ServersView.java
@@ -246,7 +246,7 @@ public class ServersView extends ViewBase {
 
 		try {
 			// if there are no servers the following text appears
-			bot.link("<a>No servers available. Define a new server from the new server wizard...</a>");
+			bot.link("<a>No servers are available. Click this link to create a new server...</a>");
 			return false;
 		} catch (WidgetNotFoundException e){
 			// ok, there are some servers, let's check the name


### PR DESCRIPTION
This string is being searched to determine if there are any servers set up or not.
It was updated by jjankovi in May, but for some reason reverted by back rhopp a bit
later. Now fixing again.
