### PR TITLE
JBQA-6186 Added CXF 2.x Web Service Client test

### DIFF
--- a/plugins/org.jboss.tools.ws.reddeer/src/org/jboss/tools/ws/reddeer/ws/ui/WsCxf2xPreferencePage.java
+++ b/plugins/org.jboss.tools.ws.reddeer/src/org/jboss/tools/ws/reddeer/ws/ui/WsCxf2xPreferencePage.java
@@ -1,0 +1,58 @@
+package org.jboss.tools.ws.reddeer.ws.ui;
+
+import org.jboss.reddeer.eclipse.jface.preference.PreferencePage;
+import org.jboss.reddeer.swt.api.Table;
+import org.jboss.reddeer.swt.api.TableItem;
+import org.jboss.reddeer.swt.impl.button.PushButton;
+import org.jboss.reddeer.swt.impl.table.DefaultTable;
+import org.jboss.reddeer.swt.impl.text.DefaultText;
+
+/**
+ * 
+ * @author Radoslav Rabara
+ *
+ */
+public class WsCxf2xPreferencePage extends PreferencePage {
+	
+	public WsCxf2xPreferencePage() {
+		super("Web Services", "CXF 2.x Preferences");
+	}
+	
+	/**
+	 * Added CXF is not selected by default...
+	 * @param cxfHome
+	 */
+	public void add(String cxfHome) {
+		new PushButton("Add...").click();
+		new DefaultText(0).setText(cxfHome);
+		new PushButton("Finish").click();
+	}
+	
+	public void remove() {
+		new PushButton("Remove").click();
+	}
+	
+	public void remove(String cxfHome) {
+		Table table = new DefaultTable();
+		for(int i=0;i<table.rowCount();i++) {
+			TableItem item = table.getItem(i);
+			if(item.getText(1).equals(cxfHome)) {
+				table.select(i);
+				remove();
+				return;
+			}
+		}
+		throw new IllegalArgumentException("Row with given CXF Home was not found in CXF 2.x Preference Page");
+	}
+	
+	public void select(String cxfHome) {
+		Table table = new DefaultTable();
+		for(TableItem item : table.getItems()) {
+			if(item.getText(1).equals(cxfHome)) {
+				item.setChecked(true);
+				return;
+			}
+		}
+		throw new IllegalArgumentException("Row with given CXF Home was not found in CXF 2.x Preference Page");
+	}
+}

--- a/tests/org.jboss.tools.ws.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.ws.ui.bot.test/META-INF/MANIFEST.MF
@@ -25,7 +25,9 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.tools.ws.ui;bundle-version="1.1.0",
  org.eclipse.wst.common.project.facet.core,
  org.hamcrest.core;bundle-version="1.3.0",
- org.eclipse.jst.ws.jaxws.ui
+ org.eclipse.jst.ws.jaxws.ui,
+ org.eclipse.jst.ws.cxf.ui;bundle-version="1.0.200",
+ org.jboss.reddeer.uiforms;bundle-version="0.5.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Eclipse-RegisterBuddy: org.apache.log4j

--- a/tests/org.jboss.tools.ws.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.ws.ui.bot.test/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.jboss.tools.ws.ui.bot.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
+		<apache-cxf-2.x>${project.build.directory}/requirements/apache-cxf-2.x/apache-cxf-2.4.6/</apache-cxf-2.x>
+		<apache-cxf-2.x.url>http://archive.apache.org/dist/cxf/2.4.6/apache-cxf-2.4.6.zip</apache-cxf-2.x.url>
+		<apache-cxf-2.x.md5>ebaab4357812b22c17eadb30b563c7b8</apache-cxf-2.x.md5>
+
 		<systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.properties.file=${project.basedir}/properties/swtbot.properties</systemProperties>
 		<surefire.timeout>10800</surefire.timeout>
 	</properties>
@@ -41,6 +45,26 @@
 									<type>zip</type>
 								</artifactItem>
 							</artifactItems>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.googlecode.maven-download-plugin</groupId>
+				<artifactId>maven-download-plugin</artifactId>
+				<version>1.0.0</version>
+				<executions>
+					<execution>
+						<id>install-apache-cxf-2.x</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>wget</goal>
+						</goals>
+						<configuration>
+							<url>${apache-cxf-2.x.url}</url>
+							<unpack>true</unpack>
+							<md5>${apache-cxf-2.x.md5}</md5>
+							<outputDirectory>${apache-cxf-2.x}</outputDirectory>
 						</configuration>
 					</execution>
 				</executions>
@@ -77,6 +101,31 @@
 						</dependency>
 					</dependencies>
 				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>2.5</version>
+				<executions>
+					<execution>
+						<id>copy-resources</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>resources</outputDirectory>
+							<resources>
+								<resource>
+									<directory>resources/properties/template</directory>
+									<filtering>true</filtering>
+									<includes>
+										<include>ws.properties</include>
+									</includes>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/WSAllBotTests.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/WSAllBotTests.java
@@ -13,6 +13,7 @@ package org.jboss.tools.ws.ui.bot.test;
 import org.jboss.tools.ui.bot.ext.RequirementAwareSuite;
 import org.jboss.tools.ws.ui.bot.test.annotation.AnnotationPropertiesTest;
 import org.jboss.tools.ws.ui.bot.test.annotation.HTTPMethodAnnotationQuickFixTest;
+import org.jboss.tools.ws.ui.bot.test.cxf.CxfWsClientTest;
 import org.jboss.tools.ws.ui.bot.test.facet.JAXRSFacetTest;
 import org.jboss.tools.ws.ui.bot.test.integration.JAXRSToolingIntegrationTest;
 import org.jboss.tools.ws.ui.bot.test.integration.SOAPWSToolingIntegrationTest;
@@ -45,6 +46,7 @@ import org.junit.runners.Suite.SuiteClasses;
  * 
  * @author Lukas Jungmann
  * @author jjankovi
+ * @author Radoslav Rabara
  */
 @RunWith(RequirementAwareSuite.class)
 @SuiteClasses({
@@ -74,7 +76,8 @@ import org.junit.runners.Suite.SuiteClasses;
 	WsClientTest.class,
 	WsTesterTest.class,
 	EAPFromJavaTest.class,
-	EAPFromWSDLTest.class
+	EAPFromWSDLTest.class,
+	CxfWsClientTest.class
 	})
 public class WSAllBotTests extends AbstractTestSuite {
 	

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/cxf/CxfWsClientTest.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/cxf/CxfWsClientTest.java
@@ -1,0 +1,66 @@
+package org.jboss.tools.ws.ui.bot.test.cxf;
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Properties;
+
+import org.jboss.tools.ui.bot.ext.SWTUtilExt;
+import org.jboss.tools.ws.reddeer.ws.ui.WsCxf2xPreferencePage;
+import org.jboss.tools.ws.ui.bot.test.Activator;
+import org.jboss.tools.ws.ui.bot.test.webservice.WebServiceRuntime;
+import org.jboss.tools.ws.ui.bot.test.wsclient.WSClientTestTemplate;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Test Web Service Client with Web Service Runtime
+ * 
+ * @author Radoslav Rabara
+ * 
+ */
+public class CxfWsClientTest extends WSClientTestTemplate {
+	private static final String CXF_HOME_LOCATION;
+	static {
+		try {
+			Properties properties = new Properties();
+			properties.load(new FileReader(SWTUtilExt.getResourceFile(
+					Activator.PLUGIN_ID, "/properties/ws.properties")));
+			
+			CXF_HOME_LOCATION = properties.getProperty("apache-cxf-2.x");
+		} catch (FileNotFoundException e) {
+			throw new RuntimeException(e);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+	
+	public CxfWsClientTest() {
+		super(WebServiceRuntime.APACHE_CXF2);
+	}
+
+	@Override
+	protected String getSampleClientFileName() {
+		return "InfoSoapType_InfoSoap_Client.java";	
+	}
+	
+	@BeforeClass
+	public static void setupCxfRuntime() {
+		WsCxf2xPreferencePage cxfPreferencePage = new WsCxf2xPreferencePage();
+		cxfPreferencePage.open();
+		cxfPreferencePage.add(CXF_HOME_LOCATION);
+		cxfPreferencePage.select(CXF_HOME_LOCATION);
+		cxfPreferencePage.ok();
+	}
+	
+	@AfterClass
+	public static void removeCxfRuntime() {
+		WsCxf2xPreferencePage cxfPreferencePage = new WsCxf2xPreferencePage();
+		cxfPreferencePage.open();
+		cxfPreferencePage.remove(CXF_HOME_LOCATION);
+	}
+	
+	/*
+	 * All tests are inherited from WSClientTestTemplate
+	 */
+}

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/uiutils/wizards/WebServiceClientWizard.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/uiutils/wizards/WebServiceClientWizard.java
@@ -10,26 +10,18 @@
  ******************************************************************************/
 package org.jboss.tools.ws.ui.bot.test.uiutils.wizards;
 
-import org.eclipse.swt.widgets.Shell;
-
 public class WebServiceClientWizard extends WsWizardBase {
 
-	public WebServiceClientWizard() {
-		super();
-	}
-	
-	public WebServiceClientWizard(Shell shell) {
-		super(shell);
-	}
-	
 	@Override
-	protected String getSourceComboLabel() {
+	public String getSourceComboLabel() {
 		return "Service definition:";
 	}
 
-	public WebServiceClientWizard setClientProject(String name) {
-		setTargetProject("Client project:", name, "Specify Client Project Settings");
-		return this;
+	public void setClientProject(String name) {
+		setTargetProject("Client project:", name);//, "Specify Client Project Settings"
 	}
-
+	
+	public void setClientEARProject(String name) {
+		setTargetProject("Client EAR project:", name);
+	}
 }

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/uiutils/wizards/WebServiceWizard.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/uiutils/wizards/WebServiceWizard.java
@@ -32,19 +32,10 @@ public class WebServiceWizard extends WsWizardBase {
 			return prefix + " Java bean Web Service";
 		}
 	}
-	
-	public WebServiceWizard() {
-		super();
-	}
-	
-	public WebServiceWizard(Shell shell) {
-		super(shell);
-	}
 
-	public WebServiceWizard setServiceType(Service_Type type) {
+	public void setServiceType(Service_Type type) {
     	setFocus();
 		bot().comboBoxWithLabel("Web service type:").setSelection(type.getDescription());
-		return this;
 	}
 	
 	public Service_Type getServiceType() {
@@ -69,34 +60,26 @@ public class WebServiceWizard extends WsWizardBase {
 		return s;
 	}
 	
-	public WebServiceWizard setServiceProject(String name) {
+	public void setServiceProject(String name) {
 		setTargetProject("Service project:", name);
-		return this;
-	}
-
-	public WebServiceWizard setServiceEARProject(String name) {
-		setTargetProject("Service EAR project:", name);
-		return this;
 	}
 	
-	public WebServiceWizard setServiceSlider(Slider_Level level) {
+	public void setServiceEARProject(String name) {
+		setTargetProject("Service EAR project:", name);
+	}
+	
+	public void setServiceSlider(Slider_Level level) {
 		if (Slider_Level.NO_CLIENT == level) {
 			throw new UnsupportedOperationException("Unsupported level: " + level);
 		}
 		setSlider(level, 0);
-		return this;
 	}
 	
-	public WebServiceWizard setClientSlider(Slider_Level level) {
+	public void setClientSlider(Slider_Level level) {
 		setSlider(level, 1);
-		return this;
 	}
 	
 	public boolean isClientEnabled() {
 		return isScaleEnabled(1);
-	}
-	
-	private void setTargetProject(String label, String name) {
-		setTargetProject(label, name, "Specify Service Project Settings");
 	}
 }

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/utils/WebServiceClientHelper.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/utils/WebServiceClientHelper.java
@@ -1,14 +1,30 @@
 package org.jboss.tools.ws.ui.bot.test.utils;
 
-import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
+import org.apache.log4j.Logger;
+import org.apache.log4j.Priority;
+import org.eclipse.swt.SWTException;
+import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
+import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
+import org.jboss.reddeer.eclipse.wst.server.ui.view.Server;
+import org.jboss.reddeer.eclipse.wst.server.ui.view.ServersView;
+import org.jboss.reddeer.swt.api.Label;
+import org.jboss.reddeer.swt.api.Shell;
+import org.jboss.reddeer.swt.impl.button.PushButton;
+import org.jboss.reddeer.swt.impl.label.DefaultLabel;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
+import org.jboss.reddeer.swt.impl.toolbar.DefaultToolItem;
 import org.jboss.tools.ui.bot.ext.SWTTestExt;
 import org.jboss.tools.ws.ui.bot.test.uiutils.actions.NewFileWizardAction;
 import org.jboss.tools.ws.ui.bot.test.uiutils.wizards.WebServiceClientWizard;
+import org.jboss.tools.ws.ui.bot.test.uiutils.wizards.Wizard;
 import org.jboss.tools.ws.ui.bot.test.uiutils.wizards.WsWizardBase.Slider_Level;
+import org.jboss.tools.ws.ui.bot.test.webservice.WebServiceRuntime;
 import org.junit.Assert;
 
 public class WebServiceClientHelper extends SWTTestExt {
 
+	private static final Logger log = Logger.getLogger(WebServiceClientHelper.class.getName());
+	
 	/**
 	 * Method creates Web Service Client for entered wsdl file, web project,
 	 * level of creation and name of package for client
@@ -17,8 +33,11 @@ public class WebServiceClientHelper extends SWTTestExt {
 	 * @param level
 	 * @param pkg
 	 */
-	public void createClient(String wsdl, String targetProject,
-			Slider_Level level, String pkg) {
+	public void createClient(String wsdl, WebServiceRuntime runtime, String targetProject,
+			String earProject, Slider_Level level, String pkg) {
+		
+		final String SERVER_NAME = configuredState.getServer().name;
+		
 		new NewFileWizardAction().run()
 				.selectTemplate("Web Services", "Web Service Client").next();
 		WebServiceClientWizard w = new WebServiceClientWizard();
@@ -26,10 +45,11 @@ public class WebServiceClientHelper extends SWTTestExt {
 		util.waitForNonIgnoredJobs();
 		bot.sleep(1000);
 		w.setSlider(level, 0);
-		w.setServerRuntime(configuredState.getServer().name);
-		w.setWebServiceRuntime("JBossWS");
+		w.setServerRuntime(SERVER_NAME);
+		w.setWebServiceRuntime(runtime.getName());
 		w.setClientProject(targetProject);
-		if (pkg != null && !"".equals(pkg.trim())) {
+		w.setClientEARProject(earProject);
+		if (pkg != null && pkg.trim().length()>0) {
 			w.next();
 			w.setPackageName(pkg);
 		}
@@ -37,16 +57,85 @@ public class WebServiceClientHelper extends SWTTestExt {
 		util.waitForNonIgnoredJobs();
 		bot.sleep(1000);
 
-		// let's fail if there's some error in the wizard,
-		// and close error dialog and the wizard so other tests
-		// can continue
-		if (bot.activeShell().getText().contains("Error")) {
-			SWTBotShell sh = bot.activeShell();
-			String msg = sh.bot().text().getText();
-			sh.bot().button(0).click();
-			w.cancel();
-			Assert.fail(msg);
+		checkErrorDialog(w);
+		
+		//check if there is any error in console output
+		checkErrorInConsoleOutput(SERVER_NAME, earProject);
+	}
+	
+	/**
+	 * let's fail if there's some error in the wizard,
+	 * and close error dialog and the wizard so other tests
+	 * can continue
+	 * 
+	 * @param wsWizard if error dialog appeared the parent wizard will be closed
+	 */
+	private void checkErrorDialog(Wizard wsWizard) {
+		Shell shell = new DefaultShell();
+		String text = shell.getText();
+		if (text.contains("Error")) {
+			new PushButton(0).click();
+			wsWizard.cancel();
+			Assert.fail(text);
 		}
 	}
 	
+	private void checkErrorInConsoleOutput(String serverName, String projectName) {
+		ConsoleView consoleView = new ConsoleView();
+		consoleView.open();
+		selectServerConsole(serverName);
+		String consoleText = consoleView.getConsoleText();
+		if (consoleText.contains("ERROR")) {
+			consoleView.clearConsole();
+			String deploymentInfoMessage = " [deployment status: ";
+			try {
+				if(projectIsDeployed(serverName, projectName)) {
+					deploymentInfoMessage += "deployed";
+				} else {
+					deploymentInfoMessage += "NOT DEPLOYED";
+				}
+				deploymentInfoMessage += "]";
+			} catch(SWTException e) {
+				deploymentInfoMessage = ""; //there is no information about deployment status
+			}
+			
+			fail("Console contains error"
+					+ deploymentInfoMessage
+					+ "\n" + consoleText);
+		}
+	}
+	
+	private void selectServerConsole(String serverName) {
+		Label consoleName = new DefaultLabel();
+		if (!consoleName.getText().startsWith(serverName)) {
+			new DefaultToolItem("Display Selected Console").click();
+			consoleName = new DefaultLabel();
+			if (!consoleName.getText().startsWith(serverName)) {
+				fail("Console of configured server was not found.");
+			}
+		}
+	}
+	
+	/**
+	 * TODO: SWTException is thrown by {@link Server#getModule(String)} because
+	 * it doesn't work properly. Remove throws clause when it will be fixed.
+	 * 
+	 * @param serverName
+	 * @param projectName
+	 * @return
+	 * @throws SWTException
+	 */
+	public boolean projectIsDeployed(String serverName, String projectName) throws SWTException {
+		try {
+			ServersView sw = new ServersView();
+			sw.getServer(serverName).getModule(projectName);
+			return true;
+		} catch(EclipseLayerException e) {
+			return false;
+		} catch(SWTException e) {
+			log.log(Priority.ERROR, "Server#getModule(String) is still not fixed! "
+					+ "Can't verify if the specified module '" + projectName + "' is deployed.");
+			throw e;
+		}
+	}
 }

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/webservice/TopDownWSTest.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/webservice/TopDownWSTest.java
@@ -172,7 +172,9 @@ public class TopDownWSTest extends WebServiceTestBase {
 	}
 	
 	protected void topDownWS(String pkg) {
-		topDownWS(TopDownWSTest.class.getResourceAsStream("/resources/jbossws/ClassB.wsdl"), pkg);
+		topDownWS(
+				TopDownWSTest.class.getResourceAsStream("/resources/jbossws/ClassB.wsdl"),
+				WebServiceRuntime.JBOSS_WS, pkg);
 		switch (getLevel()) {
 		case DEVELOP:
 		case ASSEMBLE:

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/webservice/WebServiceRuntime.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/webservice/WebServiceRuntime.java
@@ -1,0 +1,23 @@
+package org.jboss.tools.ws.ui.bot.test.webservice;
+
+/**
+ * Web Service Runtime
+ * Supported are JBossWS and ApacheCXF2.x
+ * 
+ * @author rrabara
+ * 
+ */
+public enum WebServiceRuntime {
+	JBOSS_WS	("JBossWS"),
+	APACHE_CXF2	("Apache CXF 2.x");
+	
+	private final String name;
+	
+	private WebServiceRuntime(String wsRuntimeName) {
+		this.name = wsRuntimeName;
+	}
+	
+	public String getName() {
+		return name;
+	}
+}

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/webservice/WebServiceTestBase.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/webservice/WebServiceTestBase.java
@@ -52,7 +52,7 @@ public class WebServiceTestBase extends WSTestBase {
 	 * @param input
 	 * @param pkg
 	 */
-	protected void topDownWS(InputStream input, String pkg) {
+	protected void topDownWS(InputStream input, WebServiceRuntime serviceRuntime, String pkg) {
 		String s = resourceHelper.readStream(input);
 		String[] tns = getWsPackage().split("\\.");
 		StringBuilder sb = new StringBuilder();
@@ -109,7 +109,7 @@ public class WebServiceTestBase extends WSTestBase {
 		wsw.setServiceType(t);
 		wsw.setSource(source);
 		wsw.setServerRuntime(configuredState.getServer().name);
-		wsw.setWebServiceRuntime("JBossWS");
+		wsw.setWebServiceRuntime("JBossWS");//TODO: cxf
 		wsw.setServiceProject(getWsProjectName());
 		wsw.setServiceEARProject(getEarProjectName());
 		wsw.setServiceSlider(level);

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/webservice/eap/EAPFromJavaTest.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/webservice/eap/EAPFromJavaTest.java
@@ -26,6 +26,7 @@ import org.jboss.tools.ws.ui.bot.test.WSAllBotTests;
 import org.jboss.tools.ws.ui.bot.test.uiutils.actions.NewFileWizardAction;
 import org.jboss.tools.ws.ui.bot.test.uiutils.wizards.Wizard;
 import org.jboss.tools.ws.ui.bot.test.uiutils.wizards.WsWizardBase.Slider_Level;
+import org.jboss.tools.ws.ui.bot.test.webservice.WebServiceRuntime;
 import org.jboss.tools.ws.ui.bot.test.webservice.WebServiceTestBase;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -132,8 +133,8 @@ public class EAPFromJavaTest extends WebServiceTestBase {
 
     private void testClient() {
         Assert.assertTrue("service must exist", servicePassed);
-        clientHelper.createClient(deploymentHelper.getWSDLUrl(getWsProjectName(), getWsName()), 
-        			getWsClientProjectName(), getLevel(), "");
+        clientHelper.createClient(deploymentHelper.getWSDLUrl(getWsProjectName(), getWsName()),
+        		WebServiceRuntime.JBOSS_WS, getWsClientProjectName(), getEarProjectName(), getLevel(), "");
         IProject p = ResourcesPlugin.getWorkspace().getRoot().getProject(getWsClientProjectName());
         String pkg = "test/ws";
         String cls = "src/" + pkg + "/EchoService.java";

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/webservice/eap/EAPFromWSDLTest.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/webservice/eap/EAPFromWSDLTest.java
@@ -27,6 +27,8 @@ import org.eclipse.swtbot.swt.finder.results.Result;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.jboss.reddeer.eclipse.condition.ConsoleHasText;
+import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
 import org.jboss.reddeer.swt.condition.WaitCondition;
 import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitUntil;
@@ -39,6 +41,7 @@ import org.jboss.tools.ws.reddeer.swt.condition.ConsoleContainsText;
 import org.jboss.tools.ws.ui.bot.test.WSAllBotTests;
 import org.jboss.tools.ws.ui.bot.test.uiutils.wizards.WsWizardBase.Slider_Level;
 import org.jboss.tools.ws.ui.bot.test.webservice.TopDownWSTest;
+import org.jboss.tools.ws.ui.bot.test.webservice.WebServiceRuntime;
 import org.jboss.tools.ws.ui.bot.test.webservice.WebServiceTestBase;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -128,7 +131,7 @@ public class EAPFromWSDLTest extends WebServiceTestBase {
 	
 	private void testService() {
 		topDownWS(TopDownWSTest.class.getResourceAsStream("/resources/jbossws/AreaService.wsdl"),
-				getWsPackage());
+				WebServiceRuntime.JBOSS_WS, getWsPackage());
 
 		IProject project = ResourcesPlugin.getWorkspace().getRoot()
 				.getProject(getWsProjectName());
@@ -167,8 +170,9 @@ public class EAPFromWSDLTest extends WebServiceTestBase {
 
 	private void testClient() {
 		Assert.assertTrue("service must exist", servicePassed);
-		clientHelper.createClient(deploymentHelper.getWSDLUrl(getWsProjectName(), getWsName()), 
-				getWsClientProjectName(), Slider_Level.DEVELOP, getWsClientPackage());
+		clientHelper.createClient(deploymentHelper.getWSDLUrl(getWsProjectName(), getWsName()),
+				WebServiceRuntime.JBOSS_WS, getWsClientProjectName(), getEarProjectName(), 
+				Slider_Level.DEVELOP, getWsClientPackage());
 		IProject p = ResourcesPlugin.getWorkspace().getRoot()
 				.getProject(getWsClientProjectName());
 		String pkg = "org/jboss/wsclient";
@@ -196,13 +200,13 @@ public class EAPFromWSDLTest extends WebServiceTestBase {
 		util.waitForNonIgnoredJobs();
 		
 		// wait until the client ends (prints the last line)
-		ConsoleContainsText wait = new ConsoleContainsText("Call Over!", console);
-		new WaitUntil(wait, TimePeriod.NORMAL);
+		new WaitUntil(new ConsoleHasText("Call Over!"), TimePeriod.NORMAL);
 
-		String output = wait.getConsoleText();
-		LOGGER.info(output);
-		Assert.assertTrue(output, output.contains("Server said: 37.5"));
-		Assert.assertTrue(output.contains("Server said: 3512.3699"));
+		ConsoleView cw = new ConsoleView();
+		String consoleOutput = cw.getConsoleText();
+		LOGGER.info(consoleOutput);
+		Assert.assertTrue(consoleOutput, consoleOutput.contains("Server said: 37.5"));
+		Assert.assertTrue(consoleOutput.contains("Server said: 3512.3699"));
 	}
 	
 	private void replaceContent(IFile f, String content) {

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/wsclient/WSClientTestTemplate.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/wsclient/WSClientTestTemplate.java
@@ -1,0 +1,165 @@
+/*******************************************************************************
+ * Copyright (c) 2011 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.ws.ui.bot.test.wsclient;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.swt.SWTException;
+import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
+import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
+import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.Project;
+import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.ProjectItem;
+import org.jboss.reddeer.eclipse.wst.server.ui.view.Server;
+import org.jboss.reddeer.eclipse.wst.server.ui.view.ServerModule;
+import org.jboss.reddeer.eclipse.wst.server.ui.view.ServersView;
+import org.jboss.tools.ws.ui.bot.test.WSTestBase;
+import org.jboss.tools.ws.ui.bot.test.uiutils.wizards.WsWizardBase.Slider_Level;
+import org.jboss.tools.ws.ui.bot.test.webservice.WebServiceRuntime;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test template operates on Web Service Client Wizard
+ * 
+ * @author jlukas
+ * @author Radoslav Rabara
+ */
+public class WSClientTestTemplate extends WSTestBase {
+	
+	protected final WebServiceRuntime serviceRuntime;
+	
+	public WSClientTestTemplate(WebServiceRuntime serviceRuntime) {
+		this.serviceRuntime = serviceRuntime;
+	}
+
+	@Override
+	protected String getWsProjectName() {
+		return "client";
+	}
+
+	@Override
+	protected String getWsPackage() {
+		return "client." + getLevel().toString().toLowerCase();
+	}
+
+	@Override
+	protected String getEarProjectName() {
+		return "clientEAR";
+	}
+	
+	protected String getSampleClientFileName() {
+		return "clientsample/ClientSample.java";
+	}
+	
+	/**
+	 * Fails because the created client is not deployed to the server
+	 * 
+	 * @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=428982
+	 */
+	@Test
+	public void testDeployClient() {
+		setLevel(Slider_Level.DEPLOY);
+		clientTest(getWsPackage());
+	}
+
+	@Test
+	public void testAssembleClient() {
+		setLevel(Slider_Level.ASSEMBLE);
+		clientTest(getWsPackage());
+	}
+
+	@Test
+	public void testDevelopClient() {
+		setLevel(Slider_Level.DEVELOP);
+		clientTest(getWsPackage());
+	}
+
+	@Test
+	public void testInstallClient() {
+		setLevel(Slider_Level.INSTALL);
+		clientTest(getWsPackage());
+	}
+
+	@Test
+	public void testStartClient() {
+		setLevel(Slider_Level.START);
+		clientTest(getWsPackage());
+	}
+
+	@Test
+	public void testTestClient() {
+		setLevel(Slider_Level.TEST);
+		clientTest(getWsPackage());
+	}
+
+	@Test
+	public void testDefaultPkg() {
+		setLevel(Slider_Level.ASSEMBLE);
+		clientTest(null);
+	}
+
+	@After
+	public void cleanup() {
+		super.cleanup();
+		//XXX remove all packages ??
+		PackageExplorer pe = new PackageExplorer();
+		pe.open();
+		Project p = pe.getProject(getWsProjectName());
+		ProjectItem src = p.getProjectItem("src");
+		for(ProjectItem pkg: src.getChildren()) {
+			System.err.println(pkg.getText());
+			pkg.delete();
+		}
+	}
+	
+	protected void clientTest(String targetPkg) {
+		clientHelper.createClient(
+				"http://footballpool.dataaccess.eu/data/info.wso?WSDL",
+				serviceRuntime,
+				getWsProjectName(),
+				getEarProjectName(),
+				getLevel(),
+				targetPkg);
+		
+		assertThatExpectedFilesExists(targetPkg);
+		
+		assertThatEARProjectIsDeployed();
+	}
+	
+	private void assertThatExpectedFilesExists(String targetPkg) {
+		IProject p = ResourcesPlugin.getWorkspace().getRoot().getProject(getWsProjectName());
+		String pkg = (targetPkg != null && !"".equals(targetPkg.trim())) ? getWsPackage() : "eu.dataaccess.footballpool";
+		String pkgPath = pkg.replace('.', '/');
+		String[] expectedFiles = {
+				"src/" + pkgPath + "/Info.java",
+				"src/" + pkgPath + "/"+getSampleClientFileName()};
+		for(String file : expectedFiles) {
+			Assert.assertTrue("File " + file + " was not created", p.getFile(file).exists());
+		}
+	}
+	
+	private void assertThatEARProjectIsDeployed() {
+		switch (getLevel()) {
+		case TEST:
+		case START:
+		case INSTALL:
+		case DEPLOY:
+			try{
+				if(!clientHelper.projectIsDeployed(configuredState.getServer().name, getEarProjectName())) {
+					fail("Project was not found on the server.");
+				}
+			} catch(SWTException e) {
+				
+			}
+		}
+	}
+}

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/wsclient/WsClientTest.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/wsclient/WsClientTest.java
@@ -10,79 +10,16 @@
  ******************************************************************************/
 package org.jboss.tools.ws.ui.bot.test.wsclient;
 
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.ResourcesPlugin;
-import org.jboss.tools.ws.ui.bot.test.WSTestBase;
-import org.jboss.tools.ws.ui.bot.test.uiutils.wizards.WsWizardBase.Slider_Level;
-import org.junit.Assert;
-import org.junit.Test;
+import org.jboss.tools.ws.ui.bot.test.webservice.WebServiceRuntime;
 
 /**
  * Test operates on Web Service Client Wizard
  * @author jlukas
  *
  */
-public class WsClientTest extends WSTestBase {
+public class WsClientTest extends WSClientTestTemplate {
 
-	@Override
-	protected String getWsProjectName() {
-		return "client";
-	}
-
-	@Override
-	protected String getWsPackage() {
-		return "client." + getLevel().toString().toLowerCase();
-	}
-
-	@Test
-	public void testDeployClient() {
-		setLevel(Slider_Level.DEPLOY);
-		clientTest(getWsPackage());
-	}
-	
-	@Test
-	public void testAssembleClient() {
-		setLevel(Slider_Level.ASSEMBLE);
-		clientTest(getWsPackage());
-	}
-	
-	@Test
-	public void testDevelopClient() {
-		setLevel(Slider_Level.DEVELOP);
-		clientTest(getWsPackage());
-	}
-	
-	@Test
-	public void testInstallClient() {
-		setLevel(Slider_Level.INSTALL);
-		clientTest(getWsPackage());
-	}
-	
-	@Test
-	public void testStartClient() {
-		setLevel(Slider_Level.START);
-		clientTest(getWsPackage());
-	}
-	
-	@Test
-	public void testTestClient() {
-		setLevel(Slider_Level.TEST);
-		clientTest(getWsPackage());
-	}
-	
-	@Test
-	public void testDefaultPkg() {
-		setLevel(Slider_Level.ASSEMBLE);
-		clientTest(null);
-	}
-
-	private void clientTest(String targetPkg) {
-		clientHelper.createClient("http://footballpool.dataaccess.eu/data/info.wso?WSDL", getWsProjectName(), getLevel(), targetPkg);
-		IProject p = ResourcesPlugin.getWorkspace().getRoot().getProject(getWsProjectName());
-		String pkg = (targetPkg != null && !"".equals(targetPkg.trim())) ? getWsPackage() : "eu.dataaccess.footballpool";
-		String cls = "src/" + pkg.replace('.', '/') + "/Info.java";
-		Assert.assertTrue(p.getFile(cls).exists());
-		cls = "src/" + pkg.replace('.', '/') + "/clientsample/ClientSample.java";
-		Assert.assertTrue(p.getFile(cls).exists());
+	public WsClientTest() {
+		super(WebServiceRuntime.JBOSS_WS);
 	}
 }


### PR DESCRIPTION
CXF 2.x is Web Service Runtime so there is a new class WebServiceRuntime
which is used to distinguist between CXF 2.x and JBoss WS runtime.
It's downloaded via maven download plugin and path to it is stored into
properties file ws.properties.

Tests for WsClient was extracted to WsClientTestTemplate which
covers testing. It's a super class for CxfWsClientTest and
WsClientTest, which specify the WebServiceRuntime.

Adding choice of Web Service Runtime, which is used to create dynamic web
project, brings problems with different dialogs layout and also need of having
more informations (like name of ear project).

There is also huge refactoring. This was also opportunity to reimplement
methods and implement new ones using Red Deer API.

JBoss Tools Component: webservices
Author: rrabara
