### PR TITLE
JBIDE-15117 Fix duplicate in forge ui bot test pom

### DIFF
--- a/tests/org.jboss.tools.forge.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.forge.ui.bot.test/pom.xml
@@ -46,13 +46,6 @@
 							<skip>${skipRequirements}</skip>
 						</configuration>
 					</execution>
-				</executions>
-			</plugin>
-
-			 <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-dependency-plugin</artifactId>
-                                <executions>
                                         <execution>
                                                 <id>forge-runtime-1.2.0</id>
                                                 <phase>pre-integration-test</phase>


### PR DESCRIPTION
There are two definitions of the maven-dependency-plugin.
They need to be merged into one call with two executions.
