### PR TITLE
JBIDE-16161 Temporary fix for missing equinox.event plugin

### DIFF
--- a/tests/org.jboss.tools.dummy.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.dummy.ui.bot.test/pom.xml
@@ -22,7 +22,7 @@
 					<testSuite>org.jboss.tools.dummy.ui.bot.test</testSuite>
 					<testClass>org.jboss.tools.dummy.ui.bot.test.DummySuite</testClass>
 					<skip>${swtbot.test.skip}</skip>
-					<dependencies>
+					<dependencies combine.children="append">
 						<dependency>
 							<type>p2-installable-unit</type>
 							<artifactId>org.eclipse.jdt.feature.group</artifactId>

--- a/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
@@ -141,8 +141,8 @@
 					<skip>${swtbot.test.skip}</skip>
 					<testSuite>org.jboss.tools.maven.ui.bot.test</testSuite>
 					<testClass>${suiteClass}</testClass>
-					<dependencies>
-						<dependency combine.children="append">
+					<dependencies combine.children="append">
+						<dependency>
 							<type>p2-installable-unit</type>
 							<artifactId>org.eclipse.jst.enterprise_ui.feature.feature.group</artifactId>
 							<version>0.0.0</version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -69,6 +69,14 @@
 						<bundle>org.mozilla.xulrunner.gtk.linux.x86_64</bundle>
 						<bundle>org.mozilla.xulrunner.win32.win32.x86</bundle>
 					</explodedBundles>
+					<!-- Temporary solution for mac - see JBIDE-16161 -->
+					<dependencies>
+						<dependency>
+							<type>eclipse-plugin</type>
+							<artifactId>org.eclipse.equinox.event</artifactId>
+							<version>0.0.0</version>
+						</dependency>
+					</dependencies>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
When running swt bot tests on Mac, the workbench fails to load.
This is because org.eclipse.equinox.event is no longer in the chain
of dependencies. So the temporary solution is to add it ourselves.
