### PR TITLE
JBTIS-104 Add integration-tests repo definition to root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,11 @@
 			<url>http://download.jboss.org/jbosstools/builds/staging/RedDeer_master/all/repo/</url>
 			<layout>p2</layout>
 		</repository>
+		<repository>
+			<id>jbosstools-integration-tests-site</id>
+			<url>http://download.jboss.org/jbosstools/updates/nightly/integrationtests/trunk/</url>
+			<layout>p2</layout>
+		</repository>
 	</repositories>
 
 </project>


### PR DESCRIPTION
As a consequence of JBTIS-104 and JBIDE-13790, parent pom now contains
a reference to coretests, not integrationtests. In order to resolve
dependencies for bot.ext (and/or others), we need this repo definition.
