### PR TITLE
Launchers and TestSuites

### DIFF
--- a/tests/org.jboss.tools.openshift.ui.bot.test/.classpath
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/"/>
-	<classpathentry kind="src" path="resources/"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="resources"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/tests/org.jboss.tools.openshift.ui.bot.test/OpenShiftEnterpriseBotTests.launch
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/OpenShiftEnterpriseBotTests.launch
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.swtbot.eclipse.ui.launcher.JunitLaunchConfig">
+<booleanAttribute key="append.args" value="true"/>
+<booleanAttribute key="askclear" value="false"/>
+<booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticValidate" value="false"/>
+<stringAttribute key="bootstrap" value=""/>
+<stringAttribute key="checked" value="[NONE]"/>
+<booleanAttribute key="clearConfig" value="true"/>
+<booleanAttribute key="clearws" value="true"/>
+<booleanAttribute key="clearwslog" value="false"/>
+<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+<booleanAttribute key="default" value="true"/>
+<booleanAttribute key="includeOptional" value="true"/>
+<stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/OpenShiftEnterpriseBotTests.java"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<mapAttribute key="org.eclipse.debug.core.environmentVariables">
+<mapEntry key="DISPLAY" value=":1"/>
+</mapAttribute>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.jboss.tools.openshift.ui.bot.test.OpenShiftEnterpriseBotTests"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.jboss.tools.openshift.ui.bot.test"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dosgi.requiredJavaVersion=1.5 -XX:MaxPermSize=256m -Xms40m -Xmx512m -Dswtbot.test.properties.file=${project_loc}/resources/swtbot.properties -Dusage_reporting_enabled=false -Dlibra.server=${string_prompt:OpenShift server} -Duser.name=${string_prompt:OpenShift user} -Duser.pwd=${string_prompt:OpenShift password} -Dusage_reporting_enabled=false"/>
+<stringAttribute key="pde.version" value="3.3"/>
+<stringAttribute key="product" value="com.jboss.jbds.product.product"/>
+<booleanAttribute key="show_selected_only" value="false"/>
+<stringAttribute key="templateConfig" value="${target_home}/configuration/config.ini"/>
+<booleanAttribute key="tracing" value="false"/>
+<booleanAttribute key="useCustomFeatures" value="false"/>
+<booleanAttribute key="useDefaultConfig" value="true"/>
+<booleanAttribute key="useDefaultConfigArea" value="false"/>
+<booleanAttribute key="useProduct" value="true"/>
+</launchConfiguration>

--- a/tests/org.jboss.tools.openshift.ui.bot.test/OpenShiftOnlineBotTests.launch
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/OpenShiftOnlineBotTests.launch
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.swtbot.eclipse.ui.launcher.JunitLaunchConfig">
+<booleanAttribute key="append.args" value="true"/>
+<booleanAttribute key="askclear" value="false"/>
+<booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticValidate" value="false"/>
+<stringAttribute key="bootstrap" value=""/>
+<stringAttribute key="checked" value="[NONE]"/>
+<booleanAttribute key="clearConfig" value="true"/>
+<booleanAttribute key="clearws" value="true"/>
+<booleanAttribute key="clearwslog" value="false"/>
+<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+<booleanAttribute key="default" value="true"/>
+<booleanAttribute key="includeOptional" value="true"/>
+<stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/OpenShiftOnlineBotTests.java"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<mapAttribute key="org.eclipse.debug.core.environmentVariables">
+<mapEntry key="DISPLAY" value=":1"/>
+</mapAttribute>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.jboss.tools.openshift.ui.bot.test.OpenShiftOnlineBotTests"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.jboss.tools.openshift.ui.bot.test"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dosgi.requiredJavaVersion=1.5 -XX:MaxPermSize=256m -Xms40m -Xmx512m -Dswtbot.test.properties.file=${project_loc}/resources/swtbot.properties -Dusage_reporting_enabled=false -Dlibra.server=${string_prompt:OpenShift server} -Duser.name=${string_prompt:OpenShift user} -Duser.pwd=${string_prompt:OpenShift password} -Dusage_reporting_enabled=false"/>
+<stringAttribute key="pde.version" value="3.3"/>
+<stringAttribute key="product" value="com.jboss.jbds.product.product"/>
+<booleanAttribute key="show_selected_only" value="false"/>
+<stringAttribute key="templateConfig" value="${target_home}/configuration/config.ini"/>
+<booleanAttribute key="tracing" value="false"/>
+<booleanAttribute key="useCustomFeatures" value="false"/>
+<booleanAttribute key="useDefaultConfig" value="true"/>
+<booleanAttribute key="useDefaultConfigArea" value="false"/>
+<booleanAttribute key="useProduct" value="true"/>
+</launchConfiguration>

--- a/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/cartridge/EmbedCartridges.java
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/cartridge/EmbedCartridges.java
@@ -28,9 +28,9 @@ public class EmbedCartridges extends OpenShiftBotTest {
 	public void canEmbedCartridge() {
 		embedCartrige(OpenShiftUI.Cartridge.CRON);
 		
-		//embedCartrige(OpenShiftUI.Cartridge.MYSQL);
+		embedCartrige(OpenShiftUI.Cartridge.MYSQL);
 		
-		//embedCartrige(OpenShiftUI.Cartridge.POSTGRESQL);
+		embedCartrige(OpenShiftUI.Cartridge.POSTGRESQL_8_4);
 	}
 
 	

--- a/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/util/OpenShiftUI.java
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/util/OpenShiftUI.java
@@ -83,12 +83,12 @@ public class OpenShiftUI {
 	/**
 	 * List of available application type labels
 	 * 
-	 * @author sbunciak
+	 * @author sbunciak, mlabuda
 	 * 
 	 */
 	public static class AppType {
 		public static final String JBOSS = "JBoss Application Server 7.1" + " (" + AppTypeOld.JBOSS + ")";
-		public static final String JBOSS_EAP = "JBoss Enterprise Application Platform 6.1.0" + " (" + AppTypeOld.JBOSS_EAP + ")";
+		public static final String JBOSS_EAP = "JBoss Enterprise Application Platform 6.0" + " (" + AppTypeOld.JBOSS_EAP + ")";
 		public static final String JBOSS_EWS = "Tomcat 7 (JBoss EWS 2.0)" + " (" + AppTypeOld.JBOSS_EWS + ")";
 		public static final String JENKINS = "Jenkins Server 1.4" + " (" + AppTypeOld.JENKINS + ")";
 		public static final String PERL = "Perl 5.10" + " (" + AppTypeOld.PERL + ")";
@@ -103,7 +103,7 @@ public class OpenShiftUI {
 	public static class AppTypeOld {
 
 		public static final String JBOSS = "jbossas-7.1";
-		public static final String JBOSS_EAP = "jbosseap-6";
+		public static final String JBOSS_EAP = "jbosseap-6.0";
 		public static final String JBOSS_EWS = "jbossews-2.0";
 		public static final String JENKINS = "jenkins-1.4";
 		public static final String PERL = "perl-5.10";
@@ -123,7 +123,8 @@ public class OpenShiftUI {
 
 		public static final String JENKINS = "Jenkins Client 1.4 (jenkins-client-1.4)";
 		public static final String CRON = "Cron 1.4 (cron-1.4)";
-		public static final String MYSQL = "MySQL 5.1 (mysql-5.1)";
+		public static final String MYSQL = "MySQL Database 5.1 (mysql-5.1)";
+		public static final String POSTGRESQL_8_4 = "PostgreSQL Database 8.4 (postgresql-8.4)";
 		public static final String POSTGRESQL = "PostgreSQL 9.2 (postgresql-9.2)";
 		public static final String SWITCHYARD = "SwitchYard 0.6 (switchyard-0.6)";
 		public static final String MONGODB = "MongoDB 2.2 (mongodb-2.2)";


### PR DESCRIPTION
changes:
- added swtbot launcher for OpenShift Online and OpenShift enterprise
- fix OpenShift enterprise labels for cartridges and applications
- added MySQL and PostgreSQL cartridge tests
