### PR TITLE
Using RedDeer to get RESTful services from RESTful Explorer

### DIFF
--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/annotation/AnnotationPropertiesTest.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/annotation/AnnotationPropertiesTest.java
@@ -20,6 +20,7 @@ import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 import org.hamcrest.core.Is;
 import org.hamcrest.core.IsNot;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
+import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.ProjectItem;
 import org.jboss.tools.ws.ui.bot.test.rest.RESTfulTestBase;
 import org.jboss.tools.ws.ui.bot.test.uiutils.views.AnnotationPropertiesView;
 import org.junit.Test;
@@ -173,7 +174,7 @@ public class AnnotationPropertiesTest extends RESTfulTestBase {
 				annotationsView.getAnnotationValues(pathAnnotation).get(0).getText(), 
 				"/edit");
 		
-		for (SWTBotTreeItem service : restfulServicesForProject(getWsProjectName())) {
+		for (ProjectItem service : restfulServicesForProject(getWsProjectName())) {
 			String path = restfulWizard.getPathForRestFulService(service);
 			assertDoesNotContain("rest", path);
 			assertContains("edit", path);	
@@ -189,7 +190,7 @@ public class AnnotationPropertiesTest extends RESTfulTestBase {
 		
 		annotationsView.deactivateAnnotation(getAnnotation);
 		
-		assertThat(restfulServicesForProject(getWsProjectName()).length, Is.is(3));
+		assertThat(restfulServicesForProject(getWsProjectName()).size(), Is.is(3));
 		
 		
 	}

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/facet/JAXRSFacetTest.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/facet/JAXRSFacetTest.java
@@ -68,7 +68,7 @@ public class JAXRSFacetTest extends RESTfulTestBase {
 	private void checkJAXRSTooling() {
 		RESTFullExplorer restExplorer = new RESTFullExplorer(wsProjectName);
 		assertThat("Different count of rest services was expected", 
-				restExplorer.getAllRestServices().length, Is.is(1));
+				restExplorer.getAllRestServices().size(), Is.is(1));
 			
 	}
 

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/rest/DefaultValueAnnotationSupportTest.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/rest/DefaultValueAnnotationSupportTest.java
@@ -11,7 +11,10 @@
 
 package org.jboss.tools.ws.ui.bot.test.rest;
 
+import java.util.List;
+
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.ProjectItem;
 import org.junit.Test;
 
 public class DefaultValueAnnotationSupportTest extends RESTfulTestBase {
@@ -32,11 +35,11 @@ public class DefaultValueAnnotationSupportTest extends RESTfulTestBase {
 		importRestWSProject("default1");
 		
 		/* get RESTful services from JAX-RS REST explorer for the project */
-		SWTBotTreeItem[] restServices = restfulServicesForProject("default1");
+		List<ProjectItem> restServices = restfulServicesForProject("default1");
 		
 		/* test JAX-RS REST explorer */
 		assertCountOfRESTServices(restServices, 1);
-		assertExpectedPathOfService(restServices[0], 
+		assertExpectedPathOfService(restServices.get(0), 
 				"/rest?" + queryParam + "={" + queryParam + ":" + 
 						  queryParamType + "=" + defaultValue + "}");
 		
@@ -49,11 +52,11 @@ public class DefaultValueAnnotationSupportTest extends RESTfulTestBase {
 		importRestWSProject("default2");
 		
 		/* get RESTful services from JAX-RS REST explorer for the project */
-		SWTBotTreeItem[] restServices = restfulServicesForProject("default2");
+		List<ProjectItem> restServices = restfulServicesForProject("default2");
 		
 		/* test JAX-RS REST explorer */
 		assertCountOfRESTServices(restServices, 1);
-		assertExpectedPathOfService(restServices[0], 
+		assertExpectedPathOfService(restServices.get(0), 
 				"/rest:" + queryParam + "={" + queryParam + ":" + 
 						  queryParamType + "=" + defaultValue + "}");
 	}
@@ -70,11 +73,11 @@ public class DefaultValueAnnotationSupportTest extends RESTfulTestBase {
 		importRestWSProject("default3");
 		
 		/* get RESTful services from JAX-RS REST explorer for the project */
-		SWTBotTreeItem[] restServices = restfulServicesForProject("default3");
+		List<ProjectItem> restServices = restfulServicesForProject("default3");
 		
 		/* test JAX-RS REST explorer */
 		assertCountOfRESTServices(restServices, 1);
-		assertExpectedPathOfService(restServices[0], 
+		assertExpectedPathOfService(restServices.get(0), 
 				"/rest/{" + queryParam + ":" + 
 						  queryParamType + "=" + defaultValue + "}");
 		

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/rest/MatrixAnnotationSupportTest.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/rest/MatrixAnnotationSupportTest.java
@@ -11,7 +11,10 @@
 
 package org.jboss.tools.ws.ui.bot.test.rest;
 
+import java.util.List;
+
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.ProjectItem;
 import org.jboss.tools.ui.bot.ext.Timing;
 import org.junit.Test;
 
@@ -39,11 +42,11 @@ public class MatrixAnnotationSupportTest extends RESTfulTestBase {
 	public void testMatrixParamSupport() {
 
 		/* get RESTful services from JAX-RS REST explorer for the project */
-		SWTBotTreeItem[] restServices = restfulServicesForProject("matrix1");
+		List<ProjectItem> restServices = restfulServicesForProject("matrix1");
 		
 		/* test JAX-RS REST explorer */
 		assertCountOfRESTServices(restServices, 1);	
-		assertExpectedPathOfService(restServices[0], 
+		assertExpectedPathOfService(restServices.get(0), 
 				"/rest;" + matrixParam1 + "={" + matrixParamType1 + "};"
 						+ matrixParam2 + "={" + matrixParamType2 + "}");
 
@@ -59,11 +62,11 @@ public class MatrixAnnotationSupportTest extends RESTfulTestBase {
 		bot.sleep(Timing.time2S());
 
 		/* get RESTful services from JAX-RS REST explorer for the project */
-		SWTBotTreeItem[] restServices = restfulServicesForProject("matrix1");
+		List<ProjectItem> restServices = restfulServicesForProject("matrix1");
 
 		/* test JAX-RS REST explorer */
 		assertCountOfRESTServices(restServices, 1);	
-		assertExpectedPathOfService(restServices[0], 
+		assertExpectedPathOfService(restServices.get(0), 
 				"/rest;" + matrixParamNew + "={" + matrixParamType1 + "};"
 						+ matrixParam2 + "={" + matrixParamType2 + "}");
 	}
@@ -78,11 +81,11 @@ public class MatrixAnnotationSupportTest extends RESTfulTestBase {
 		bot.sleep(Timing.time2S());
 
 		/* get RESTful services from JAX-RS REST explorer for the project */
-		SWTBotTreeItem[] restServices = restfulServicesForProject("matrix1");
+		List<ProjectItem> restServices = restfulServicesForProject("matrix1");
 		
 		/* test JAX-RS REST explorer */
 		assertCountOfRESTServices(restServices, 1);	
-		assertExpectedPathOfService(restServices[0], 
+		assertExpectedPathOfService(restServices.get(0), 
 				"/rest;" + matrixParam1 + "={" + matrixParamTypeNew + "};"
 						+ matrixParam2 + "={" + matrixParamType2 + "}");
 	}

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/rest/PathAnnotationSupportTest.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/rest/PathAnnotationSupportTest.java
@@ -11,8 +11,17 @@
 
 package org.jboss.tools.ws.ui.bot.test.rest;
 
+import java.util.List;
+
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEclipseEditor;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.ProjectItem;
+
+import org.jboss.reddeer.swt.condition.JobIsRunning;
+import org.jboss.reddeer.swt.wait.TimePeriod;
+import org.jboss.reddeer.swt.wait.WaitUntil;
+import org.jboss.reddeer.swt.wait.WaitWhile;
+import org.junit.Ignore;
 import org.jboss.tools.ui.bot.ext.Timing;
 import org.junit.Test;
 
@@ -36,8 +45,8 @@ public class PathAnnotationSupportTest extends RESTfulTestBase {
 		importRestWSProject("restBasic");
 		
 		/* get RESTful services from JAX-RS REST explorer for the project */
-		SWTBotTreeItem[] restServices = restfulServicesForProject("restBasic");
-		
+		List<ProjectItem> restServices = restfulServicesForProject("restBasic");
+
 		/* test JAX-RS REST explorer */
 		assertCountOfRESTServices(restServices, 4);		
 		assertAllRESTServicesInExplorer(restServices);
@@ -51,7 +60,7 @@ public class PathAnnotationSupportTest extends RESTfulTestBase {
 		importRestWSProject("restAdvanced");
 		
 		/* get RESTful services from JAX-RS REST explorer for the project */
-		SWTBotTreeItem[] restServices = restfulServicesForProject("restAdvanced");
+		List<ProjectItem> restServices = restfulServicesForProject("restAdvanced");
 		
 		/* test JAX-RS REST explorer */
 		assertCountOfRESTServices(restServices, 4);		
@@ -59,13 +68,6 @@ public class PathAnnotationSupportTest extends RESTfulTestBase {
 		testAdvancedRESTServices(restServices);
 	}
 	
-	/**
-	 * Fails due to JBIDE-11766.
-	 * Workaround is possible: delay between typing
-	 *  - add bot.sleep(Timing.time2S()) after replacing the text in editor
-	 * 
-	 * @see https://issues.jboss.org/browse/JBIDE-11766
-	 */
 	@Test
 	public void testEditingSimpleRESTMethods() {
 		
@@ -75,10 +77,9 @@ public class PathAnnotationSupportTest extends RESTfulTestBase {
 		/* replace @DELETE annotation to @GET annotation */
 		resourceHelper.replaceInEditor(editorForClass("restBasic", "src",
 				"org.rest.test", "RestService.java").toTextEditor(), "@DELETE", "@GET", true);
-		//bot.sleep(Timing.time2S());
 		
 		/* get RESTful services from JAX-RS REST explorer for the project */
-		SWTBotTreeItem[] restServices = restfulServicesForProject("restBasic"); 
+		List<ProjectItem> restServices = restfulServicesForProject("restBasic"); 
 		
 		/* test JAX-RS REST explorer */
 		assertNotAllRESTServicesInExplorer(restServices);
@@ -87,11 +88,11 @@ public class PathAnnotationSupportTest extends RESTfulTestBase {
 	}
 	
 	/**
-	 * Fails due to JBIDE-11766.
+	 * Fails due to JBIDE-16163.
 	 * Workaround is possible: delay between typing
 	 *  - add bot.sleep(Timing.time2S()) after replacing the text in editor
 	 * 
-	 * @see https://issues.jboss.org/browse/JBIDE-11766
+	 * @see https://issues.jboss.org/browse/JBIDE-16163
 	 */
 	@Test
 	public void testEditingAdvancedRESTMethods() {
@@ -109,8 +110,8 @@ public class PathAnnotationSupportTest extends RESTfulTestBase {
 		//bot.sleep(Timing.time2S());
 		
 		/* get RESTful services from JAX-RS REST explorer for the project */
-		SWTBotTreeItem[] restServices = restfulServicesForProject("restAdvanced");
-		
+		List<ProjectItem> restServices = restfulServicesForProject("restAdvanced");
+
 		/* test JAX-RS REST explorer */
 		testEditedDeleteRestWebResource(restServices);
 	}
@@ -126,15 +127,14 @@ public class PathAnnotationSupportTest extends RESTfulTestBase {
 		bot.sleep(Timing.time2S());
 		
 		/* get RESTful services from JAX-RS REST explorer for the project */
-		SWTBotTreeItem[] restServices = restfulServicesForProject("restBasic");  
+		List<ProjectItem> restServices = restfulServicesForProject("restBasic");
 		
 		/* none of REST web services found */
 		assertCountOfRESTServices(restServices, 0);
 	}
 
-	private void testEditedDeleteRestWebResource(
-			SWTBotTreeItem[] restServices) {
-		for (SWTBotTreeItem restService : restServices) {
+	private void testEditedDeleteRestWebResource(List<ProjectItem> restServices) {
+		for (ProjectItem restService : restServices) {
 			if (restfulWizard.getRestServiceName(restService).equals(RESTFulAnnotations.DELETE.getLabel())) {
 				assertTrue(restfulWizard.getPathForRestFulService(restService).equals("/rest/delete/edited/{id}"));
 				assertTrue(restfulWizard.getProducesInfo(restService).equals("text/plain"));
@@ -142,9 +142,8 @@ public class PathAnnotationSupportTest extends RESTfulTestBase {
 		}
 	}
 
-	private void testAdvancedRESTServices(
-			SWTBotTreeItem[] restServices) {
-		for (SWTBotTreeItem restService : restServices) {
+	private void testAdvancedRESTServices(List<ProjectItem> restServices) {
+		for (ProjectItem restService : restServices) {
 			if (restfulWizard.getRestServiceName(restService).equals(RESTFulAnnotations.GET.getLabel())) {
 				assertTrue(restfulWizard.getPathForRestFulService(restService).equals("/rest/{id}"));
 				assertTrue(restfulWizard.getConsumesInfo(restService).equals("*/*"));

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/rest/QueryAnnotationSupportTest.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/rest/QueryAnnotationSupportTest.java
@@ -11,7 +11,10 @@
 
 package org.jboss.tools.ws.ui.bot.test.rest;
 
+import java.util.List;
+
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.ProjectItem;
 import org.jboss.tools.ui.bot.ext.Timing;
 import org.junit.Test;
 
@@ -39,11 +42,11 @@ public class QueryAnnotationSupportTest extends RESTfulTestBase {
 		importRestWSProject("query1");
 		
 		/* get RESTful services from JAX-RS REST explorer for the project */
-		SWTBotTreeItem[] restServices = restfulServicesForProject("query1"); 
-		
+		List<ProjectItem> restServices = restfulServicesForProject("query1"); 
+
 		/* test JAX-RS REST explorer */
 		assertCountOfRESTServices(restServices, 1);	
-		assertExpectedPathOfService(restServices[0], 
+		assertExpectedPathOfService(restServices.get(0), 
 				"/rest?" + queryParam1 + "={" + queryParam1 + ":" + queryType + "}");
 		
 		/* prepare project*/
@@ -54,7 +57,7 @@ public class QueryAnnotationSupportTest extends RESTfulTestBase {
 		
 		/* test JAX-RS REST explorer */
 		assertCountOfRESTServices(restServices, 1);	
-		assertExpectedPathOfService(restServices[0], 
+		assertExpectedPathOfService(restServices.get(0), 
 				"/rest?" + queryParam1 + "={" + queryParam1 + ":" + queryType + "}&" +
 						queryParam2 + "={" + queryParam2 + ":" + queryType + "}");
 	}
@@ -72,11 +75,11 @@ public class QueryAnnotationSupportTest extends RESTfulTestBase {
 		bot.sleep(Timing.time2S());
 		
 		/* get RESTful services from JAX-RS REST explorer for the project */
-		SWTBotTreeItem[] restServices = restfulServicesForProject("query2");
+		List<ProjectItem> restServices = restfulServicesForProject("query2");
 		
 		/* test JAX-RS REST explorer */
 		assertCountOfRESTServices(restServices, 1);
-		assertExpectedPathOfService(restServices[0], 
+		assertExpectedPathOfService(restServices.get(0), 
 				"/rest?" + queryParam1New + "={" + queryParam1New + ":" + queryType + "}&" +
 						queryParam2 + "={" + queryParam2 + ":" + queryType + "}");
 	}
@@ -107,11 +110,11 @@ public class QueryAnnotationSupportTest extends RESTfulTestBase {
 		bot.sleep(Timing.time2S());
 		
 		/* get RESTful services from JAX-RS REST explorer for the project */
-		SWTBotTreeItem[] restServices = restfulServicesForProject("query2");
+		List<ProjectItem> restServices = restfulServicesForProject("query2");
 		
 		/* test JAX-RS REST explorer */
 		assertCountOfRESTServices(restServices, 1);
-		assertExpectedPathOfService(restServices[0], 
+		assertExpectedPathOfService(restServices.get(0), 
 				"/rest?" + queryParam1 + "={" + queryParam1 + ":" + queryTypeNew + "}&" +
 						queryParam2 + "={" + queryParam2 + ":" + queryType2 + "}");
 	}

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/rest/RESTfulTestBase.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/rest/RESTfulTestBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2011 Red Hat, Inc.
+ * Copyright (c) 2010-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -11,9 +11,12 @@
 
 package org.jboss.tools.ws.ui.bot.test.rest;
 
+import java.util.List;
+
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEditor;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.ProjectItem;
 import org.jboss.tools.ui.bot.ext.Timing;
 import org.jboss.tools.ui.bot.ext.condition.NonSystemJobRunsCondition;
 import org.jboss.tools.ui.bot.ext.condition.ViewIsActive;
@@ -85,29 +88,28 @@ public class RESTfulTestBase extends WSTestBase {
 				+ "project \"" + projectName + "\"", explorer);
 	}
 
-	protected void assertCountOfRESTServices(SWTBotTreeItem[] restServices,
+	protected void assertCountOfRESTServices(List<ProjectItem> restServices,
 			int expectedCount) {
-		assertTrue(restServices.length + " RESTful services"
+		assertTrue(restServices.size() + " RESTful services"
 				+ " was found instead of " + expectedCount,
-				restServices.length == expectedCount);
+				restServices.size() == expectedCount);
 	}
 
-	protected void assertAllRESTServicesInExplorer(SWTBotTreeItem[] restServices) {
+	protected void assertAllRESTServicesInExplorer(List<ProjectItem> restServices) {
 		assertTrue("All RESTful services (GET, DELETE, POST, PUT) "
 				+ "should be present but they are not",
 				allRestServicesArePresent(restServices));
 	}
 
-	protected void assertNotAllRESTServicesInExplorer(
-			SWTBotTreeItem[] restServices) {
+	protected void assertNotAllRESTServicesInExplorer(List<ProjectItem> restServices) {
 		assertFalse("All RESTful services (GET, DELETE, POST, PUT) "
 				+ "shouldnt be present but they are",
 				allRestServicesArePresent(restServices));
 	}
 
-	protected void assertPathOfAllRESTWebServices(
-			SWTBotTreeItem[] restServices, String path) {
-		for (SWTBotTreeItem restService : restServices) {
+	protected void assertPathOfAllRESTWebServices(List<ProjectItem> restServices,
+			String path) {
+		for (ProjectItem restService : restServices) {
 			assertTrue(
 					"RESTful Web Service \""
 							+ restfulWizard.getRestServiceName(restService)
@@ -116,9 +118,9 @@ public class RESTfulTestBase extends WSTestBase {
 		}
 	}
 
-	protected void assertAbsenceOfRESTWebService(SWTBotTreeItem[] restServices,
+	protected void assertAbsenceOfRESTWebService(List<ProjectItem> restServices,
 			String restWebService) {
-		for (SWTBotTreeItem restService : restServices) {
+		for (ProjectItem restService : restServices) {
 			if (restfulWizard.getRestServiceName(restService).equals(
 					restWebService)) {
 				fail("There should not be " + restWebService
@@ -127,10 +129,10 @@ public class RESTfulTestBase extends WSTestBase {
 		}
 	}
 
-	protected void assertPresenceOfRESTWebService(
-			SWTBotTreeItem[] restServices, String restWebService) {
+	protected void assertPresenceOfRESTWebService(List<ProjectItem> restServices,
+			String restWebService) {
 		boolean found = false;
-		for (SWTBotTreeItem restService : restServices) {
+		for (ProjectItem restService : restServices) {
 			if (restfulWizard.getRestServiceName(restService).equals(
 					restWebService)) {
 				found = true;
@@ -141,7 +143,7 @@ public class RESTfulTestBase extends WSTestBase {
 				found);
 	}
 
-	protected void assertExpectedPathOfService(SWTBotTreeItem service,
+	protected void assertExpectedPathOfService(ProjectItem service,
 			String expectedPath) {
 		String path = restfulWizard.getPathForRestFulService(service);
 		assertEquals("Failure when comparing paths = ", expectedPath, path);
@@ -171,14 +173,14 @@ public class RESTfulTestBase extends WSTestBase {
 				foundCount == expectedCount);
 	}
 	
-	protected void runRestServiceOnConfiguredServer(SWTBotTreeItem webService) {
+	protected void runRestServiceOnConfiguredServer(ProjectItem webService) {
 		RunOnServerDialog dialog = restfulWizard.runOnServer(webService);
 		dialog.chooseExistingServer().selectServer(configuredState.getServer().name).finish();
 		bot.waitUntil(new ViewIsActive(IDELabel.View.WEB_SERVICE_TESTER), TIME_20S);
 		bot.waitWhile(new NonSystemJobRunsCondition(), TIME_20S);
 	}
-	
-	protected SWTBotTreeItem[] restfulServicesForProject(String projectName) {
+
+	protected List<ProjectItem> restfulServicesForProject(String projectName) {
 		restfulWizard = new RESTFullExplorer(projectName);
 		return restfulWizard.getAllRestServices();
 	}
@@ -202,15 +204,14 @@ public class RESTfulTestBase extends WSTestBase {
 		bot.sleep(Timing.time2S());
 	}
 
-	private boolean allRestServicesArePresent(SWTBotTreeItem[] restServices) {
-
+	private boolean allRestServicesArePresent(List<ProjectItem> restServices) {
 		String[] restMethods = { RESTFulAnnotations.GET.getLabel(),
 				RESTFulAnnotations.POST.getLabel(),
 				RESTFulAnnotations.POST.getLabel(),
 				RESTFulAnnotations.DELETE.getLabel() };
 		for (String restMethod : restMethods) {
 			boolean serviceFound = false;
-			for (SWTBotTreeItem restService : restServices) {
+			for (ProjectItem restService : restServices) {
 				if (restfulWizard.getRestServiceName(restService).equals(
 						restMethod)) {
 					serviceFound = true;

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/uiutils/RESTFullExplorer.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/uiutils/RESTFullExplorer.java
@@ -11,54 +11,53 @@
 
 package org.jboss.tools.ws.ui.bot.test.uiutils;
 
+import java.util.List;
+
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.jboss.reddeer.eclipse.jdt.ui.ProjectExplorer;
+import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.Project;
+import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.ProjectItem;
 import org.jboss.reddeer.swt.api.Menu;
 import org.jboss.reddeer.swt.impl.menu.ContextMenu;
 import org.jboss.reddeer.swt.matcher.RegexMatchers;
-import org.jboss.tools.ui.bot.ext.SWTBotFactory;
-import org.jboss.tools.ui.bot.ext.view.ProjectExplorer;
 import org.jboss.tools.ws.ui.bot.test.rest.RESTFulAnnotations;
 
 public class RESTFullExplorer {
-
-	private SWTBotTreeItem restFulExplorer;
 	
-	private ProjectExplorer projectExplorer = SWTBotFactory.getProjectexplorer();
+	private ProjectItem restFulExplorer;
 	
 	public RESTFullExplorer(String wsProjectName) {
-		String[] pathToRestExplorer = {wsProjectName};
-		/** workaround when project in project explorer is not expanded **/
-		String[] pathToProject = {};
-		SWTBotTreeItem ti = projectExplorer.selectTreeItem(wsProjectName, pathToProject);
-		ti.expand();
-		ti.collapse();
-		ti.expand();
+		Project project = new ProjectExplorer().getProject(wsProjectName);
 		
-		restFulExplorer = projectExplorer.selectTreeItem(
-				RESTFulAnnotations.REST_EXPLORER_LABEL.getLabel(), 
-				pathToRestExplorer).expand().collapse().expand();
+		/* REDDEER-369
+		 * workaround for bug that will show project with no items
+		 */
+		project.getTreeItem().expand();
+		project.getTreeItem().collapse();
+		
+		/* open JAX-RS / RESTful Explorer */
+		restFulExplorer = project.getProjectItem(RESTFulAnnotations.REST_EXPLORER_LABEL.getLabel());
+		restFulExplorer.open();
 	}
 	
 	/**
 	 * 
 	 * @return
 	 */
-	public SWTBotTreeItem[] getAllRestServices() {
-		return restFulExplorer.getItems();
+	public List<ProjectItem> getAllRestServices() {
+		return restFulExplorer.getChildren();
 	}
 	
-	public SWTBotTreeItem restService(String method) {
-		SWTBotTreeItem getMethod = null;
-		for (SWTBotTreeItem ti : getAllRestServices()) {
+	public ProjectItem restService(String method) {
+		for (ProjectItem ti : getAllRestServices()) {
 			if (ti.getText().contains(method)) {
-				getMethod = ti;
-				break;
+				return ti;
 			}
 		}
-		return getMethod;
+		return null;
 	}
 	
-	public RunOnServerDialog runOnServer(SWTBotTreeItem service) {
+	public RunOnServerDialog runOnServer(ProjectItem service) {
 		service.select();
 		
 		Menu menu = new ContextMenu(new RegexMatchers(
@@ -73,9 +72,9 @@ public class RESTFullExplorer {
 	 * @param restService
 	 * @return
 	 */
-	public SWTBotTreeItem[] getAllInfoAboutRestService(SWTBotTreeItem restService) {
-		restService.expand();
-		return restService.getItems();
+	public List<ProjectItem> getAllInfoAboutRestService(ProjectItem restService) {
+		restService.open();
+		return restService.getChildren();
 	}
 	
 	/**
@@ -83,8 +82,8 @@ public class RESTFullExplorer {
 	 * @param restService
 	 * @return
 	 */
-	public String getConsumesInfo(SWTBotTreeItem restService) {
-		for (SWTBotTreeItem ti: getAllInfoAboutRestService(restService)) {
+	public String getConsumesInfo(ProjectItem restService) {
+		for (ProjectItem ti: getAllInfoAboutRestService(restService)) {
 			if (ti.getText().contains("consumes:")) {
 				return ti.getText().split(" ")[1];
 			}
@@ -97,8 +96,8 @@ public class RESTFullExplorer {
 	 * @param restService
 	 * @return
 	 */
-	public String getProducesInfo(SWTBotTreeItem restService) {
-		for (SWTBotTreeItem ti: getAllInfoAboutRestService(restService)) {
+	public String getProducesInfo(ProjectItem restService) {
+		for (ProjectItem ti: getAllInfoAboutRestService(restService)) {
 			if (ti.getText().contains("produces:")) {
 				return ti.getText().split(" ")[1];
 			}
@@ -111,8 +110,8 @@ public class RESTFullExplorer {
 	 * @param restService
 	 * @return
 	 */
-	public String getClassMethodName(SWTBotTreeItem restService) {
-		for (SWTBotTreeItem ti: getAllInfoAboutRestService(restService)) {
+	public String getClassMethodName(ProjectItem restService) {
+		for (ProjectItem ti: getAllInfoAboutRestService(restService)) {
 			if (!ti.getText().contains("produces:") && !ti.getText().contains("consumes:")) {
 				return ti.getText();
 			}
@@ -125,7 +124,7 @@ public class RESTFullExplorer {
 	 * @param restService
 	 * @return
 	 */
-	public String getRestServiceName(SWTBotTreeItem restService) {
+	public String getRestServiceName(ProjectItem restService) {
 		return restService.getText().split(" ")[0];
 	}
 	
@@ -134,7 +133,7 @@ public class RESTFullExplorer {
 	 * @param restService
 	 * @return
 	 */
-	public String getPathForRestFulService(SWTBotTreeItem restService) {		
+	public String getPathForRestFulService(ProjectItem restService) {
 		return restService.getText().split(" ")[1];
 	}
 	

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/wstester/WSTesterPromptValuesSupportTest.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/wstester/WSTesterPromptValuesSupportTest.java
@@ -81,7 +81,7 @@ public class WSTesterPromptValuesSupportTest extends RESTfulTestBase {
 		restExplorer = new RESTFullExplorer(getWsProjectName());
 		
 		RunOnServerDialog dialog = restExplorer.runOnServer(
-				restExplorer.getAllRestServices()[0]);
+				restExplorer.getAllRestServices().get(0));
 		dialog.chooseExistingServer();
 		dialog.finish();
 		

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/wstester/XmlJsonFormattingTest.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/wstester/XmlJsonFormattingTest.java
@@ -15,6 +15,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 import org.hamcrest.core.IsEqual;
+import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.ProjectItem;
 import org.jboss.tools.ui.bot.ext.config.Annotations.Require;
 import org.jboss.tools.ui.bot.ext.config.Annotations.Server;
 import org.jboss.tools.ui.bot.ext.config.Annotations.ServerState;
@@ -93,9 +94,9 @@ public class XmlJsonFormattingTest extends RESTfulTestBase {
 				IsEqual.equalTo(format.formattedMessage));
 	}
 	
-	private SWTBotTreeItem getProperRestService(RESTFullExplorer explorer, 
+	private ProjectItem getProperRestService(RESTFullExplorer explorer, 
 			Format format) {
-		for (SWTBotTreeItem service : explorer.getAllRestServices()) {
+		for (ProjectItem service : explorer.getAllRestServices()) {
 			if (explorer.getPathForRestFulService(service).contains(
 				format.formatType)) { 
 				return service;


### PR DESCRIPTION
Using RedDeer to get RESTful Explorer and its items. Replaced SWTBotTreeItem by ProjectItem.

JBoss Tools Component: webservices
Author: rrabara
