### PR TITLE
JBIDE-16245 Show correct version of integration tests repo web page

### DIFF
--- a/site/pom.xml
+++ b/site/pom.xml
@@ -9,16 +9,14 @@
 	</parent>
 	<groupId>org.jboss.tools.integration-tests</groupId>
 	<artifactId>site</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 	<name>integration-tests.site</name>
 	<packaging>eclipse-repository</packaging>
 	<repositories>
 	</repositories>
 
 	<properties>
-		<update.site.name>JBoss Tools 4.1 - Tests</update.site.name>
+		<update.site.name>JBoss Tools 4.1 - Integration Tests</update.site.name>
 		<update.site.description>Nightly Build</update.site.description>
-		<update.site.version>1.0.0.${BUILD_ALIAS}</update.site.version>
 		<target.eclipse.version>4.3 (Kepler)</target.eclipse.version>
 		<siteTemplateFolder>siteTemplateFolder</siteTemplateFolder>
 	</properties>
@@ -47,7 +45,6 @@
 							<symbols>
 								<update.site.name>${update.site.name}</update.site.name>
 								<update.site.description>${update.site.description}</update.site.description>
-								<update.site.version>${update.site.version}</update.site.version>
 								<target.eclipse.version>${target.eclipse.version}</target.eclipse.version>
 							</symbols>
 						</configuration>


### PR DESCRIPTION
Updated site/pom.xml to generate the proper version in the repo html
page. This also removes the explicit version definition for the site.
