### PR TITLE
Simplify dummy bot test

### DIFF
--- a/tests/org.jboss.tools.dummy.ui.bot.test/src/org/jboss/tools/dummy/ui/bot/test/DummySuite.java
+++ b/tests/org.jboss.tools.dummy.ui.bot.test/src/org/jboss/tools/dummy/ui/bot/test/DummySuite.java
@@ -1,15 +1,15 @@
 package org.jboss.tools.dummy.ui.bot.test;
 
-import org.jboss.tools.ui.bot.ext.RequirementAwareSuite;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite.SuiteClasses;
+import org.junit.runners.Suite;
 
 /**
  * Dummy test suite is SWTBot test suite for basic jenkins slave test
  * @author Jiri Peterka
  *
  */
-@RunWith(RequirementAwareSuite.class)
+@RunWith(Suite.class)
 @SuiteClasses({DummyTest.class})
 public class DummySuite {
 


### PR DESCRIPTION
The dummy bot test used RequirementAwareSuite which is not necessary
- the aim of this test is to check if a simple bot test will work
  so it should be as simple as possible. Now the test suite uses
  @RunWith(Suite.class)
