### PR TITLE
Updated runtime tests to support EAP 6.2 GA

### DIFF
--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/pom.xml
@@ -17,8 +17,8 @@
 		<requirementsDirectory>${project.build.directory}/requirements</requirementsDirectory>
 
 		<jboss-eap-6.2>${requirementsDirectory}/jboss-eap-6.2/</jboss-eap-6.2>
-		<jbosstools.test.jboss-eap-6.2.url>http://download.devel.redhat.com/released/JBEAP-6/6.2.0-Beta/jboss-eap-6.2.0.Beta.zip</jbosstools.test.jboss-eap-6.2.url>
-		<jbosstools.test.jboss-eap-6.2.md5>7abd969f6a80f5eb1311e16522ae2209</jbosstools.test.jboss-eap-6.2.md5>
+		<jbosstools.test.jboss-eap-6.2.url>http://download.devel.redhat.com/released/JBEAP-6/6.2.0/jboss-eap-6.2.0.zip</jbosstools.test.jboss-eap-6.2.url>
+		<jbosstools.test.jboss-eap-6.2.md5>03ec01654cf4aee8c8e26313fae68c16</jbosstools.test.jboss-eap-6.2.md5>
 
 		<jboss-eap-6.1.x>${requirementsDirectory}/jboss-eap-6.1.x/jboss-eap-6.1/</jboss-eap-6.1.x>
 		<jbosstools.test.jboss-eap-6.1.x.url>http://download.devel.redhat.com/released/JBEAP-6/6.1.1/jboss-eap-6.1.1.zip</jbosstools.test.jboss-eap-6.1.x.url>


### PR DESCRIPTION
Changed pom.xml to use EAP 6.2 GA instead of EAP 6.2 Beta

JBoss Tools Component: runtimes
Author: rrabara
