### PR TITLE
Changed root element name in server requirements

### DIFF
--- a/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerRequirementConfig.java
+++ b/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerRequirementConfig.java
@@ -17,7 +17,7 @@ import org.jboss.reddeer.requirements.server.IServerReqConfig;
  *
  */
 
-@XmlRootElement(name="server-requirement", namespace="http://www.jboss.org/NS/ServerReq")
+@XmlRootElement(name="jboss-server-requirement", namespace="http://www.jboss.org/NS/ServerReq")
 public class ServerRequirementConfig implements IServerReqConfig {
 	
 	private String runtime;

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/product/eap-4.3.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/product/eap-4.3.xml
@@ -7,11 +7,11 @@
 						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/JBossServerRequirements.xsd">
 
 	<requirements>
-		<server:server-requirement name="EAP-4.3">
+		<server:jboss-server-requirement name="EAP-4.3">
 			<server:type>
 				<server:familyEAP version="4.3"></server:familyEAP>
 			</server:type>
 			<server:runtime>${jbosstools.test.jboss-eap-4.home}</server:runtime>
-		</server:server-requirement>
+		</server:jboss-server-requirement>
 	</requirements>
 </testrun>

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/product/eap-5.x.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/product/eap-5.x.xml
@@ -7,11 +7,11 @@
 						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/JBossServerRequirements.xsd">
 
 	<requirements>
-		<server:server-requirement name="EAP-5.x">
+		<server:jboss-server-requirement name="EAP-5.x">
 			<server:type>
 				<server:familyEAP version="5.x"></server:familyEAP>
 			</server:type>
 			<server:runtime>${jbosstools.test.jboss-eap-5.home}</server:runtime>
-		</server:server-requirement>
+		</server:jboss-server-requirement>
 	</requirements>
 </testrun>

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/product/eap-6.0.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/product/eap-6.0.xml
@@ -7,11 +7,11 @@
 						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/JBossServerRequirements.xsd">
 
 	<requirements>
-		<server:server-requirement name="EAP-6.0">
+		<server:jboss-server-requirement name="EAP-6.0">
 			<server:type>
 				<server:familyEAP version="6.0"></server:familyEAP>
 			</server:type>
 			<server:runtime>${jbosstools.test.jboss-eap-6.0.home}</server:runtime>
-		</server:server-requirement>
+		</server:jboss-server-requirement>
 	</requirements>
 </testrun>

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/product/eap-6.x.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/product/eap-6.x.xml
@@ -7,11 +7,11 @@
 						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/JBossServerRequirements.xsd">
 
 	<requirements>
-		<server:server-requirement name="EAP-6.x">
+		<server:jboss-server-requirement name="EAP-6.x">
 			<server:type>
 				<server:familyEAP version="6.1+"></server:familyEAP>
 			</server:type>
 			<server:runtime>${jbosstools.test.jboss-eap-6.x.home}</server:runtime>
-		</server:server-requirement>
+		</server:jboss-server-requirement>
 	</requirements>
 </testrun>

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/project/jbossas-3.2.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/project/jbossas-3.2.xml
@@ -7,11 +7,11 @@
 						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/JBossServerRequirements.xsd">
 
 	<requirements>
-		<server:server-requirement name="JBoss-3.2">
+		<server:jboss-server-requirement name="JBoss-3.2">
 			<server:type>
 				<server:familyAS version="3.2"></server:familyAS>
 			</server:type>
 			<server:runtime>${jbosstools.test.jboss-as-3.2.home}</server:runtime>
-		</server:server-requirement>
+		</server:jboss-server-requirement>
 	</requirements>
 </testrun>

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/project/jbossas-4.0.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/project/jbossas-4.0.xml
@@ -7,11 +7,11 @@
 						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/JBossServerRequirements.xsd">
 
 	<requirements>
-		<server:server-requirement name="JBoss-4.0">
+		<server:jboss-server-requirement name="JBoss-4.0">
 			<server:type>
 				<server:familyAS version="4.0"></server:familyAS>
 			</server:type>
 			<server:runtime>${jbosstools.test.jboss-as-4.0.home}</server:runtime>
-		</server:server-requirement>
+		</server:jboss-server-requirement>
 	</requirements>
 </testrun>

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/project/jbossas-4.2.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/project/jbossas-4.2.xml
@@ -7,11 +7,11 @@
 						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/JBossServerRequirements.xsd">
 
 	<requirements>
-		<server:server-requirement name="JBoss-4.2">
+		<server:jboss-server-requirement name="JBoss-4.2">
 			<server:type>
 				<server:familyAS version="4.2"></server:familyAS>
 			</server:type>
 			<server:runtime>${jbosstools.test.jboss-as-4.2.home}</server:runtime>
-		</server:server-requirement>
+		</server:jboss-server-requirement>
 	</requirements>
 </testrun>

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/project/jbossas-5.0.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/project/jbossas-5.0.xml
@@ -7,11 +7,11 @@
 						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/JBossServerRequirements.xsd">
 
 	<requirements>
-		<server:server-requirement name="JBoss-5.0">
+		<server:jboss-server-requirement name="JBoss-5.0">
 			<server:type>
 				<server:familyAS version="5.0"></server:familyAS>
 			</server:type>
 			<server:runtime>${jbosstools.test.jboss-as-5.0.home}</server:runtime>
-		</server:server-requirement>
+		</server:jboss-server-requirement>
 	</requirements>
 </testrun>

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/project/jbossas-5.1.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/project/jbossas-5.1.xml
@@ -7,11 +7,11 @@
 						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/JBossServerRequirements.xsd">
 
 	<requirements>
-		<server:server-requirement name="JBoss-5.1">
+		<server:jboss-server-requirement name="JBoss-5.1">
 			<server:type>
 				<server:familyAS version="5.1"></server:familyAS>
 			</server:type>
 			<server:runtime>${jbosstools.test.jboss-as-5.1.home}</server:runtime>
-		</server:server-requirement>
+		</server:jboss-server-requirement>
 	</requirements>
 </testrun>

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/project/jbossas-6.x.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/project/jbossas-6.x.xml
@@ -7,11 +7,11 @@
 						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/JBossServerRequirements.xsd">
 
 	<requirements>
-		<server:server-requirement name="JBoss-6">
+		<server:jboss-server-requirement name="JBoss-6">
 			<server:type>
 				<server:familyAS version="6.x"></server:familyAS>
 			</server:type>
 			<server:runtime>${jbosstools.test.jboss-as-6.x.home}</server:runtime>
-		</server:server-requirement>
+		</server:jboss-server-requirement>
 	</requirements>
 </testrun>

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/project/jbossas-7.0.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/project/jbossas-7.0.xml
@@ -7,11 +7,11 @@
 						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/JBossServerRequirements.xsd">
 
 	<requirements>
-		<server:server-requirement name="JBoss-7.0">
+		<server:jboss-server-requirement name="JBoss-7.0">
 			<server:type>
 				<server:familyAS version="7.0"></server:familyAS>
 			</server:type>
 			<server:runtime>${jbosstools.test.jboss-as-7.0.home}</server:runtime>
-		</server:server-requirement>
+		</server:jboss-server-requirement>
 	</requirements>
 </testrun>

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/project/jbossas-7.1.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/project/jbossas-7.1.xml
@@ -7,11 +7,11 @@
 						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/JBossServerRequirements.xsd">
 
 	<requirements>
-		<server:server-requirement name="JBoss-7.1">
+		<server:jboss-server-requirement name="JBoss-7.1">
 			<server:type>
 				<server:familyAS version="7.1"></server:familyAS>
 			</server:type>
 			<server:runtime>${jbosstools.test.jboss-as-7.1.home}</server:runtime>
-		</server:server-requirement>
+		</server:jboss-server-requirement>
 	</requirements>
 </testrun>

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/project/wildfly-8.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/resources/config_files_templates/project/wildfly-8.xml
@@ -7,11 +7,11 @@
 						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/JBossServerRequirements.xsd">
 
 	<requirements>
-		<server:server-requirement name="Wildfly-6">
+		<server:jboss-server-requirement name="Wildfly-6">
 			<server:type>
 				<server:familyWildFly version="8.0"></server:familyWildFly>
 			</server:type>
 			<server:runtime>${jbosstools.test.jboss-wildfly-8.home}</server:runtime>
-		</server:server-requirement>
+		</server:jboss-server-requirement>
 	</requirements>
 </testrun>

--- a/tests/org.jboss.tools.archives.ui.bot.test/.project
+++ b/tests/org.jboss.tools.archives.ui.bot.test/.project
@@ -21,12 +21,12 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<name>org.jboss.ide.eclipse.archives.core.archivesBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.jboss.ide.eclipse.archives.core.archivesBuilder</name>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>

--- a/tests/org.jboss.tools.archives.ui.bot.test/resources/servers/jboss-as71.xml
+++ b/tests/org.jboss.tools.archives.ui.bot.test/resources/servers/jboss-as71.xml
@@ -7,11 +7,11 @@
 						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/JBossServerRequirements.xsd">
 
 	<requirements>
-		<server:server-requirement name="JBoss-7.1">
+		<server:jboss-server-requirement name="JBoss-7.1">
 			<server:type>
 				<server:familyAS version="7.1"></server:familyAS>
 			</server:type>
 			<server:runtime>${jboss-as-7.1.home}</server:runtime>
-		</server:server-requirement>
+		</server:jboss-server-requirement>
 	</requirements>
 </testrun>


### PR DESCRIPTION
to be jboss-server-requirement instead of server-requirement. All found server requirements resources should be changed by now and reflect this change. This allows to use new version of server requirements schema which will support remote server adapters later on.
