### PR TITLE
Add dependency on org.eclipse.platform - fix for tests on mac

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -78,6 +78,11 @@
 							<artifactId>org.eclipse.equinox.event</artifactId>
 							<version>0.0.0</version>
 						</dependency>
+						<dependency>
+							<type>p2-installable-unit</type>
+							<artifactId>org.eclipse.platform.feature.group</artifactId>
+							<version>0.0.0</version>
+						</dependency>
 					</dependencies>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
Ever since we switched to luna, all integration tests stopped working on mac
(all tests using parent pom are affected, not RedDeer). The Preferences window
could not be opened. To fix this, we add explicit dependency on
org.eclipse.platform.feature.group to all tests.
