### PR TITLE
Removed repository swtbot/snapshots from portlet's pom.xml

### DIFF
--- a/tests/org.jboss.tools.portlet.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.portlet.ui.bot.test/pom.xml
@@ -30,11 +30,6 @@
 
 	<repositories>
 		<repository>
-			<id>swtbot-nightly-staging-site</id>
-			<url>http://download.eclipse.org/technology/swtbot/snapshots</url>
-			<layout>p2</layout>
-		</repository>
-		<repository>
 			<id>jbosstools-experiments</id>
 			<url>https://repository.jboss.org/nexus/content/repositories/jbosstools-experiments/</url>
 		</repository>


### PR DESCRIPTION
It is not necessary to have repository http://download.eclipse.org/technology/swtbot/snapshots in portlet's pom.xml because the project can be built without it.

JBoss Tools Component: portals
Author: rrabara
