### PR TITLE
Split different functionality for OpenShift Online and OpenShift enterprise

### DIFF
--- a/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/OpenShiftEnterpriseBotTests.java
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/OpenShiftEnterpriseBotTests.java
@@ -11,6 +11,9 @@
 package org.jboss.tools.openshift.ui.bot.test;
 
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.tools.openshift.ui.bot.test.app.CreateAdapterFromServerView;
+import org.jboss.tools.openshift.ui.bot.test.app.CreateAppUsingWizard;
+import org.jboss.tools.openshift.ui.bot.test.app.CreateApplicationFromGithubEnterprise;
 import org.jboss.tools.openshift.ui.bot.test.app.CreateDeleteEWSApp;
 import org.jboss.tools.openshift.ui.bot.test.app.CreateDeleteJBossApp;
 import org.jboss.tools.openshift.ui.bot.test.app.CreateDeleteJenkinsApp;
@@ -33,7 +36,8 @@ import org.jboss.tools.openshift.ui.bot.test.domain.RenameDomain;
 import org.jboss.tools.openshift.ui.bot.test.explorer.Connection;
 import org.jboss.tools.openshift.ui.bot.test.explorer.CreateAdapter;
 import org.jboss.tools.openshift.ui.bot.test.explorer.ManageSSH;
-import org.jboss.tools.openshift.ui.bot.test.explorer.OpenShiftDebugFeatures;
+import org.jboss.tools.openshift.ui.bot.test.explorer.OpenShiftEnterpriseDebugFeatures;
+import org.jboss.tools.openshift.ui.bot.util.CleanUp;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite.SuiteClasses;
 
@@ -59,13 +63,15 @@ import org.junit.runners.Suite.SuiteClasses;
  	RenameDomain.class,
 
 	/* Application creation*/
- 	// TODO create app from github template
+ 	CreateAppUsingWizard.class,
+ 	CreateApplicationFromGithubEnterprise.class,
  	// TODO deploy existing app
  	CreateAdapter.class,
+ 	CreateAdapterFromServerView.class,
 	EmbedCartridges.class, 
 	// TODO Conflict cartridge 
 	RepublishApp.class,
-	OpenShiftDebugFeatures.class,
+	OpenShiftEnterpriseDebugFeatures.class,
  	RestartApplication.class, 
  	// TODO import application
  	// TODO maven profile
@@ -87,7 +93,8 @@ import org.junit.runners.Suite.SuiteClasses;
 	CreateDeleteScalablePythonApp.class, 
 	CreateDeleteScalablePerlApp.class, 
 	CreateDeleteScaledRubyApp.class, 
-
+	
+	CleanUp.class
 })
 public class OpenShiftEnterpriseBotTests {
 	

--- a/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/app/CreateAppUsingWizard.java
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/app/CreateAppUsingWizard.java
@@ -17,10 +17,8 @@ import org.jboss.reddeer.swt.impl.combo.DefaultCombo;
 import org.jboss.reddeer.swt.impl.menu.ContextMenu;
 import org.jboss.reddeer.swt.impl.menu.ShellMenu;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
-import org.jboss.reddeer.swt.impl.text.DefaultText;
 import org.jboss.reddeer.swt.impl.text.LabeledText;
 import org.jboss.reddeer.swt.impl.tree.DefaultTree;
-import org.jboss.reddeer.swt.lookup.ShellLookup;
 import org.jboss.reddeer.swt.wait.AbstractWait;
 import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitUntil;
@@ -53,11 +51,7 @@ public class CreateAppUsingWizard {
 		
 		new WaitUntil(new ShellWithTextIsAvailable("New OpenShift Application"), TimePeriod.LONG);
 
-		new DefaultShell("New OpenShift Application").setFocus();
-		if (new CheckBox(1).isChecked()) {
-			new CheckBox(1).click();
-		}
-		new DefaultText(1).setText(System.getProperty("user.pwd"));
+		new DefaultCombo().setSelection(0);
 		new WaitUntil(new ButtonWithTextIsActive(new PushButton(OpenShiftLabel.Button.NEXT)));
 		new PushButton(OpenShiftLabel.Button.NEXT).click();
 		
@@ -65,7 +59,6 @@ public class CreateAppUsingWizard {
 		
 		new DefaultShell("New OpenShift Application").setFocus();
 		
-		// ffs
 		AbstractWait.sleep(10000);
 		
 		new LabeledText("Name:").setText(APP_NAME);

--- a/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/app/CreateApplicationFromGithub.java
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/app/CreateApplicationFromGithub.java
@@ -27,7 +27,11 @@ public class CreateApplicationFromGithub {
 	private static final String URL = "https://github.com/openshift/wordpress-example";
 	
 	@Test
-	public void createAppFromGithub() {
+	public void createAppFromGithubTemplate() {
+		createAppFromGithub(OpenShiftLabel.Cartridge.MYSQL_ONLINE);
+	}
+	
+	public static void createAppFromGithub(String mySQLLabel) {
 		OpenShiftExplorerView explorer = new OpenShiftExplorerView();
 		explorer.open();
 		
@@ -40,7 +44,7 @@ public class CreateApplicationFromGithub {
 		new DefaultShell("New OpenShift Application").setFocus();
 		new LabeledText("Name:").setText(APP_NAME);
 		new DefaultCombo(1).setSelection(OpenShiftLabel.AppType.PHP);
-		new DefaultTable().getItem(OpenShiftLabel.Cartridge.MYSQL_ONLINE).setChecked(true);
+		new DefaultTable().getItem(mySQLLabel).setChecked(true);
 		new PushButton(OpenShiftLabel.Button.ADVANCED).click();
 		new CheckBox(2).click();
 		new LabeledText("Source code:").setText(URL);
@@ -76,7 +80,11 @@ public class CreateApplicationFromGithub {
 	}
 
 	@After
-	public void deleteApp() {
+	public void deleteApplication() {
+		deleteApp();
+	}
+	
+	public static void deleteApp() {
 		OpenShiftBotTest.deleteOpenShiftApplication(APP_NAME, OpenShiftLabel.AppType.PHP);
 	}
 }

--- a/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/app/CreateApplicationFromGithubEnterprise.java
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/app/CreateApplicationFromGithubEnterprise.java
@@ -1,0 +1,19 @@
+package org.jboss.tools.openshift.ui.bot.test.app;
+
+import org.jboss.tools.openshift.ui.bot.util.OpenShiftLabel;
+import org.junit.After;
+import org.junit.Test;
+
+public class CreateApplicationFromGithubEnterprise {
+
+	@Test
+	public void createAppFromGithubTemplate() {
+		CreateApplicationFromGithub.createAppFromGithub(OpenShiftLabel.Cartridge.MYSQL);
+	}
+	
+	@After
+	public void deleteApplication() {
+		CreateApplicationFromGithub.deleteApp();
+	}
+	
+}

--- a/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/explorer/OpenShiftDebugFeatures.java
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/explorer/OpenShiftDebugFeatures.java
@@ -32,10 +32,14 @@ import org.junit.Test;
 */
 public class OpenShiftDebugFeatures extends OpenShiftBotTest {
 
-        private final String DYI_APP = "diyapp" + new Date().getTime();
+        public static final String DYI_APP = "diyapp" + new Date().getTime();
 
         @Before
-        public void createDYIApp() {
+        public void createDIYApplication() {
+        	createDYIApp();
+        }
+        
+        public static void createDYIApp() {
                 createOpenShiftApplication(DYI_APP, OpenShiftLabel.AppType.DIY);
         }
        
@@ -48,7 +52,7 @@ public class OpenShiftDebugFeatures extends OpenShiftBotTest {
         	canCreateEnvVariable();
         }
         
-        public void canTailFiles() {
+        public static void canTailFiles() {
                 openDebugFeature(OpenShiftLabel.Labels.EXPLORER_TAIL_FILES);
                 
                 new WaitUntil(new ShellWithTextIsAvailable(OpenShiftLabel.Shell.TAIL_FILES), TimePeriod.LONG);
@@ -67,7 +71,7 @@ public class OpenShiftDebugFeatures extends OpenShiftBotTest {
                 new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
         }
 
-        public void canForwardPorts() {
+        public static void canForwardPorts() {
                 openDebugFeature(OpenShiftLabel.Labels.EXPLORER_PORTS);
 
                 new WaitUntil(new ShellWithTextIsAvailable(OpenShiftLabel.Shell.PORTS), TimePeriod.LONG);
@@ -98,7 +102,7 @@ public class OpenShiftDebugFeatures extends OpenShiftBotTest {
                 new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
         }
 
-        public void canOpenWebBrowser() {
+        public static void canOpenWebBrowser() {
                 openDebugFeature("Show in Web Browser");
 
                 new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
@@ -106,7 +110,7 @@ public class OpenShiftDebugFeatures extends OpenShiftBotTest {
                 // it is browser editor
         }
 
-        public void canShowEnvVariables() {
+        public static void canShowEnvVariables() {
                 openDebugFeature(OpenShiftLabel.Labels.EXPLORER_ENV_VAR);
 
                 new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
@@ -118,7 +122,7 @@ public class OpenShiftDebugFeatures extends OpenShiftBotTest {
                 new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
         }
 
-        public void canCreateEnvVariable() {
+        public static void canCreateEnvVariable() {
                 openDebugFeature("Edit Environment Variables...");
                 
                 new WaitUntil(new ShellWithTextIsAvailable(
@@ -146,7 +150,7 @@ public class OpenShiftDebugFeatures extends OpenShiftBotTest {
                 new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
         }
         
-        private void openDebugFeature(String label) {
+        private static void openDebugFeature(String label) {
 		        OpenShiftExplorerView explorer = new OpenShiftExplorerView();
 		        explorer.open();
 
@@ -169,7 +173,11 @@ public class OpenShiftDebugFeatures extends OpenShiftBotTest {
         }
         
         @After
-        public void deleteDIYApp() {
+        public void deleteDIYApplication() {
+        	deleteDIYApp();
+        }
+        
+        public static void deleteDIYApp() {
                 deleteOpenShiftApplication(DYI_APP, OpenShiftLabel.AppType.DIY);
         }   
 

--- a/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/explorer/OpenShiftEnterpriseDebugFeatures.java
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/explorer/OpenShiftEnterpriseDebugFeatures.java
@@ -1,0 +1,37 @@
+package org.jboss.tools.openshift.ui.bot.test.explorer;
+
+import org.jboss.tools.openshift.ui.bot.test.OpenShiftBotTest;
+import org.jboss.tools.openshift.ui.bot.util.OpenShiftLabel;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+* Test class for tailing remote files, port forwarding, opening web browser & displaying env.variables.
+* To prevent creation of OpenShift application for each test, all tests are included in one test method.
+*
+* @author mlabuda
+*
+*/
+public class OpenShiftEnterpriseDebugFeatures extends OpenShiftBotTest {
+
+        @Before
+        public void createDYIApp() {
+                OpenShiftDebugFeatures.createDYIApp();
+        }
+       
+        @Test
+        public void testDebufFeaures() {
+        	OpenShiftDebugFeatures.canTailFiles();
+        	OpenShiftDebugFeatures.canForwardPorts();
+        	OpenShiftDebugFeatures.canOpenWebBrowser();
+        	OpenShiftDebugFeatures.canShowEnvVariables();
+        }
+        
+        @After
+        public void deleteDIYApp() {
+                OpenShiftDebugFeatures.deleteOpenShiftApplication(
+                		OpenShiftDebugFeatures.DYI_APP, OpenShiftLabel.AppType.DIY);
+        }   
+
+}


### PR DESCRIPTION
- split create application from github template, bcs. of different labels
- minor fix for create app through wizard - now more flexible solution
- some cleanup performed
- modified Enterprise test suite
