### PR TITLE
SWTBotExt changed test's names

### DIFF
--- a/plugins/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/RequirementAwareSuite.java
+++ b/plugins/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/RequirementAwareSuite.java
@@ -189,7 +189,7 @@ public class RequirementAwareSuite extends Suite {
 
 		@Override
 		protected String testName(FrameworkMethod method) {
-			return config.getPropName() + " - " + method.getName();
+			return method.getName() + " - " + config.getPropName();
 		}
 
 		@Override
@@ -403,8 +403,8 @@ public class RequirementAwareSuite extends Suite {
 			try {
 				TestConfiguration config = new TestConfiguration(entry.getKey()
 						.toString(), entry.getValue().toString());
-				String suiteName = config.getPropName() + " - "
-						+ klass.getCanonicalName();
+				String suiteName = klass.getCanonicalName() + " - "
+						+ config.getPropName();
 				log.info("Determine whether test classes meet configuration");
 				NamedSuite suite = new NamedSuite(klass,new RequirementAwareRunnerBuilder(config), suiteName);
 				// when no class mathces given config, do not init it 


### PR DESCRIPTION
This small change enables "Go To Test" feature in JUnit View.

When you click on the test class/method in tree in JUnit View, it will navigate you to the test class and it highlights the selected class/method or the line where the test failed.

JBoss Tools Component: SWTBotExt
Author: rrabara
