### PR TITLE
JBIDE-13938 Changed version of JBoss server requirements from string to enum

### DIFF
--- a/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/example/simple/advanced/AS7plusServerTest.java
+++ b/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/example/simple/advanced/AS7plusServerTest.java
@@ -1,6 +1,6 @@
 package org.jboss.ide.eclipse.as.reddeer.server.example.simple.advanced;
 
-import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqOperator;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqVersion;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqState;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(RedDeerSuite.class)
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS, version="7", operator=ServerReqOperator.GREATER_OR_EQUAL)
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS7_0, version=ServerReqVersion.GREATER_OR_EQUAL)
 public class AS7plusServerTest {
 	
 	@Test

--- a/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/example/simple/advanced/EAP6ServerTest.java
+++ b/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/example/simple/advanced/EAP6ServerTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(RedDeerSuite.class)
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP, version="6")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP6_0)
 public class EAP6ServerTest {
 	
 	@Test

--- a/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerReqType.java
+++ b/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerReqType.java
@@ -1,30 +1,133 @@
 package org.jboss.ide.eclipse.as.reddeer.server.requirement;
 
 /**
- * Enumeration of server's types
+ * Enumeration of server types.
+ * <br/>
+ * 
+ * Server type can be defined just by family({@link #AS}, {@link #EAP} or {@link #WILDFLY})
+ * or by family and version (e.g. {@link #AS7_1}, {@link #EAP6_1plus} or {@link #WILDFLY8_0)
+ * <br/><br/>
+ *
+ * When server type is defined just by family, it matches any version (version is empty string).
+ * When server type has defined version, it must match to version defined
+ * as part of server adapter string in New Server dialog window.
+ * <br/>
+ * 
+ * e.g. Server type matching EAP 6.1 must have version <code>6.1+</code> because server adapter for EAP 6.1
+ * has string "JBoss Enterprise Application Platform <b>6.1+</b>"
  * 
  * @author Radoslav Rabara
  *
  */
 public enum ServerReqType {
+	
 	/**
 	 * Matches any server
 	 */
-	ANY,
+	ANY(ServerReqFamily.ANY),
 	
 	/**
-	 * JBoss Application Server
+	 * JBoss Application Server with any version
 	 */
-	AS,
+	AS(ServerReqFamily.AS),
+	/**
+	 * JBoss Application Server 3.2
+	 */
+	AS3_2(ServerReqFamily.AS, "3.2"),
+	/**
+	 * JBoss Application Server 4.0
+	 */
+	AS4_0(ServerReqFamily.AS, "4.0"),
+	/**
+	 * JBoss Application Server 4.2
+	 */
+	AS4_2(ServerReqFamily.AS, "4.2"),
+	/**
+	 * JBoss Application Server 5.0
+	 */
+	AS5_0(ServerReqFamily.AS, "5.0"),
+	/**
+	 * JBoss Application Server 5.1
+	 */
+	AS5_1(ServerReqFamily.AS, "5.1"),
+	/**
+	 * JBoss Application Server 6.x
+	 */
+	AS6x(ServerReqFamily.AS, "6.x"),
+	/**
+	 * JBoss Application Server 7.0
+	 */
+	AS7_0(ServerReqFamily.AS, "7.0"),
+	/**
+	 * JBoss Application Server 7.1
+	 */
+	AS7_1(ServerReqFamily.AS, "7.1"),
 	
 	/**
-	 * JBoss Enterprise Application Platform
+	 * JBoss Enterprise Application Platform with any version
 	 */
-	EAP,
+	EAP(ServerReqFamily.EAP),
+	/**
+	 * JBoss Enterprise Application Platform 4.3
+	 */
+	EAP4_3(ServerReqFamily.EAP, "4.3"),
+	/**
+	 * JBoss Enterprise Application Platform 5.x
+	 */
+	EAP5x(ServerReqFamily.EAP, "5.x"),
+	/**
+	 * JBoss Enterprise Application Platform 6.0
+	 */
+	EAP6_0(ServerReqFamily.EAP, "6.0"),
+	/**
+	 * JBoss Enterprise Application Platform 6.1+
+	 */
+	EAP6_1plus(ServerReqFamily.EAP, "6.1+"),
 	
 	/**
 	 * WildFly
 	 * - successor of AS
 	 */
-	WILDFLY
+	WILDFLY(ServerReqFamily.WILDFLY),
+	/**
+	 * WildFly 8.0
+	 */
+	WILDFLY8_0(ServerReqFamily.WILDFLY, "8.0 (Experimental)");
+
+
+	private String version;
+	
+	private ServerReqFamily family;
+	
+	/**
+	 * Define server type by {@link ServerReqFamily} with any version.
+	 * 
+	 * @param family family of defined server
+	 */
+	ServerReqType(ServerReqFamily family) {
+		this(family, "");
+	}
+	
+	/**
+	 * Define server type by {@link ServerReqFamily} with specified <var><version/var>
+	 * 
+	 * @param family family of defined server
+	 * @param version version of defined server
+	 */
+	ServerReqType(ServerReqFamily family, String version) {
+		this.version = version;
+		this.family = family;
+	}
+	
+	public String getVersion() {
+		return version;
+	}
+	
+	public ServerReqFamily getFamily() {
+		return family;
+	}
+	
+	enum ServerReqFamily {
+		AS, EAP, WILDFLY, ANY
+	}
 }

--- a/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerReqVersion.java
+++ b/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerReqVersion.java
@@ -1,12 +1,12 @@
 package org.jboss.ide.eclipse.as.reddeer.server.requirement;
 
 /**
- * Enumeration of operators used to match server's version
+ * Enumeration of version matchers.
  * 
  * @author Radoslav Rabara
  *
  */
-public enum ServerReqOperator {
+public enum ServerReqVersion {
 	/**
 	 * =
 	 */

--- a/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerRequirement.java
+++ b/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerRequirement.java
@@ -38,8 +38,7 @@ public class ServerRequirement implements Requirement<JBossServer>, CustomConfig
 	public @interface JBossServer {
 		ServerReqState state() default ServerReqState.RUNNING;
 		ServerReqType type() default ServerReqType.ANY;
-		String version() default "";
-		ServerReqOperator operator() default ServerReqOperator.EQUAL;
+		ServerReqVersion version() default ServerReqVersion.EQUAL;
 	}
 	
 	
@@ -47,8 +46,8 @@ public class ServerRequirement implements Requirement<JBossServer>, CustomConfig
 	public boolean canFulfill() {
 		//requirement can be fulfilled only when required server's type and version matches to
 		//configured server's type and version
-		return ServerMatcher.matchServerType(server.type(), config.getServerFamily()) &&
-				ServerMatcher.matchServerVersion(server.version(), server.operator(),
+		return ServerMatcher.matchServerFamily(server.type().getFamily(), config.getServerFamily()) &&
+				ServerMatcher.matchServerVersion(server.type().getVersion(), server.version(),
 				config.getServerFamily().getVersion());
 	}
 

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as3/CreateAS3Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as3/CreateAS3Server.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.fail;
 * @author Lucia Jelinkova
 *
 */
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS, version="3.2")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS3_2)
 @CleanWorkspace
 public class CreateAS3Server extends CreateServerTemplate {
 

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as3/DeleteServerAS3Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as3/DeleteServerAS3Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeleteServerTemplate;
 
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS, version="3.2")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS3_2)
 public class DeleteServerAS3Server extends DeleteServerTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as3/DeployJSPProjectAS3Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as3/DeployJSPProjectAS3Server.java
@@ -10,7 +10,8 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="3.2")
+
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS3_2)
 public class DeployJSPProjectAS3Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as3/HotDeployJSPFileAS3Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as3/HotDeployJSPFileAS3Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="3.2")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS3_2)
 public class HotDeployJSPFileAS3Server extends HotDeployJSPFileTemplate{
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as3/OperateAS3Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as3/OperateAS3Server.java
@@ -10,7 +10,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.OperateServerTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.AS, version="3.2")
+@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.AS3_2)
 public class OperateAS3Server extends OperateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as3/UndeployJSPProjectAS3Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as3/UndeployJSPProjectAS3Server.java
@@ -11,7 +11,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.UndeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="3.2")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS3_2)
 public class UndeployJSPProjectAS3Server extends UndeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as40/CreateAS40Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as40/CreateAS40Server.java
@@ -22,7 +22,8 @@ import static org.junit.Assert.fail;
 *
 */
 @CleanWorkspace
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS, version="4.0")
+
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS4_0)
 public class CreateAS40Server extends CreateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as40/DeleteServerAS40Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as40/DeleteServerAS40Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeleteServerTemplate;
 
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS, version="4.0")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS4_0)
 public class DeleteServerAS40Server extends DeleteServerTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as40/DeployJSPProjectAS40Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as40/DeployJSPProjectAS40Server.java
@@ -10,7 +10,8 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="4.0")
+
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS4_0)
 public class DeployJSPProjectAS40Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as40/HotDeployJSPFileAS40Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as40/HotDeployJSPFileAS40Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="4.0")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS4_0)
 public class HotDeployJSPFileAS40Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as40/OperateAS40Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as40/OperateAS40Server.java
@@ -10,7 +10,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.OperateServerTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.AS, version="4.0")
+@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.AS4_0)
 public class OperateAS40Server extends OperateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as40/UndeployJSPProjectAS40Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as40/UndeployJSPProjectAS40Server.java
@@ -11,7 +11,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.UndeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="4.0")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS4_0)
 public class UndeployJSPProjectAS40Server extends UndeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as42/CreateAS42Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as42/CreateAS42Server.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.fail;
 *
 */
 @CleanWorkspace
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS, version="4.2")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS4_2)
 public class CreateAS42Server extends CreateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as42/DeleteServerAS42Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as42/DeleteServerAS42Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeleteServerTemplate;
 
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS, version="4.2")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS4_2)
 public class DeleteServerAS42Server extends DeleteServerTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as42/DeployJSPProjectAS42Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as42/DeployJSPProjectAS42Server.java
@@ -10,7 +10,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="4.2")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS4_2)
 public class DeployJSPProjectAS42Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as42/HotDeployJSPFileAS42Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as42/HotDeployJSPFileAS42Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="4.2")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS4_2)
 public class HotDeployJSPFileAS42Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as42/OperateAS42Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as42/OperateAS42Server.java
@@ -10,7 +10,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.OperateServerTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.AS, version="4.2")
+@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.AS4_2)
 public class OperateAS42Server extends OperateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as42/UndeployJSPProjectAS42Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as42/UndeployJSPProjectAS42Server.java
@@ -11,7 +11,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.UndeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="4.2")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS4_2)
 public class UndeployJSPProjectAS42Server extends UndeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as50/CreateAS50Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as50/CreateAS50Server.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.fail;
 *
 */
 @CleanWorkspace
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS, version="5.0")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS5_0)
 public class CreateAS50Server extends CreateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as50/DeleteServerAS50Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as50/DeleteServerAS50Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeleteServerTemplate;
 
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS, version="5.0")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS5_0)
 public class DeleteServerAS50Server extends DeleteServerTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as50/DeployJSPProjectAS50Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as50/DeployJSPProjectAS50Server.java
@@ -10,7 +10,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="5.0")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS5_0)
 public class DeployJSPProjectAS50Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as50/HotDeployJSPFileAS50Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as50/HotDeployJSPFileAS50Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="5.0")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS5_0)
 public class HotDeployJSPFileAS50Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as50/OperateAS50Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as50/OperateAS50Server.java
@@ -10,7 +10,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.OperateServerTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.AS, version="5.0")
+@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.AS5_0)
 public class OperateAS50Server extends OperateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as50/UndeployJSPProjectAS50Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as50/UndeployJSPProjectAS50Server.java
@@ -11,7 +11,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.UndeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="5.0")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS5_0)
 public class UndeployJSPProjectAS50Server extends UndeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as51/CreateAS51Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as51/CreateAS51Server.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.fail;
 *
 */
 @CleanWorkspace
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS, version="5.1")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS5_1)
 public class CreateAS51Server extends CreateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as51/DeleteServerAS51Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as51/DeleteServerAS51Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeleteServerTemplate;
 
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS, version="5.1")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS5_1)
 public class DeleteServerAS51Server extends DeleteServerTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as51/DeployJSPProjectAS51Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as51/DeployJSPProjectAS51Server.java
@@ -10,7 +10,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="5.1")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS5_1)
 public class DeployJSPProjectAS51Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as51/HotDeployJSPFileAS51Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as51/HotDeployJSPFileAS51Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="5.1")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS5_1)
 public class HotDeployJSPFileAS51Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as51/OperateAS51Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as51/OperateAS51Server.java
@@ -10,7 +10,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.OperateServerTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.AS, version="5.1")
+@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.AS5_1)
 public class OperateAS51Server extends OperateServerTemplate {
 	
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as51/UndeployJSPProjectAS51Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as51/UndeployJSPProjectAS51Server.java
@@ -11,7 +11,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.UndeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="5.1")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS5_1)
 public class UndeployJSPProjectAS51Server extends UndeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as6/CreateAS6Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as6/CreateAS6Server.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.fail;
 *
 */
 @CleanWorkspace
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS, version="6")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS6x)
 public class CreateAS6Server extends CreateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as6/DeleteServerAS6Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as6/DeleteServerAS6Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeleteServerTemplate;
 
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS, version="6")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS6x)
 public class DeleteServerAS6Server extends DeleteServerTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as6/DeployJSPProjectAS6Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as6/DeployJSPProjectAS6Server.java
@@ -10,7 +10,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="6")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS6x)
 public class DeployJSPProjectAS6Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as6/HotDeployJSPFileAS6Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as6/HotDeployJSPFileAS6Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="6")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS6x)
 public class HotDeployJSPFileAS6Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as6/OperateAS6Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as6/OperateAS6Server.java
@@ -10,7 +10,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.OperateServerTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.AS, version="6")
+@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.AS6x)
 public class OperateAS6Server extends OperateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as6/UndeployJSPProjectAS6Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as6/UndeployJSPProjectAS6Server.java
@@ -11,7 +11,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.UndeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="6")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS6x)
 public class UndeployJSPProjectAS6Server extends UndeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as70/CreateAS70Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as70/CreateAS70Server.java
@@ -23,7 +23,7 @@ import static org.hamcrest.core.IsCollectionContaining.hasItem;
  *
  */
 @CleanWorkspace
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS, version="7.0")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS7_0)
 public class CreateAS70Server extends CreateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as70/DeleteServerAS70Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as70/DeleteServerAS70Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeleteServerTemplate;
 
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS, version="7.0")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS7_0)
 public class DeleteServerAS70Server extends DeleteServerTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as70/DeployJSPProjectAS70Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as70/DeployJSPProjectAS70Server.java
@@ -10,7 +10,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="7.0")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS7_0)
 public class DeployJSPProjectAS70Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as70/HotDeployJSPFileAS70Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as70/HotDeployJSPFileAS70Server.java
@@ -6,7 +6,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="7.0")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS7_0)
 public class HotDeployJSPFileAS70Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as70/OperateAS70Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as70/OperateAS70Server.java
@@ -11,7 +11,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.OperateServerTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.AS, version="7.0")
+@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.AS7_0)
 public class OperateAS70Server extends OperateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as70/UndeployJSPProjectAS70Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as70/UndeployJSPProjectAS70Server.java
@@ -11,7 +11,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.UndeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="7.0")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS7_0)
 public class UndeployJSPProjectAS70Server extends UndeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as71/CreateAS71Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as71/CreateAS71Server.java
@@ -21,7 +21,7 @@ import static org.hamcrest.core.IsCollectionContaining.hasItem;
  *
  */
 @CleanWorkspace
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS, version="7.1")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS7_1)
 public class CreateAS71Server extends CreateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as71/DeleteServerAS71Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as71/DeleteServerAS71Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeleteServerTemplate;
 
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS, version="7.1")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.AS7_1)
 public class DeleteServerAS71Server extends DeleteServerTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as71/DeployJSPProjectAS71Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as71/DeployJSPProjectAS71Server.java
@@ -11,7 +11,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="7.1")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS7_1)
 public class DeployJSPProjectAS71Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as71/HotDeployJSPFileAS71Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as71/HotDeployJSPFileAS71Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="7.1")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS7_1)
 public class HotDeployJSPFileAS71Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as71/OperateAS71Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as71/OperateAS71Server.java
@@ -10,7 +10,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.OperateServerTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.AS, version="7.1")
+@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.AS7_1)
 public class OperateAS71Server extends OperateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as71/ServerStateDetectorsAS71Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as71/ServerStateDetectorsAS71Server.java
@@ -6,7 +6,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.ServerStateDetectorsTemplate;
 
-@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.AS, version="7.1")
+@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.AS7_1)
 public class ServerStateDetectorsAS71Server extends ServerStateDetectorsTemplate{
 	
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as71/UndeployJSPProjectAS71Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as71/UndeployJSPProjectAS71Server.java
@@ -12,7 +12,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.UndeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS, version="7.1")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS7_1)
 public class UndeployJSPProjectAS71Server extends UndeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap4/CreateEAP4Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap4/CreateEAP4Server.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.fail;
 *
 */
 @CleanWorkspace
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.EAP, version="4.3")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.EAP4_3)
 public class CreateEAP4Server extends CreateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap4/DeleteServerEAP4Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap4/DeleteServerEAP4Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeleteServerTemplate;
 
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.EAP, version="4.3")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.EAP4_3)
 public class DeleteServerEAP4Server extends DeleteServerTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap4/DeployJSPProjectEAP4Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap4/DeployJSPProjectEAP4Server.java
@@ -10,7 +10,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP, version="4.3")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP4_3)
 public class DeployJSPProjectEAP4Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap4/HotDeployJSPFileEAP4Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap4/HotDeployJSPFileEAP4Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP, version="4.3")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP4_3)
 public class HotDeployJSPFileEAP4Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap4/OperateEAP4Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap4/OperateEAP4Server.java
@@ -10,7 +10,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.OperateServerTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.EAP, version="4.3")
+@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.EAP4_3)
 public class OperateEAP4Server extends OperateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap4/UndeployJSPProjectEAP4Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap4/UndeployJSPProjectEAP4Server.java
@@ -11,7 +11,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.UndeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP, version="4.3")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP4_3)
 public class UndeployJSPProjectEAP4Server extends UndeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap5/CreateEAP5Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap5/CreateEAP5Server.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.fail;
 *
 */
 @CleanWorkspace
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.EAP, version="5")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.EAP5x)
 public class CreateEAP5Server extends CreateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap5/DeleteServerEAP5Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap5/DeleteServerEAP5Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeleteServerTemplate;
 
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.EAP, version="5")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.EAP5x)
 public class DeleteServerEAP5Server extends DeleteServerTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap5/DeployJSPProjectEAP5Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap5/DeployJSPProjectEAP5Server.java
@@ -10,7 +10,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP, version="5")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP5x)
 public class DeployJSPProjectEAP5Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap5/HotDeployJSPFileEAP5Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap5/HotDeployJSPFileEAP5Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP, version="5")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP5x)
 public class HotDeployJSPFileEAP5Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap5/OperateEAP5Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap5/OperateEAP5Server.java
@@ -10,7 +10,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.OperateServerTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.EAP, version="5")
+@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.EAP5x)
 public class OperateEAP5Server extends OperateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap5/UndeployJSPProjectEAP5Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap5/UndeployJSPProjectEAP5Server.java
@@ -11,7 +11,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.UndeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP, version="5")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP5x)
 public class UndeployJSPProjectEAP5Server extends UndeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap60/CreateEAP60Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap60/CreateEAP60Server.java
@@ -21,7 +21,7 @@ import static org.hamcrest.core.IsCollectionContaining.hasItem;
  *
  */
 @CleanWorkspace
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.EAP, version="6.0")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.EAP6_0)
 public class CreateEAP60Server extends CreateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap60/DeleteServerEAP60Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap60/DeleteServerEAP60Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeleteServerTemplate;
 
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.EAP, version="6.0")
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.EAP6_0)
 public class DeleteServerEAP60Server extends DeleteServerTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap60/DeployJSPProjectEAP60Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap60/DeployJSPProjectEAP60Server.java
@@ -10,7 +10,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP, version="6.0")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP6_0)
 public class DeployJSPProjectEAP60Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap60/HotDeployJSPFileEAP60Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap60/HotDeployJSPFileEAP60Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP, version="6.0")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP6_0)
 public class HotDeployJSPFileEAP60Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap60/OperateEAP60Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap60/OperateEAP60Server.java
@@ -11,7 +11,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.OperateServerTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.EAP, version="6.0")
+@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.EAP6_0)
 public class OperateEAP60Server extends OperateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap60/UndeployJSPProjectEAP60Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap60/UndeployJSPProjectEAP60Server.java
@@ -11,7 +11,7 @@ import org.jboss.ide.eclipse.as.ui.bot.test.template.UndeployJSPProjectTemplate;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP, version="6.0")
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP6_0)
 public class UndeployJSPProjectEAP60Server extends UndeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap6x/CreateEAP6xServer.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap6x/CreateEAP6xServer.java
@@ -2,7 +2,7 @@ package org.jboss.ide.eclipse.as.ui.bot.test.eap6x;
 
 import java.util.List;
 
-import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqOperator;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqVersion;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqState;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
@@ -16,7 +16,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 
 @CleanWorkspace
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.EAP, version="6.1", operator=ServerReqOperator.GREATER_OR_EQUAL)
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.EAP6_1plus, version=ServerReqVersion.GREATER_OR_EQUAL)
 public class CreateEAP6xServer extends CreateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap6x/DeleteServerEAP6xServer.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap6x/DeleteServerEAP6xServer.java
@@ -1,12 +1,12 @@
 package org.jboss.ide.eclipse.as.ui.bot.test.eap6x;
 
-import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqOperator;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqVersion;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqState;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeleteServerTemplate;
 
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.EAP, version="6.1", operator=ServerReqOperator.GREATER_OR_EQUAL)
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.EAP6_1plus, version=ServerReqVersion.GREATER_OR_EQUAL)
 public class DeleteServerEAP6xServer extends DeleteServerTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap6x/DeployJSPProjectEAP6xServer.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap6x/DeployJSPProjectEAP6xServer.java
@@ -1,12 +1,12 @@
 package org.jboss.ide.eclipse.as.ui.bot.test.eap6x;
 
-import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqOperator;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqVersion;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqState;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP, version="6.1", operator=ServerReqOperator.GREATER_OR_EQUAL)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP6_1plus, version=ServerReqVersion.GREATER_OR_EQUAL)
 public class DeployJSPProjectEAP6xServer extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap6x/HotDeployJSPFileEAP6xServer.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap6x/HotDeployJSPFileEAP6xServer.java
@@ -1,12 +1,12 @@
 package org.jboss.ide.eclipse.as.ui.bot.test.eap6x;
 
-import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqOperator;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqVersion;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqState;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP, version="6.1", operator=ServerReqOperator.GREATER_OR_EQUAL)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP6_1plus, version=ServerReqVersion.GREATER_OR_EQUAL)
 public class HotDeployJSPFileEAP6xServer extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap6x/OperateEAP6xServer.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap6x/OperateEAP6xServer.java
@@ -1,12 +1,12 @@
 package org.jboss.ide.eclipse.as.ui.bot.test.eap6x;
 
-import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqOperator;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqVersion;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqState;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.OperateServerTemplate;
 
-@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.EAP, version="6.1", operator=ServerReqOperator.GREATER_OR_EQUAL)
+@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.EAP6_1plus, version=ServerReqVersion.GREATER_OR_EQUAL)
 public class OperateEAP6xServer extends OperateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap6x/ServerStateDetectorsEAP6xServer.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap6x/ServerStateDetectorsEAP6xServer.java
@@ -1,12 +1,12 @@
 package org.jboss.ide.eclipse.as.ui.bot.test.eap6x;
 
-import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqOperator;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqVersion;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqState;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.ServerStateDetectorsTemplate;
 
-@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.EAP, version="6.1", operator=ServerReqOperator.GREATER_OR_EQUAL)
+@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.EAP6_1plus, version=ServerReqVersion.GREATER_OR_EQUAL)
 public class ServerStateDetectorsEAP6xServer extends ServerStateDetectorsTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap6x/UndeployJSPProjectEAP6xServer.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap6x/UndeployJSPProjectEAP6xServer.java
@@ -1,13 +1,13 @@
 package org.jboss.ide.eclipse.as.ui.bot.test.eap6x;
 
-import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqOperator;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqVersion;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqState;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.UndeployJSPProjectTemplate;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP, version="6.1", operator=ServerReqOperator.GREATER_OR_EQUAL)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP6_1plus, version=ServerReqVersion.GREATER_OR_EQUAL)
 public class UndeployJSPProjectEAP6xServer extends UndeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly8/CreateWildfly8Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly8/CreateWildfly8Server.java
@@ -3,7 +3,7 @@ package org.jboss.ide.eclipse.as.ui.bot.test.wildfly8;
 
 import java.util.List;
 
-import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqOperator;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqVersion;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqState;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
@@ -17,7 +17,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 
 @CleanWorkspace
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.WILDFLY, version="8.0", operator=ServerReqOperator.GREATER_OR_EQUAL)
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.WILDFLY8_0, version=ServerReqVersion.GREATER_OR_EQUAL)
 public class CreateWildfly8Server extends CreateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly8/DeleteServerWildfly8Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly8/DeleteServerWildfly8Server.java
@@ -1,12 +1,12 @@
 package org.jboss.ide.eclipse.as.ui.bot.test.wildfly8;
 
-import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqOperator;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqVersion;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqState;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeleteServerTemplate;
 
-@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.WILDFLY, version="8.0", operator=ServerReqOperator.GREATER_OR_EQUAL)
+@JBossServer(state=ServerReqState.PRESENT, type=ServerReqType.WILDFLY8_0, version=ServerReqVersion.GREATER_OR_EQUAL)
 public class DeleteServerWildfly8Server extends DeleteServerTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly8/DeployJSPProjectWildfly8Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly8/DeployJSPProjectWildfly8Server.java
@@ -1,12 +1,12 @@
 package org.jboss.ide.eclipse.as.ui.bot.test.wildfly8;
 
-import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqOperator;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqVersion;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqState;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.WILDFLY, version="8.0", operator=ServerReqOperator.GREATER_OR_EQUAL)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.WILDFLY8_0, version=ServerReqVersion.GREATER_OR_EQUAL)
 public class DeployJSPProjectWildfly8Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly8/HotDeployJSPFileWildfly8Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly8/HotDeployJSPFileWildfly8Server.java
@@ -1,12 +1,12 @@
 package org.jboss.ide.eclipse.as.ui.bot.test.wildfly8;
 
-import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqOperator;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqVersion;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqState;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.WILDFLY, version="8.0", operator=ServerReqOperator.GREATER_OR_EQUAL)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.WILDFLY8_0, version=ServerReqVersion.GREATER_OR_EQUAL)
 public class HotDeployJSPFileWildfly8Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly8/OperateWildfly8Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly8/OperateWildfly8Server.java
@@ -1,12 +1,12 @@
 package org.jboss.ide.eclipse.as.ui.bot.test.wildfly8;
 
-import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqOperator;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqVersion;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqState;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.OperateServerTemplate;
 
-@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.WILDFLY, version="8.0", operator=ServerReqOperator.GREATER_OR_EQUAL)
+@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.WILDFLY8_0, version=ServerReqVersion.GREATER_OR_EQUAL)
 public class OperateWildfly8Server extends OperateServerTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly8/ServerStateDetectorsWildfly8Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly8/ServerStateDetectorsWildfly8Server.java
@@ -1,13 +1,13 @@
 package org.jboss.ide.eclipse.as.ui.bot.test.wildfly8;
 
-import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqOperator;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqVersion;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqState;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.ServerStateDetectorsTemplate;
 
 
-@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.WILDFLY, version="8.0", operator=ServerReqOperator.GREATER_OR_EQUAL)
+@JBossServer(state=ServerReqState.STOPPED, type=ServerReqType.WILDFLY8_0, version=ServerReqVersion.GREATER_OR_EQUAL)
 public class ServerStateDetectorsWildfly8Server extends ServerStateDetectorsTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly8/UndeployJSPProjectWildfly8Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly8/UndeployJSPProjectWildfly8Server.java
@@ -1,13 +1,13 @@
 package org.jboss.ide.eclipse.as.ui.bot.test.wildfly8;
 
-import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqOperator;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqVersion;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqState;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
 import org.jboss.ide.eclipse.as.ui.bot.test.template.UndeployJSPProjectTemplate;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.WILDFLY, version="8.0", operator=ServerReqOperator.GREATER_OR_EQUAL)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.WILDFLY8_0, version=ServerReqVersion.GREATER_OR_EQUAL)
 public class UndeployJSPProjectWildfly8Server extends UndeployJSPProjectTemplate {
 
 	@Override


### PR DESCRIPTION
Server family (previously server type) and version was merged to one enum
type - server type. Server type now provides information about server family
and also about server version.

Enumerate is better (content assist, error when we use removed server type)

Renamed ServerReqOperator to ServerReqVersion because the annotation's
attributes has changed and attribute "version" is more explicit than attribute
"operator". For example this @JBossServer(type=EAP5x, version=GREATER) is
explicitly saying that we want EAP with version greater than 5.x.
However this @JBossServer(type=EAP5x, operator=GREATER) is a little bit
confusing for new user of JBoss Server requirements, because he don't know
what is an operator.

Changed parsing server version. Now it distinct major and minor versions.
Parse server version has format MAJOR_VERSION*10+MINOR_VERSION, where
minor version is a single-digit

JBoss Tools Component: Red Deer JBoss server requirements
Author: rrabara
