### PR TITLE
JBIDE-13324: Enabled portlets in category.xml 

### DIFF
--- a/site/category.xml
+++ b/site/category.xml
@@ -70,7 +70,7 @@
 <bundle id="org.jboss.tools.maven.ui.bot.test.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle>
 <bundle id="org.jboss.tools.mylyn.ui.bot.test.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle>
 <bundle id="org.jboss.tools.openshift.ui.bot.test.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle>
-<!-- JBIDE-13324 <bundle id="org.jboss.tools.portlet.ui.bot.test.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle> -->
+<bundle id="org.jboss.tools.portlet.ui.bot.test.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle>
 <bundle id="org.jboss.tools.runtime.as.ui.bot.test.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle>
 <bundle id="org.jboss.tools.seam.ui.bot.test.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle>
 <bundle id="org.jboss.tools.ui.bot.ext.test.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle>


### PR DESCRIPTION
Solving "integration-tests: cannot build portlet ui bot tests". Also enabled portles in site/category.xml to build bundle

Link: https://issues.jboss.org/browse/JBIDE-13324
JBoss Tools Component: portlets
Author: rrabara
