### PR TITLE
Fixed JBoss Server requirements with processing a New Adapter Page

### DIFF
--- a/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerRequirement.java
+++ b/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerRequirement.java
@@ -5,11 +5,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.jboss.ide.eclipse.as.reddeer.server.family.FamilyWildFly;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerFamily;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.ide.eclipse.as.reddeer.server.wizard.NewServerWizardDialog;
 import org.jboss.ide.eclipse.as.reddeer.server.wizard.page.JBossRuntimeWizardPage;
+import org.jboss.ide.eclipse.as.reddeer.server.wizard.page.NewServerAdapterPage;
 import org.jboss.ide.eclipse.as.reddeer.server.wizard.page.NewServerWizardPageWithErrorCheck;
 import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
 import org.jboss.reddeer.eclipse.wst.server.ui.view.ServersView;
@@ -55,12 +54,12 @@ public class ServerRequirement implements Requirement<JBossServer>, CustomConfig
 	public void fulfill() {
 		if(lastServerConfiguration != null) {
 			boolean differentConfig = !config.equals(lastServerConfiguration.getConfig());
-			if(differentConfig) {
+			if (differentConfig) {
 				removeLastRequiredServer();
 				lastServerConfiguration = null;
 			}
 		}
-		if(lastServerConfiguration == null || !isLastConfiguredServerPresent()) {
+		if (lastServerConfiguration == null || !isLastConfiguredServerPresent()) {
 			LOGGER.info("Setup server");
 			setupServerAdapter();
 			lastServerConfiguration = new ConfiguredServerInfo(getServerNameLabelText(), config);
@@ -171,8 +170,12 @@ public class ServerRequirement implements Requirement<JBossServer>, CustomConfig
 			
 			serverW.next();
 			
-			JBossRuntimeWizardPage rp = new JBossRuntimeWizardPage();
+			NewServerAdapterPage ap = new NewServerAdapterPage();
+			ap.checkErrors();
 			
+			serverW.next();
+			
+			JBossRuntimeWizardPage rp = new JBossRuntimeWizardPage();
 			rp.setRuntimeName(getRuntimeNameLabelText());
 			rp.setRuntimeDir(config.getRuntime());
 			

--- a/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/wizard/page/NewServerAdapterPage.java
+++ b/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/wizard/page/NewServerAdapterPage.java
@@ -1,0 +1,108 @@
+package org.jboss.ide.eclipse.as.reddeer.server.wizard.page;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.jboss.reddeer.eclipse.jface.wizard.WizardPage;
+import org.jboss.reddeer.swt.api.Combo;
+import org.jboss.reddeer.swt.impl.button.CheckBox;
+import org.jboss.reddeer.swt.impl.combo.DefaultCombo;
+/**
+ * Create a New Server Adapter wizard page<br/>
+ * 
+ * Represents JBoss Runtime page displayed when adding JBoss Runtime via New Server dialog.<br/>
+ * 
+ * It's the next page displayed after invoking next page from New Server page,
+ * when any JBoss Runtime had been selected.<br/><br/>
+ * 
+ * @author Radoslav Rabara
+ * @since JBoss Tools 4.2.0.Beta1
+ */
+public class NewServerAdapterPage extends WizardPage {
+	
+	public void setProfile(Profile profile) {
+		getProfileCombo().setText(profile.getLabel());
+	}
+	
+	public Profile getProfile() {
+		String profileLabel = getProfileCombo().getText();
+		for(Profile profile : Profile.values()) {
+			if(profile.getLabel().equals(profileLabel)) {
+				return profile;
+			}
+		}
+		throw new AssertionError("Unrecognized profile: " + profileLabel);
+	}
+	
+	private Combo getProfileCombo() {
+		return new DefaultCombo(0);
+	}
+	
+	public void setAssignRuntime(boolean assign) {
+		CheckBox check = new CheckBox();
+		if(check.isChecked() != assign) {
+			check.click();
+		}
+	}
+	
+	private static final String NEW_RUNTIME_LABEL = "New...";
+	
+	public List<String> getRuntimes() {
+		List<String> items = new LinkedList<String>(getRuntimeCombo().getItems());
+		items.remove(NEW_RUNTIME_LABEL);
+		return items;
+	}	
+	
+	/**
+	 * Sets the specified <var>runtime</var> as runtime required
+	 * by the selected profile.
+	 * 
+	 * If <code>null</code> is given than a new runtime will be used.
+	 */
+	public void setRuntime(String runtime) {
+		Combo combo = getRuntimeCombo();
+		if(runtime == null) {
+			combo.setText(NEW_RUNTIME_LABEL);
+		} else {
+			combo.setText(runtime);
+		}
+	}
+	
+	public String getRuntime() {
+		String runtime = getRuntimeCombo().getSelection();
+		if(runtime.equals(NEW_RUNTIME_LABEL)) {
+			return null;
+		}
+		return runtime;
+	}
+	
+	private Combo getRuntimeCombo() {
+		return new DefaultCombo(1);
+	}
+	
+	public enum Profile {
+		LOCAL("Local"), REMOTE("Remote");
+		//TODO: Add profiles preferring management operations
+		
+		private String label;
+		
+		Profile(String label) {
+			this.label = label;
+		}
+		
+		public String getLabel() {
+			return label;
+		}
+	}
+
+	public void checkErrors() {
+		List<String> runtimes = getRuntimes();
+		
+		boolean anotherServerWithSameType = runtimes.size() > 0;		
+		if(anotherServerWithSameType) {
+			throw new AssertionError("There is another server with the same type.\n"
+					+ "Present server: " + Arrays.toString(runtimes.toArray()));
+		}
+	}
+}

--- a/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/wizard/page/NewServerWizardPageWithErrorCheck.java
+++ b/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/wizard/page/NewServerWizardPageWithErrorCheck.java
@@ -22,34 +22,28 @@ public class NewServerWizardPageWithErrorCheck extends NewServerWizardPage {
 	}
 
 	public void checkErrors() {
-		checkIfThereIsAnotherServerWithSameType();
-		
+		String errorText = getErrorText();
+		if(errorText == null)
+			return;
+		checkServerName(errorText);
+	}
+
+	private String getErrorText() {
 		String text;
 		try {
 			text = new LabeledText("Define a New Server").getText();
 			log.info("Found error text: " + text);
 		} catch(SWTLayerException e) {
 			log.info("No error text found.");
-			return;
+			return null;
 		}
-		
-		checkServerName(text);
+		return text;
 	}
-
-	private void checkIfThereIsAnotherServerWithSameType() {
-		try {
-			//combo box indicates that there are present other servers with the same type
-			Combo combo = new DefaultCombo();
-			throw new AssertionError("There is another server with the same type.\n"
-					+ "Present server: "+combo.getText());
-		} catch(SWTLayerException e) {
-			//combo box is not present so there is not any other server with the same type
-		}
-	}
-
+	
 	private void checkServerName(String errorText) {
 		if(errorText.contains("The server name is already in use. Specify a different name.")) {
-			throw new AssertionError("The server name '"+getServerName()+"' is already in use.");
+			throw new AssertionError("The server name '" + getServerName() + "' is already in use.");
 		}
 	}
 }
+


### PR DESCRIPTION
The workflow of creating server via New Server dialog has been changed.
There is a new wizard page, which brings options to set up profile and
to create remote runtime without a server.

Therefore, JBoss Server requirements had to be updated.

JBoss Tools Component: Red Deer server requirements
Author: rrabara
