### PR TITLE
Workaround for intermittent/inconsistent situation where

### DIFF
--- a/tests/org.jboss.tools.mylyn.ui.bot.test/src/org/jboss/tools/mylyn/ui/bot/test/MylynTestLocalRepo.java
+++ b/tests/org.jboss.tools.mylyn.ui.bot.test/src/org/jboss/tools/mylyn/ui/bot/test/MylynTestLocalRepo.java
@@ -70,8 +70,21 @@ public class MylynTestLocalRepo {
 		/* Find the task in the repo */
 		TaskListView listView = new TaskListView();
 		listView.open();
-		listView.getTask("Uncategorized", TASKNAME);
-				
+		
+		/* Workaround for intermittent/inconsistent situation where newly created task is not visible.
+		 * Seems to be a timing issue in the UI - dependent on CPU speed? Only seeing this sometimes
+		 * on Jenkins - never locally.
+		 */
+		try {
+			listView.getTask("Uncategorized", TASKNAME);
+		}
+		catch (org.jboss.reddeer.swt.exception.SWTLayerException E) {
+			log.error("Newly created task not found - retrying");
+			listView.close();
+			listView.open();
+			listView.getTask("Uncategorized", TASKNAME);
+		}
+		
 		log.info("Activate the " + TASKNAME + " task");
 		view.activateTask(TASKNAME);
 


### PR DESCRIPTION
newly created task is not visible.
Seems to be a timing issue in the UI - dependent on
CPU speed? Only seeing this sometimes on Jenkins - never locally.

Wait statements were not successful in resolving this issue. Trapping an exception, then closing and opening the view seems to always work. Very odd bug - never see it locally - only on machydra and only part of the time.
