### PR TITLE
Set -Dusage_reporting_enabled=false for integration tests

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -16,7 +16,7 @@
             <surefire.timeout>7200</surefire.timeout>
             <memoryOptions2>-XX:MaxPermSize=512m</memoryOptions2>
             <swt.bot.test.record.screencast>false</swt.bot.test.record.screencast>
-            <integrationTestsSystemProperties>-Dswt.bot.test.record.screencast=${swt.bot.test.record.screencast} -Dorg.eclipse.swtbot.screenshots.dir=${project.build.directory}/screenshots</integrationTestsSystemProperties>
+            <integrationTestsSystemProperties>-Dswt.bot.test.record.screencast=${swt.bot.test.record.screencast} -Dorg.eclipse.swtbot.screenshots.dir=${project.build.directory}/screenshots -Dusage_reporting_enabled=false -Dcom.atlassian.connector.eclipse.monitor.usage.first.time=false -Dcom.atlassian.connector.eclipse.monitor.usage.enabled=false</integrationTestsSystemProperties>
         </properties>
 
 	<modules>


### PR DESCRIPTION
This property should disable both subclipse and jbt usage reporting dialogs at
startup.
