### PR TITLE
Applied Red Deer API changes

### DIFF
--- a/tests/org.jboss.tools.bpel.ui.bot.test/src/org/jboss/tools/bpel/ui/bot/test/AssociateRuntimeTest.java
+++ b/tests/org.jboss.tools.bpel.ui.bot.test/src/org/jboss/tools/bpel/ui/bot/test/AssociateRuntimeTest.java
@@ -45,7 +45,7 @@ public class AssociateRuntimeTest extends SWTBotTestCase {
 	private static boolean containsItem(Table table, String item) {
 		int count = table.rowCount();
 		for (int i = 0; i < count; i++) {
-			if (table.cell(i, 0).equals(item)) {
+			if (table.getItem(i).getText(0).equals(item)) {
 				return true;
 			}
 		}


### PR DESCRIPTION
The method table.cel(x,y) doesn't exist anymore in Red Deer API.
Changed to table.getItem(x).getText(y).
