### PR TITLE
Runtime-detection: Created EAP 6.2.x, EAP 6.3 and JPP 6.1.x tests.

### DIFF
--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/pom.xml
@@ -13,7 +13,11 @@
 
 	<properties>
 		<requirementsDirectory>${project.build.directory}/requirements</requirementsDirectory>
-
+		
+		<jboss-eap-6.2.x>${requirementsDirectory}/jboss-eap-6.2.x/jboss-eap-6.2</jboss-eap-6.2.x>
+		<jbosstools.test.jboss-eap-6.2.x.url>http://download.devel.redhat.com/released/JBEAP-6/6.2.2/jboss-eap-6.2.2-full-build.zip</jbosstools.test.jboss-eap-6.2.x.url>
+		<jbosstools.test.jboss-eap-6.2.x.md5>1727e5723de123c2470c134e4a25e9cf</jbosstools.test.jboss-eap-6.2.x.md5>
+		
 		<jboss-eap-6.2>${requirementsDirectory}/jboss-eap-6.2/</jboss-eap-6.2>
 		<jbosstools.test.jboss-eap-6.2.url>http://download.devel.redhat.com/released/JBEAP-6/6.2.0/jboss-eap-6.2.0.zip</jbosstools.test.jboss-eap-6.2.url>
 		<jbosstools.test.jboss-eap-6.2.md5>03ec01654cf4aee8c8e26313fae68c16</jbosstools.test.jboss-eap-6.2.md5>
@@ -28,6 +32,10 @@
 
 		<wildfly-8.0>${requirementsDirectory}/wildfly-8.0.0.Final/</wildfly-8.0>
 
+		<jboss-jpp-6.1.x>${requirementsDirectory}/jboss/portal-6.1.x/</jboss-jpp-6.1.x>
+		<jbosstools.test.jboss-jpp-6.1.x.url>http://download.devel.redhat.com/released/JBossEPP/6.1.1/jboss-portal-6.1.1.zip</jbosstools.test.jboss-jpp-6.1.x.url>
+		<jbosstools.test.jboss-jpp-6.1.x.md5>bc0e59f9ad4ab248f6b8542135b11599</jbosstools.test.jboss-jpp-6.1.x.md5>
+		
 		<jboss-seam-2.2>${requirementsDirectory}/jboss-seam-2.2.2.Final/</jboss-seam-2.2>
 		<jboss-seam-2.3>${requirementsDirectory}/jboss-seam-2.3.0.Final/</jboss-seam-2.3>
 		<test.class>org.jboss.tools.runtime.as.ui.bot.test.ProjectTestsSuite</test.class>
@@ -101,16 +109,29 @@
 				<version>1.0.0</version>
 				<executions>
 					<execution>
-						<id>install-eap-6.0.x</id>
+						<id>install-eap-6.2.x</id>
 						<phase>pre-integration-test</phase>
 						<goals>
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<url>${jbosstools.test.jboss-eap-6.0.x.url}</url>
+							<url>${jbosstools.test.jboss-eap-6.2.x.url}</url>
 							<unpack>true</unpack>
-							<md5>${jbosstools.test.jboss-eap-6.0.x.md5}</md5>
-							<outputDirectory>${requirementsDirectory}/jboss-eap-6.0.x/</outputDirectory>
+							<md5>${jbosstools.test.jboss-eap-6.2.x.md5}</md5>
+							<outputDirectory>${requirementsDirectory}/jboss-eap-6.2.x/</outputDirectory>
+						</configuration>
+					</execution>
+					<execution>
+						<id>install-eap-6.2</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>wget</goal>
+						</goals>
+						<configuration>
+							<url>${jbosstools.test.jboss-eap-6.2.url}</url>
+							<unpack>true</unpack>
+							<md5>${jbosstools.test.jboss-eap-6.2.md5}</md5>
+							<outputDirectory>${requirementsDirectory}/</outputDirectory>
 						</configuration>
 					</execution>
 					<execution>
@@ -127,16 +148,29 @@
 						</configuration>
 					</execution>
 					<execution>
-						<id>install-eap-6.2</id>
+						<id>install-eap-6.0.x</id>
 						<phase>pre-integration-test</phase>
 						<goals>
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<url>${jbosstools.test.jboss-eap-6.2.url}</url>
+							<url>${jbosstools.test.jboss-eap-6.0.x.url}</url>
 							<unpack>true</unpack>
-							<md5>${jbosstools.test.jboss-eap-6.2.md5}</md5>
-							<outputDirectory>${requirementsDirectory}/</outputDirectory>
+							<md5>${jbosstools.test.jboss-eap-6.0.x.md5}</md5>
+							<outputDirectory>${requirementsDirectory}/jboss-eap-6.0.x/</outputDirectory>
+						</configuration>
+					</execution>
+					<execution>
+						<id>install-jpp-6.1.x</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>wget</goal>
+						</goals>
+						<configuration>
+							<url>${jbosstools.test.jboss-jpp-6.1.x.url}</url>
+							<unpack>true</unpack>
+							<md5>${jbosstools.test.jboss-jpp-6.1.x.md5}</md5>
+							<outputDirectory>${jboss-jpp-6.1.x}</outputDirectory>
 						</configuration>
 					</execution>
 					<execution>

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/resources/template/runtimes.properties
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/resources/template/runtimes.properties
@@ -1,5 +1,7 @@
 wildfly-8.0=${wildfly-8.0}
 jboss-as-7.1.1.Final=${jboss-as-7}
+jboss-eap-6.3=${jboss-eap-6.3}
+jboss-eap-6.2.x=${jboss-eap-6.2.x}
 jboss-eap-6.2=${jboss-eap-6.2}
 jboss-eap-6.1.x=${jboss-eap-6.1.x}
 jboss-eap-6.1=${jboss-eap-6.1}
@@ -10,6 +12,7 @@ jboss-eap-5.1=${jboss-eap-5.1}
 jboss-eap-4.3=${jboss-eap-4}
 jboss-jpp-6.0=${jboss-jpp-6.0}
 jboss-jpp-6.1=${jboss-jpp-6.1}
+jboss-jpp-6.1.x=${jboss-jpp-6.1.x}
 jboss-epp-5.2=${jboss-epp-5.2}
 jboss-epp-4.3=${jboss-epp-4}
 jboss-ewp-5.1=${jboss-ewp-5}

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/AllTestsSuite.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/AllTestsSuite.java
@@ -25,6 +25,10 @@ import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap61x.DetectEAP61
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap61x.OperateEAP61x;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap62.DetectEAP62;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap62.OperateEAP62;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap62x.DetectEAP62x;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap62x.OperateEAP62x;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap63.DetectEAP63;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap63.OperateEAP63;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.epp4.CheckEPP4Seam;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.epp4.DetectEPP4;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.epp4.OperateEPP4;
@@ -38,6 +42,10 @@ import org.jboss.tools.runtime.as.ui.bot.test.detector.server.jboss7.DetectJBoss
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.jboss7.OperateJBoss7;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.jpp60.DetectJPP60;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.jpp60.OperateJPP60;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.jpp61.DetectJPP61;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.jpp61.OperateJPP61;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.jpp61x.DetectJPP61x;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.jpp61x.OperateJPP61x;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.soap52.CheckSOAP52Seam;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.soap52.DetectSOAP52;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.soap52.OperateSOAP52;
@@ -68,20 +76,26 @@ import org.junit.runners.Suite;
 		DetectJBoss7.class,
 		OperateJBoss7.class,
 		
-		DetectEAP60.class,
-		OperateEAP60.class,
+		DetectEAP63.class,
+		OperateEAP63.class,
 		
-		DetectEAP60x.class,
-		OperateEAP60x.class,
+		DetectEAP62x.class,
+		OperateEAP62x.class,
 		
-		DetectEAP61.class,
-		OperateEAP61.class,
+		DetectEAP62.class,
+		OperateEAP62.class,
 		
 		DetectEAP61x.class,
 		OperateEAP61x.class,
 		
-		DetectEAP62.class,
-		OperateEAP62.class,
+		DetectEAP61.class,
+		OperateEAP61.class,
+		
+		DetectEAP60x.class,
+		OperateEAP60x.class,
+		
+		DetectEAP60.class,
+		OperateEAP60.class,
 		
 		// Needs Java SE 1.6
 		DetectEAP51.class, 
@@ -105,7 +119,13 @@ import org.junit.runners.Suite;
 		CheckEPP5Seam.class,
 		OperateEPP5.class,
 		
-		DetectJPP60.class, 
+		DetectJPP61.class,
+		OperateJPP61.class,
+		
+		DetectJPP61x.class,
+		OperateJPP61x.class,
+		
+		DetectJPP60.class,
 		OperateJPP60.class,
 		
 		// Needs Java SE 1.6

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/Java6AllTestsSuite.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/Java6AllTestsSuite.java
@@ -40,7 +40,7 @@ import org.junit.runners.Suite;
 		
 		DetectSOAP52.class, 
 		CheckSOAP52Seam.class,
-		OperateSOAP52.class, 
+		OperateSOAP52.class,
 		DetectSOAPStandalone52.class, 
 		OperateSOAPStandalone52.class,
 	

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/Java7AllTestsSuite.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/Java7AllTestsSuite.java
@@ -22,6 +22,10 @@ import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap61x.DetectEAP61
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap61x.OperateEAP61x;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap62.DetectEAP62;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap62.OperateEAP62;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap62x.DetectEAP62x;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap62x.OperateEAP62x;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap63.DetectEAP63;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap63.OperateEAP63;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.epp4.CheckEPP4Seam;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.epp4.DetectEPP4;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.epp4.OperateEPP4;
@@ -31,6 +35,8 @@ import org.jboss.tools.runtime.as.ui.bot.test.detector.server.jpp60.DetectJPP60;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.jpp60.OperateJPP60;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.jpp61.DetectJPP61;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.jpp61.OperateJPP61;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.jpp61x.DetectJPP61x;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.jpp61x.OperateJPP61x;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.soap53.CheckSOAP53Seam;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.soap53.DetectSOAP53;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.soap53.OperateSOAP53;
@@ -46,7 +52,7 @@ import org.junit.runners.Suite;
  * Tests with Java SE 1.7 requirement
  * 
  * @author Petr Suchy
- *
+ * @author Radoslav Rabara
  */
 @RunWith(JBTSuite.class)
 @Suite.SuiteClasses({
@@ -61,20 +67,26 @@ import org.junit.runners.Suite;
 		DetectJBoss7.class,
 		OperateJBoss7.class,
 		
-		DetectEAP60.class,
-		OperateEAP60.class,
+		DetectEAP63.class,
+		OperateEAP63.class,
 		
-		DetectEAP60x.class,
-		OperateEAP60x.class,
+		DetectEAP62x.class,
+		OperateEAP62x.class,
 		
-		DetectEAP61.class,
-		OperateEAP61.class,
+		DetectEAP62.class,
+		OperateEAP62.class,
 		
 		DetectEAP61x.class,
 		OperateEAP61x.class,
 		
-		DetectEAP62.class,
-		OperateEAP62.class,
+		DetectEAP61.class,
+		OperateEAP61.class,
+		
+		DetectEAP60x.class,
+		OperateEAP60x.class,
+		
+		DetectEAP60.class,
+		OperateEAP60.class,
 		
 		DetectEAP52.class, 
 		CheckEAP52Seam.class,
@@ -90,6 +102,9 @@ import org.junit.runners.Suite;
 		
 		DetectJPP60.class, 
 		OperateJPP60.class,
+		
+		DetectJPP61x.class,
+		OperateJPP61x.class,
 		
 		DetectJPP61.class,
 		OperateJPP61.class,

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/ProjectTestsSuite.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/ProjectTestsSuite.java
@@ -10,14 +10,26 @@ import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap61x.DetectEAP61
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap61x.OperateEAP61x;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap62.DetectEAP62;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap62.OperateEAP62;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap62x.DetectEAP62x;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap62x.OperateEAP62x;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap63.DetectEAP63;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap63.OperateEAP63;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.jboss7.DetectJBoss7;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.jboss7.OperateJBoss7;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.jpp61x.DetectJPP61x;
+import org.jboss.tools.runtime.as.ui.bot.test.detector.server.jpp61x.OperateJPP61x;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.wildfly8.DetectWildFly8;
 import org.jboss.tools.runtime.as.ui.bot.test.detector.server.wildfly8.OperateWildFly8;
 import org.jboss.tools.runtime.as.ui.bot.test.download.RuntimeDownload;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite.SuiteClasses;
 
+/**
+ * Mavenized test suite
+ * 
+ * @author Petr Suchy
+ * @author Radoslav Rabara
+ */
 @RunWith(JBTSuite.class)
 @SuiteClasses({
 		RuntimeDownload.class,
@@ -28,14 +40,23 @@ import org.junit.runners.Suite.SuiteClasses;
 		DetectJBoss7.class,
 		OperateJBoss7.class,
 		
-		DetectEAP60x.class,
-		OperateEAP60x.class,
+//		DetectEAP63.class,
+//		OperateEAP63.class,
+		
+		DetectEAP62x.class,
+		OperateEAP62x.class,
+		
+		DetectEAP62.class,
+		OperateEAP62.class,
 		
 		DetectEAP61x.class,
 		OperateEAP61x.class,
 		
-		DetectEAP62.class,
-		OperateEAP62.class,
+		DetectEAP60x.class,
+		OperateEAP60x.class,
+		
+		DetectJPP61x.class,
+		OperateJPP61x.class,
 		
 		DetectSeam22.class,
 		CheckSeam22.class,

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/detector/server/eap62x/DetectEAP62x.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/detector/server/eap62x/DetectEAP62x.java
@@ -1,0 +1,30 @@
+package org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap62x;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.jboss.tools.runtime.as.ui.bot.test.RuntimeProperties;
+import org.jboss.tools.runtime.as.ui.bot.test.entity.Runtime;
+import org.jboss.tools.runtime.as.ui.bot.test.template.DetectRuntimeTemplate;
+
+public class DetectEAP62x extends DetectRuntimeTemplate {
+
+	public static final String SERVER_ID = "jboss-eap-6.2.x";
+	
+	public static final String SERVER_NAME = "jboss-eap-6.2";
+	
+	@Override
+	protected String getPathID() {
+		return SERVER_ID;
+	}
+
+	@Override
+	protected List<Runtime> getExpectedRuntimes() {
+		Runtime server = new Runtime();
+		server.setName(SERVER_NAME);
+		server.setType("EAP");
+		server.setVersion("6.2");
+		server.setLocation(RuntimeProperties.getInstance().getRuntimePath(getPathID()));
+		return Arrays.asList(server);
+	}
+}

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/detector/server/eap62x/OperateEAP62x.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/detector/server/eap62x/OperateEAP62x.java
@@ -1,0 +1,11 @@
+package org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap62x;
+
+import org.jboss.tools.runtime.as.ui.bot.test.template.OperateServerTemplate;
+
+public class OperateEAP62x extends OperateServerTemplate {
+
+	@Override
+	protected String getServerName() {
+		return DetectEAP62x.SERVER_NAME;
+	}
+}

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/detector/server/eap63/DetectEAP63.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/detector/server/eap63/DetectEAP63.java
@@ -1,0 +1,28 @@
+package org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap63;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.jboss.tools.runtime.as.ui.bot.test.RuntimeProperties;
+import org.jboss.tools.runtime.as.ui.bot.test.entity.Runtime;
+import org.jboss.tools.runtime.as.ui.bot.test.template.DetectRuntimeTemplate;
+
+public class DetectEAP63 extends DetectRuntimeTemplate {
+
+	public static final String SERVER_ID = "jboss-eap-6.3";
+	
+	@Override
+	protected String getPathID() {
+		return SERVER_ID;
+	}
+
+	@Override
+	protected List<Runtime> getExpectedRuntimes() {
+		Runtime server = new Runtime();
+		server.setName(SERVER_ID);
+		server.setType("EAP");
+		server.setVersion("6.3");
+		server.setLocation(RuntimeProperties.getInstance().getRuntimePath(getPathID()));
+		return Arrays.asList(server);
+	}
+}

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/detector/server/eap63/OperateEAP63.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/detector/server/eap63/OperateEAP63.java
@@ -1,0 +1,11 @@
+package org.jboss.tools.runtime.as.ui.bot.test.detector.server.eap63;
+
+import org.jboss.tools.runtime.as.ui.bot.test.template.OperateServerTemplate;
+
+public class OperateEAP63 extends OperateServerTemplate {
+
+	@Override
+	protected String getServerName() {
+		return DetectEAP63.SERVER_ID;
+	}
+}

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/detector/server/jpp61x/DetectJPP61x.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/detector/server/jpp61x/DetectJPP61x.java
@@ -1,0 +1,30 @@
+package org.jboss.tools.runtime.as.ui.bot.test.detector.server.jpp61x;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.jboss.tools.runtime.as.ui.bot.test.RuntimeProperties;
+import org.jboss.tools.runtime.as.ui.bot.test.entity.Runtime;
+import org.jboss.tools.runtime.as.ui.bot.test.template.DetectRuntimeTemplate;
+
+public class DetectJPP61x extends DetectRuntimeTemplate {
+
+	public static final String SERVER_ID = "jboss-jpp-6.1.x";
+	
+	public static final String SERVER_NAME = "jboss-portal-6.1";
+	
+	@Override
+	protected String getPathID() {
+		return SERVER_ID;
+	}
+
+	@Override
+	protected List<Runtime> getExpectedRuntimes() {
+		Runtime server = new Runtime();
+		server.setName(SERVER_NAME);
+		server.setType("JPP");
+		server.setVersion("6.1");
+		server.setLocation(RuntimeProperties.getInstance().getRuntimePath(getPathID()));
+		return Arrays.asList(server);
+	}
+}

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/detector/server/jpp61x/OperateJPP61x.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/detector/server/jpp61x/OperateJPP61x.java
@@ -1,0 +1,11 @@
+package org.jboss.tools.runtime.as.ui.bot.test.detector.server.jpp61x;
+
+import org.jboss.tools.runtime.as.ui.bot.test.template.OperateServerTemplate;
+
+public class OperateJPP61x extends OperateServerTemplate {
+
+	@Override
+	protected String getServerName() {
+		return DetectJPP61x.SERVER_NAME;
+	}
+}


### PR DESCRIPTION
Created EAP 6.2.x, EAP 6.3 and JPP 6.1.x tests.
EAP 6.2.x and JPP 6.1.x tests are mavenized.

Refactored TestsSuites and added missing runtimes to AllTestsSuite.

JBoss Tools Component: runtime-detection
Author: rrabara
