### PR TITLE
SWTBot-Ext: Fixed and updated WildFly setup

### DIFF
--- a/plugins/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/config/TestConfigurator.java
+++ b/plugins/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/config/TestConfigurator.java
@@ -219,6 +219,12 @@ public class TestConfigurator {
 				ReasonLogger.serverTypeMatch(s.type().toString(), currentConfig.getServer().type);
 				return null;
 			}
+			if (s.type().equals(ServerType.WildFly)
+					&& !currentConfig.getServer().type
+							.equals(Values.SERVER_TYPE_WILDFLY)) {
+				ReasonLogger.serverTypeMatch(s.type().toString(), currentConfig.getServer().type);
+				return null;
+			}
 			if (s.type().equals(ServerType.EPP)
 					&& !currentConfig.getServer().type
 							.equals(Values.SERVER_TYPE_EPP)) {

--- a/plugins/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/config/requirement/AddServer.java
+++ b/plugins/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/config/requirement/AddServer.java
@@ -138,7 +138,7 @@ public class AddServer extends RequirementBase {
 			
 		}
 		if (TestConfigurator.Values.SERVER_TYPE_WILDFLY.equals(serverType)){
-			if ("8".equals(version)){
+			if (version != null && version.startsWith("8")){
 				return new ServerInfo(JBossCommunityWildFly8Runtime.LABEL, JBossCommunityWildFly8.LABEL);
 			}
 		}

--- a/plugins/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/gen/ActionItem.java
+++ b/plugins/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/gen/ActionItem.java
@@ -1718,10 +1718,10 @@ public static String getItemString(IActionItem item) {
 			}
 		public static class JBossCommunityWildFly8 {
 			/**
-			* represents item : JBoss Community->WildFly 8.0 (Expreimental)
+			* represents item : JBoss Community->WildFly 8.0
 			*/
 			public static final IServer LABEL = new IServer() {
-				public String getName() { return "WildFly 8.0 (Experimental)";}
+				public String getName() { return "WildFly 8.0";}
 				public List<String> getGroupPath() {
 					List<String> l = new Vector<String>();
 					l.add("JBoss Community");
@@ -10927,10 +10927,10 @@ public static String getItemString(IActionItem item) {
 			}
 		public static class JBossCommunityWildFly8Runtime {
 			/**
-			 * reptresents item : WildFly 8.0 Runtime (Experimental)
+			 * reptresents item : WildFly 8.0 Runtime
 			 */
 			public static final IServerRuntime LABEL = new IServerRuntime() {
-				public String getName() { return "WildFly 8.0 Runtime (Experimental)";}
+				public String getName() { return "WildFly 8.0 Runtime";}
 				public List<String> getGroupPath() {
 					List<String> l = new Vector<String>();
 					l.add("JBoss Community");


### PR DESCRIPTION
Updated adapter label from "Wildfly 8.0 (Experimental)" to "Wildfly 8.0"

Fixed check if the given server has the same type as the specified server - now it works also for WildFly

JBoss Tools Component: SWTBot-Ext
Author: rrabara
