### PR TITLE
Using getItem(row) and getText(cell) instead of using cell(row, cell).

### DIFF
--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/dialog/preferences/SeamPreferencesDialog.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/dialog/preferences/SeamPreferencesDialog.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import org.jboss.reddeer.eclipse.jface.preference.PreferencePage;
 import org.jboss.reddeer.swt.api.Table;
+import org.jboss.reddeer.swt.api.TableItem;
 import org.jboss.reddeer.swt.condition.JobIsRunning;
 import org.jboss.reddeer.swt.condition.WaitCondition;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
@@ -30,10 +31,11 @@ public class SeamPreferencesDialog extends PreferencePage {
 		Table table = new DefaultTable();
 
 		for (int i = 0; i < table.rowCount(); i++) {
+			TableItem row = table.getItem(i);
 			Runtime runtime = new Runtime();
-			runtime.setName(table.cell(i, 1));
-			runtime.setVersion(table.cell(i, 2));
-			runtime.setLocation(table.cell(i, 3));
+			runtime.setName(row.getText(1));
+			runtime.setVersion(row.getText(2));
+			runtime.setLocation(row.getText(3));
 			runtimes.add(runtime);
 		}
 		return runtimes;


### PR DESCRIPTION
Using changed Reddeer Api to get text from the Table. Just replaced using method .cell(row, cell) by .getItem(row) and .getText(cell)

JBoss Tools Component: runtimes
Author: rrabara
