### PR TITLE
Runtimes table

### DIFF
--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/dialog/preferences/SearchingForRuntimesDialog.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/dialog/preferences/SearchingForRuntimesDialog.java
@@ -18,6 +18,7 @@ import org.jboss.reddeer.swt.util.Display;
 import org.jboss.reddeer.swt.util.ResultRunnable;
 import org.jboss.reddeer.swt.wait.WaitWhile;
 import org.jboss.tools.runtime.as.ui.bot.test.entity.Runtime;
+import org.jboss.tools.ui.bot.ext.condition.ShellIsActiveCondition;
 
 public class SearchingForRuntimesDialog {
 	/**
@@ -66,8 +67,9 @@ public class SearchingForRuntimesDialog {
 	
 	public void ok(){
 		Shell shell = new DefaultShell();
+		String title = shell.getText();
 		new PushButton("OK").click();
-		new WaitWhile(new ShellWithTextIsActive(shell.getText()));
+		new WaitWhile(new ShellWithTextIsActive(title));
 	}
 	
 	public void cancel(){


### PR DESCRIPTION
Fixed problem with condition ShellWithTextIsActive(shell.getText())
- getText() returns null when the shell is closed and the constructor of ShellWithTextIsActive is now checking if the param is null (and throw an exception).

Fixed problem with changed order of columns in runtimes table with more sophisticated getting text from TableItem by name of the column.

JBoss Tools component: runtimes
Author: rrabara
