### PR TITLE
Updating Mylyn tests to reflect latest changes in Red Deer test

### DIFF
--- a/tests/org.jboss.tools.mylyn.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.mylyn.ui.bot.test/META-INF/MANIFEST.MF
@@ -11,7 +11,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.swtbot.go;bundle-version="2.0.5",
  org.jboss.reddeer.swt,
  org.jboss.reddeer.eclipse,
- org.jboss.tools.mylyn.reddeer
+ org.jboss.tools.mylyn.reddeer,
+ org.jboss.reddeer.workbench
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Import-Package: org.eclipse.wst.server.ui.internal.view.servers,

--- a/tests/org.jboss.tools.mylyn.ui.bot.test/src/org/jboss/tools/mylyn/ui/bot/test/MylynTestJenkins.java
+++ b/tests/org.jboss.tools.mylyn.ui.bot.test/src/org/jboss/tools/mylyn/ui/bot/test/MylynTestJenkins.java
@@ -43,6 +43,9 @@ public class MylynTestJenkins {
 
 	@Test
 	public void TestIt() {
+		
+		TestSupport.closeWelcome();
+
 		BuildServerDialog buildServerDialog = null;
 		MylynBuildView view = new MylynBuildView();
 

--- a/tests/org.jboss.tools.mylyn.ui.bot.test/src/org/jboss/tools/mylyn/ui/bot/test/MylynTestLocalRepo.java
+++ b/tests/org.jboss.tools.mylyn.ui.bot.test/src/org/jboss/tools/mylyn/ui/bot/test/MylynTestLocalRepo.java
@@ -34,6 +34,8 @@ public class MylynTestLocalRepo {
 	@Test
 	public void TestIt() {
 
+		TestSupport.closeWelcome();
+		
 		/* Verify Local task repository can be found */
 		TaskRepositoriesView view = new TaskRepositoriesView();	
 		view.open();

--- a/tests/org.jboss.tools.mylyn.ui.bot.test/src/org/jboss/tools/mylyn/ui/bot/test/MylynTestValidate.java
+++ b/tests/org.jboss.tools.mylyn.ui.bot.test/src/org/jboss/tools/mylyn/ui/bot/test/MylynTestValidate.java
@@ -21,7 +21,6 @@ import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitUntil;
 import org.jboss.reddeer.eclipse.mylyn.tasks.ui.view.*;
 import org.jboss.reddeer.eclipse.ui.ide.RepoConnectionDialog;
-
 import org.jboss.reddeer.swt.condition.ShellIsActive;
 
 public class MylynTestValidate {
@@ -34,6 +33,8 @@ public class MylynTestValidate {
 
 	@Test
 	public void TestIt() {
+		
+		TestSupport.closeWelcome();
 
 		TaskRepositoriesView view = new TaskRepositoriesView();
 		


### PR DESCRIPTION
framework.

Added org.jboss.reddeer.workbench as required bundle. Added code to close the welcome view - this was causing intermittent errors when running the tests in JBDS.
