### PR TITLE
JBIDE-13938 Improved Reddeer server requirements

### DIFF
--- a/plugins/org.jboss.ide.eclipse.as.reddeer/resources/ServerRequirements.xsd
+++ b/plugins/org.jboss.ide.eclipse.as.reddeer/resources/ServerRequirements.xsd
@@ -40,6 +40,7 @@
         		<xs:enumeration value="6.x"></xs:enumeration>
         		<xs:enumeration value="7.0"></xs:enumeration>
         		<xs:enumeration value="7.1"></xs:enumeration>
+        		<xs:enumeration value="8.0"></xs:enumeration>
         	</xs:restriction>
         </xs:simpleType>
 
@@ -48,7 +49,8 @@
         		<xs:enumeration value="4.3"></xs:enumeration>
         		<xs:enumeration value="5.x"></xs:enumeration>
         		<xs:enumeration value="6.0"></xs:enumeration>
-        		<xs:enumeration value="6.1(Tech Preview)"></xs:enumeration>
+        		<xs:enumeration value="6.1"></xs:enumeration>
+        		<xs:enumeration value="6.2"></xs:enumeration>
         	</xs:restriction>
         </xs:simpleType>
 

--- a/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ConfiguredServerInfo.java
+++ b/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ConfiguredServerInfo.java
@@ -1,0 +1,34 @@
+package org.jboss.ide.eclipse.as.reddeer.server.requirement;
+
+/**
+ * Contains informations about configured server via server requirement.
+ * The configured server is defined by its name(name displayed in servers view)
+ * and configuration (ServerRequirementConfig).
+ * 
+ * @author Radoslav Rabara
+ * @see ServerRequirementConfig
+ */
+class ConfiguredServerInfo {
+	
+	private String serverName;
+	private ServerRequirementConfig config;
+	
+	/**
+	 * Define configured server by its name and configuration.
+	 * 
+	 * @param serverName is the name of the configured server
+	 * @param config configuration which was used to configure server
+	 */
+	public ConfiguredServerInfo(String serverName, ServerRequirementConfig config) {
+		this.serverName = serverName;
+		this.config = config;
+	}
+	
+	public String getServerName() {
+		return serverName;
+	}
+	
+	public ServerRequirementConfig getConfig() {
+		return config;
+	}
+}

--- a/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerReqState.java
+++ b/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerReqState.java
@@ -1,0 +1,11 @@
+package org.jboss.ide.eclipse.as.reddeer.server.requirement;
+
+/**
+ * Enumeration of possible states of required server
+ * 
+ * @author Radoslav Rabara
+ *
+ */
+public enum ServerReqState {
+	RUNNING, STOPPED, PRESENT
+}

--- a/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerRequirement.java
+++ b/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerRequirement.java
@@ -5,50 +5,134 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.apache.log4j.Logger;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.Server;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirementConfig.FamilyAS;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirementConfig.FamilyEAP;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirementConfig.ServerFamily;
 import org.jboss.ide.eclipse.as.reddeer.server.wizard.NewServerWizardDialog;
 import org.jboss.ide.eclipse.as.reddeer.server.wizard.page.DefineNewServerWizardPage;
 import org.jboss.ide.eclipse.as.reddeer.server.wizard.page.JBossRuntimeWizardPage;
+import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
 import org.jboss.reddeer.eclipse.wst.server.ui.view.ServersView;
+import org.jboss.reddeer.eclipse.wst.server.ui.view.ServersViewEnums.ServerState;
 import org.jboss.reddeer.junit.requirement.CustomConfiguration;
 import org.jboss.reddeer.junit.requirement.Requirement;
+import org.jboss.reddeer.swt.api.Combo;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.swt.impl.combo.DefaultCombo;
 import org.jboss.reddeer.workbench.view.impl.WorkbenchView;
 
 /**
  * 
  * @author psrna
+ * @author Radoslav Rabara
  *
  */
 
 public class ServerRequirement implements Requirement<Server>, CustomConfiguration<ServerRequirementConfig> {
 
+	private static final Logger LOGGER = Logger.getLogger(ServerRequirement.class);
+	
+	private static ConfiguredServerInfo currentState;
+	
 	private ServerRequirementConfig config;
 	private Server server;
-	
 	
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target(ElementType.TYPE)
 	public @interface Server {
-		boolean started() default true;
+		ServerReqState state() default ServerReqState.RUNNING;
 	}
 	
 	
 	@Override
 	public boolean canFulfill() {
-		//TODO
+		//Server can be always added.
+		//However, when something goes wrong then AssertionError is thrown
 		return true;
 	}
 
 	@Override
 	public void fulfill() {
-		
-		setupServerAdapter();
-		if(server.started()){
-			startServer();
+		try {
+			if(currentState == null) {
+				//close welcome screen
+				try {
+					new WorkbenchView("Welcome").close();
+				} catch(Exception e){
+					//do nothing
+				}
+
+				throw new ServerIsNotSetException();
+			} else {
+				if(!config.equals(currentState.getConfig())) {
+					//different config = different server
+					removeLastRequiredServer();
+					throw new ServerIsNotSetException();
+				} else {
+					//the same config = the same server
+					setupServerState();
+				} 
+			}
+		} catch(ServerIsNotSetException e) {
+			LOGGER.info("Setup server");
+			setupServerAdapter();
+			currentState = new ConfiguredServerInfo(getServerNameLabelText(), config);
+			if(server.state() == ServerReqState.RUNNING){
+				startServer();
+			}
 		}
-		
 	}
 
+	private void setupServerState() throws NoServerFoundException {
+		LOGGER.info("Checking the state of the server '"+currentState.getServerName()+"'");
+		
+		org.jboss.reddeer.eclipse.wst.server.ui.view.Server serverInView = getConfiguredServer();
+		
+		ServerState state = serverInView.getLabel().getState();
+		ServerReqState requiredState = server.state();
+		switch(state) {
+			case STARTED:
+				if(requiredState == ServerReqState.STOPPED)
+					serverInView.stop();
+				break;
+			case STOPPED:
+				if(requiredState == ServerReqState.RUNNING)
+					serverInView.start();
+				break;
+			default:
+				new AssertionError("It was expected to have server in "
+					+ServerState.STARTED+" or "+ServerState.STOPPED+"state."
+							+ " Not in state "+state+".");
+		}
+	}
+	
+	private void removeLastRequiredServer() throws NoServerFoundException {		
+		org.jboss.reddeer.eclipse.wst.server.ui.view.Server serverInView = getConfiguredServer();
+		//if server is not stopped than stop the server
+		if(serverInView.getLabel().getState() == ServerState.STARTED) {
+			serverInView.stop();
+		}
+		//remove server added by last requirement
+		serverInView.delete();
+		//current state = there is no server defined
+		currentState = null;
+	}
+	
+	private org.jboss.reddeer.eclipse.wst.server.ui.view.Server getConfiguredServer()
+				throws NoServerFoundException {
+		ServersView serversView = new ServersView();
+		final String serverName = currentState.getServerName();
+		try {
+			return serversView.getServer(serverName);
+		} catch(EclipseLayerException e) {
+			//server had been removed
+			LOGGER.warn("Server had been removed "+serverName+".");
+			throw new NoServerFoundException();
+		}
+	}
+	
 	@Override
 	public void setDeclaration(Server server) {
 		this.server = server;
@@ -65,51 +149,130 @@ public class ServerRequirement implements Requirement<Server>, CustomConfigurati
 		this.config = config;
 	}
 
-	public ServerRequirementConfig getConfig(){
+	public ServerRequirementConfig getConfig() {
 		return this.config;
 	}
-		
-	public String getServerTypeLabelText(){
-		return config.getServerFamily().getLabel() + " " 
-	         + config.getServerFamily().getVersion();
+	
+	public String getServerTypeLabelText() {
+		ServerFamily server = config.getServerFamily();
+		if (server instanceof FamilyAS) {
+			if (server.getVersion().equals("8.0")) {
+				return "WildFly 8.0 (Experimental)";
+			}
+		}
+		if (server instanceof FamilyEAP) {
+			if (server.getVersion().equals("6.1")
+					|| server.getVersion().equals("6.2")) {
+				return config.getServerFamily().getLabel() + " " + "6.1+";
+			}
+		}
+		return config.getServerFamily().getLabel() + " "
+				+ config.getServerFamily().getVersion();
 	}
 	
-	public String getServerNameLabelText(){
+	public String getServerNameLabelText() {
 		return getServerTypeLabelText() + " Server";
 	}
 
-	public String getRuntimeNameLabelText(){
+	public String getRuntimeNameLabelText() {
 		return getServerTypeLabelText() + " Runtime";
 	}
-	
-	public void setupServerAdapter(){
-		
-		NewServerWizardDialog serverW = new NewServerWizardDialog();
-		serverW.open();
-		
-		DefineNewServerWizardPage sp = new DefineNewServerWizardPage(serverW);
 
-		sp.setName(getServerNameLabelText());
-		sp.selectType(getServerTypeLabelText());
-		serverW.next();
-		
-		JBossRuntimeWizardPage rp = new JBossRuntimeWizardPage();
-		rp.setRuntimeName(getRuntimeNameLabelText());
-		rp.setRuntimeDir(config.getRuntime());
-		
-		serverW.finish();
+	public void setupServerAdapter() {
+		NewServerWizardDialog serverW = new NewServerWizardDialog();
+		try {
+			serverW.open();
+			
+			DefineNewServerWizardPage sp = new DefineNewServerWizardPage(serverW);
+	
+			sp.selectType(config.getServerFamily().getCategory(),
+					getServerTypeLabelText());
+			checkIfThereIsAnyOtherServerWithTheSameType();
+			
+			sp.setName(getServerNameLabelText());
+			checkTheServerName();
+			
+			serverW.next();
+			
+			JBossRuntimeWizardPage rp = new JBossRuntimeWizardPage();
+			
+			rp.setRuntimeName(getRuntimeNameLabelText());
+			checkTheServerName();
+			
+			rp.setRuntimeDir(config.getRuntime());
+			checkTheHomeDirectory();
+			
+			checkOtherErrors();
+			
+			serverW.finish();
+		} catch(AssertionError e) {
+			serverW.cancel();
+			throw e;
+		}
+	}
+	
+	private void checkIfThereIsAnyOtherServerWithTheSameType() {
+		try {
+			//combo box indicate other servers with the same type
+			Combo combo = new DefaultCombo();
+			throw new AssertionError("There is another server with the same type.\n"
+					+ "Type: "+getServerTypeLabelText()+"\n"
+					+ "Present server: "+combo.getText());
+		} catch(SWTLayerException e) {
+			//combo box is not present so there is not any other server with the same type
+		}
+	}
+
+	private void checkTheServerName() {
+		String text = new org.jboss.reddeer.swt.impl.text.DefaultText(3).getText();
+		if(text.contains("The server name is already in use. Specify a different name.")) {
+			throw new AssertionError("The server name '"+getServerNameLabelText()+"' is already in use.");
+		}
+		if(text.contains("The name field must not be blank")) {
+			throw new AssertionError("The server name '"+getServerNameLabelText()+"' is empty.");
+		}
+	}
+	
+	private void checkTheHomeDirectory() {
+		String text = new org.jboss.reddeer.swt.impl.text.DefaultText(3).getText();
+		if(text.contains("The home directory does not exist or is not a directory.")) {
+			throw new AssertionError("The home directory '"+config.getRuntime()+"'"
+					+" does not exist or is not a directory.");
+		}
+		if(text.contains("The home directory is missing a required file or folder:")) {
+			throw new AssertionError("The home directory '"+config.getRuntime()+"'"
+					+" is missing a required file or folder:"+text.split(":")[1]);
+		}
+	}
+	
+	private void checkOtherErrors() {
+		String text = new org.jboss.reddeer.swt.impl.text.DefaultText(3).getText();
+		if(text.contains("No valid JREs found for execution environment")) {
+			throw new AssertionError(text);
+		}
+	}
+	
+	public void startServer() {
+		ServersView sw = new ServersView();
+		sw.getServer(getServerNameLabelText()).start();
+	}
+	
+	/**
+	 * Internal exception indicates that server must be set
+	 * 
+	 * @author rrabara
+	 */
+	private class ServerIsNotSetException extends Exception {
 		
 	}
 	
-	public void startServer(){
+	/**
+	 * Internal exception indicates aborting of procedure due to missing server
+	 * 
+	 * @author rrabara
+	 * @see ServerIsNotSetException
+	 */
+	private class NoServerFoundException extends ServerIsNotSetException {
 		
-		try{
-			new WorkbenchView("Welcome").close();
-		}catch(Exception e){
-			//do nothing
-		}
-		
-		ServersView sw = new ServersView();
-		sw.getServer(getServerNameLabelText()).start();
 	}
 }

--- a/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerRequirementConfig.java
+++ b/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerRequirementConfig.java
@@ -43,8 +43,16 @@ public class ServerRequirementConfig {
 	@XmlRootElement(name="familyAS", namespace="http://www.jboss.org/NS/ServerReq")
 	public static class FamilyAS implements ServerFamily {
 
-		private String label = "JBoss AS";
+		private final String category = "JBoss Community";
+		
+		private final String label = "JBoss AS";
+		
 		private String version;	
+		
+		@Override
+		public String getCategory() {
+			return category;
+		}
 		
 		@Override
 		public String getLabel() {
@@ -66,8 +74,16 @@ public class ServerRequirementConfig {
 	@XmlRootElement(name="familyEAP", namespace="http://www.jboss.org/NS/ServerReq")
 	public static class FamilyEAP implements ServerFamily {
 
-		private String label = "JBoss Enterprise Application Platform";
+		private final String category = "JBoss Enterprise Middleware";
+		
+		private final String label = "JBoss Enterprise Application Platform";
+		
 		private String version;
+		
+		@Override
+		public String getCategory() {
+			return category;
+		}
 		
 		@Override
 		public String getLabel() {
@@ -89,10 +105,24 @@ public class ServerRequirementConfig {
 	
 	public interface ServerFamily {
 		
+		public String getCategory();
+		
 		public String getLabel();
 		
 		public String getVersion();
 		
 	}
 	
+	public boolean equals(Object arg) {
+		if(arg == null || !(arg instanceof ServerRequirementConfig))
+			return false;
+		if(arg == this)
+			return true;
+		ServerRequirementConfig conf = (ServerRequirementConfig) arg;
+		ServerFamily family1 = this.getServerFamily();
+		ServerFamily family2 = conf.getServerFamily();
+		if(!runtime.equals(conf.runtime) || (family1 == null && family2 != null))
+			return false;
+		return family1.getLabel().equals(family2.getLabel()) && family1.getVersion().equals(family2.getVersion());
+	}
 }

--- a/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/wizard/page/DefineNewServerWizardPage.java
+++ b/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/wizard/page/DefineNewServerWizardPage.java
@@ -7,9 +7,12 @@ import org.jboss.reddeer.swt.impl.text.LabeledText;
 import org.jboss.reddeer.swt.impl.tree.DefaultTree;
 
 /**
+ * First wizard page of wizard "New Server"
+ * 
+ * File > New > Other... > Server > Server
  * 
  * @author psrna
- *
+ * @author Radoslav Rabara
  */
 public class DefineNewServerWizardPage extends NewServerWizardPage {
 	
@@ -18,19 +21,25 @@ public class DefineNewServerWizardPage extends NewServerWizardPage {
 	}
 
 	/**
-	 * Selects server of specified type.
+	 * Selects server of specified type in specified category.
+	 * 
+	 * @param category represents category of servers as seen in server tree.
 	 * @param type represents server node label as seen in server tree.
-	 * For example "JBoss AS 7.1"
+	 * 
+	 * For example "JBoss Community" "JBoss AS 7.1"
 	 */
-	public void selectType(String type){
-		
+	public void selectType(String category, String type){
 		DefaultTree t = new DefaultTree();
-		for(TreeItem i : t.getAllItems()){
-			if(i.getText().equals(type)){
-				i.select();
-				break;
+		for(TreeItem i : t.getItems()) {
+			if(i.getText().equals(category)) {
+				for(TreeItem j : i.getItems()) {
+					if(j.getText().equals(type)) {
+						j.select();
+						return;
+					}
+				}
 			}
 		}
+		throw new AssertionError("Type " + type + " is not among server types in category "+category+".");
 	}
-	
 }


### PR DESCRIPTION
- Added ServerReqState which is defining a state of the server (RUNNING, STOPPED or just PRESENT)
- Dealing with various situations like NoServerFound or ServerIsNotSet and errors that shows up in Add New Server dialog
- Added support for Wildfly (AS 8.0)
- Using versions 6.1 and 6.2 instead of 6.1+
- Reduced time of selecting server type by using server's category instead of searching the server in all items
- Handled running test suite against more config files
