### PR TITLE
Changed EAP-6.1's adapter name to EAP-6.1+

### DIFF
--- a/tests/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/config/requirement/AddServer.java
+++ b/tests/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/config/requirement/AddServer.java
@@ -16,7 +16,7 @@ import org.jboss.tools.ui.bot.ext.gen.ActionItem.Server.JBossCommunityWildFly8;
 import org.jboss.tools.ui.bot.ext.gen.ActionItem.Server.JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform43;
 import org.jboss.tools.ui.bot.ext.gen.ActionItem.Server.JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform5x;
 import org.jboss.tools.ui.bot.ext.gen.ActionItem.Server.JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform60;
-import org.jboss.tools.ui.bot.ext.gen.ActionItem.Server.JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform61;
+import org.jboss.tools.ui.bot.ext.gen.ActionItem.Server.JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform61AndLater;
 import org.jboss.tools.ui.bot.ext.gen.ActionItem.ServerRuntime.JBossCommunityJBoss32Runtime;
 import org.jboss.tools.ui.bot.ext.gen.ActionItem.ServerRuntime.JBossCommunityJBoss40Runtime;
 import org.jboss.tools.ui.bot.ext.gen.ActionItem.ServerRuntime.JBossCommunityJBoss42Runtime;
@@ -29,7 +29,7 @@ import org.jboss.tools.ui.bot.ext.gen.ActionItem.ServerRuntime.JBossCommunityWil
 import org.jboss.tools.ui.bot.ext.gen.ActionItem.ServerRuntime.JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform43Runtime;
 import org.jboss.tools.ui.bot.ext.gen.ActionItem.ServerRuntime.JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform5xRuntime;
 import org.jboss.tools.ui.bot.ext.gen.ActionItem.ServerRuntime.JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform60Runtime;
-import org.jboss.tools.ui.bot.ext.gen.ActionItem.ServerRuntime.JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform61Runtime;
+import org.jboss.tools.ui.bot.ext.gen.ActionItem.ServerRuntime.JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform61AndLaterRuntime;
 import org.jboss.tools.ui.bot.ext.gen.IServer;
 import org.jboss.tools.ui.bot.ext.gen.IServerRuntime;
 /**
@@ -129,8 +129,8 @@ public class AddServer extends RequirementBase {
 						JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform5x.LABEL);
 			}
 			if (version!=null && version.equals("6.1")){
-				return new ServerInfo(JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform61Runtime.LABEL,
-						JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform61.LABEL);
+				return new ServerInfo(JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform61AndLaterRuntime.LABEL,
+						JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform61AndLater.LABEL);
 			}else if (version!=null && version.startsWith("6")) {
 				return new ServerInfo(JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform60Runtime.LABEL,
 						JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform60.LABEL);

--- a/tests/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/gen/ActionItem.java
+++ b/tests/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/gen/ActionItem.java
@@ -1900,12 +1900,12 @@ public static String getItemString(IActionItem item) {
 			*/
 			public static final String TEXT_DIRECTORY = "Directory:";
 			}	
-		public static class JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform61 {
+		public static class JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform61AndLater {
 			/**
-			* represents item : JBoss Enterprise Middleware->JBoss Enterprise Application Platform 6.1
+			* represents item : JBoss Enterprise Middleware->JBoss Enterprise Application Platform 6.1+
 			*/
 			public static final IServer LABEL = new IServer() {
-				public String getName() { return "JBoss Enterprise Application Platform 6.1";}
+				public String getName() { return "JBoss Enterprise Application Platform 6.1+";}
 				public List<String> getGroupPath() {
 					List<String> l = new Vector<String>();
 					l.add("JBoss Enterprise Middleware");
@@ -10747,12 +10747,12 @@ public static String getItemString(IActionItem item) {
 			*/
 			public static final String TEXT_DIRECTORY = "Directory:";
 			}
-		public static class JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform61Runtime {
+		public static class JBossEnterpriseMiddlewareJBossEnterpriseApplicationPlatform61AndLaterRuntime {
 			/**
-			* represents item : JBoss Enterprise Middleware->JBoss Enterprise Application Platform 6.1 Runtime
+			* represents item : JBoss Enterprise Middleware->JBoss Enterprise Application Platform 6.1+ Runtime
 			*/
 			public static final IServerRuntime LABEL = new IServerRuntime() {
-				public String getName() { return "JBoss Enterprise Application Platform 6.1 Runtime";}
+				public String getName() { return "JBoss Enterprise Application Platform 6.1+ Runtime";}
 				public List<String> getGroupPath() {
 					List<String> l = new Vector<String>();
 					l.add("JBoss Enterprise Middleware");


### PR DESCRIPTION
EAP 6.1 is now using server adapter "JBoss Enterprise Application Platform 6.1+"

JBoss Tools Component: SWTBotExt
Author: rrabara
