### PR TITLE
Runtime-detection: runtime detection tests were changed

### DIFF
--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/dialog/preferences/RuntimeDetectionPreferencesDialog.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/dialog/preferences/RuntimeDetectionPreferencesDialog.java
@@ -1,7 +1,14 @@
 package org.jboss.tools.runtime.as.ui.bot.test.dialog.preferences;
 
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.jboss.reddeer.eclipse.jface.preference.PreferencePage;
+import org.jboss.reddeer.swt.api.Button;
 import org.jboss.reddeer.swt.api.Table;
+import org.jboss.reddeer.swt.api.TableItem;
 import org.jboss.reddeer.swt.condition.JobIsRunning;
 import org.jboss.reddeer.swt.condition.WaitCondition;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
@@ -12,9 +19,14 @@ import org.jboss.reddeer.swt.impl.table.DefaultTable;
 import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitUntil;
 import org.jboss.reddeer.swt.wait.WaitWhile;
-import org.jboss.tools.runtime.core.model.RuntimePath;
-import org.jboss.tools.runtime.ui.RuntimeUIActivator;
 
+/**
+ * 
+ * @author ljelinkova
+ * @author psuchy
+ * @author rrabara
+ *
+ */
 public class RuntimeDetectionPreferencesDialog extends PreferencePage {
 
 	public RuntimeDetectionPreferencesDialog() {
@@ -26,13 +38,6 @@ public class RuntimeDetectionPreferencesDialog extends PreferencePage {
 		new WaitWhile(new JobIsRunning());
 		super.ok();
 	}
-	
-	public SearchingForRuntimesDialog addPath(final String path){
-		RuntimeUIActivator.getDefault().getModel().addRuntimePath(new RuntimePath(path));
-		cancel();
-		open();
-		return new SearchingForRuntimesDialog();
-	}
 
 	public void removeAllPaths(){
 		Table table = new DefaultTable();
@@ -40,10 +45,21 @@ public class RuntimeDetectionPreferencesDialog extends PreferencePage {
 		int pathsNumber = table.rowCount();
 		for (int i = 0; i < pathsNumber; i++){
 			table.select(0);
-			new PushButton("Remove").click();
+			Button removeButton = new PushButton("Remove");
+			assertTrue("Remove button is not enabled", removeButton.isEnabled());
+			removeButton.click();
 		}
 	}
 
+	public List<String> getAllPaths() {
+		Table table = new DefaultTable();
+		List<String> paths = new ArrayList<String>();
+		for(TableItem ti : table.getItems()) {
+			paths.add(ti.getText(0));
+		}
+		return paths;
+	}
+	
 	public SearchingForRuntimesDialog search(){
 		new PushButton("Search...").click();
 		new DefaultShell("Searching for runtimes...");

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/dialog/preferences/SearchingForRuntimesDialog.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/dialog/preferences/SearchingForRuntimesDialog.java
@@ -18,9 +18,15 @@ import org.jboss.reddeer.swt.util.Display;
 import org.jboss.reddeer.swt.util.ResultRunnable;
 import org.jboss.reddeer.swt.wait.WaitWhile;
 import org.jboss.tools.runtime.as.ui.bot.test.entity.Runtime;
-import org.jboss.tools.ui.bot.ext.condition.ShellIsActiveCondition;
 
-public class SearchingForRuntimesDialog {
+public class SearchingForRuntimesDialog extends DefaultShell {
+	
+	public static final String DIALOG_TITLE = "Searching for runtimes...";
+	
+	public SearchingForRuntimesDialog() {
+		super(DIALOG_TITLE);
+	}
+	
 	/**
 	 * We get columns names and their indexes.
 	 * 

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/template/DetectRuntimeTemplate.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/template/DetectRuntimeTemplate.java
@@ -1,30 +1,48 @@
 package org.jboss.tools.runtime.as.ui.bot.test.template;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 
+import org.hamcrest.core.Is;
+import org.jboss.reddeer.swt.condition.ShellWithTextIsAvailable;
+import org.jboss.reddeer.swt.impl.button.PushButton;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.tools.runtime.as.ui.bot.test.RuntimeProperties;
+import org.jboss.tools.runtime.as.ui.bot.test.dialog.preferences.RuntimeDetectionPreferencesDialog;
 import org.jboss.tools.runtime.as.ui.bot.test.dialog.preferences.SearchingForRuntimesDialog;
 import org.jboss.tools.runtime.as.ui.bot.test.entity.Runtime;
 import org.jboss.tools.runtime.as.ui.bot.test.matcher.RuntimeMatcher;
 import org.jboss.tools.runtime.core.model.RuntimePath;
 import org.jboss.tools.runtime.ui.RuntimeUIActivator;
 import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
+import org.junit.runners.MethodSorters;
 
 /**
- * Common scenario for runtime detection tests. It adds the runtime's installation
- * folder to the runtime detection and checks if it is correctly recognized and created. 
+ * Common scenario for runtime detection tests.
+ * 
+ * It adds the runtime's installation folder to the runtime detection,
+ * checks if it is correctly recognized and created and then remove
+ * added runtime's installation folder.
+ * 
+ * 
  *   
  * @author Lucia Jelinkova
  * @author Petr Suchy
- *
+ * @author Radoslav Rabara
  */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)//first detectRuntime and then removePath
 public abstract class DetectRuntimeTemplate extends RuntimeDetectionTestCase {
-
+	
 	private SearchingForRuntimesDialog searchingForRuntimesDialog;
 
 	protected abstract String getPathID();
@@ -34,33 +52,68 @@ public abstract class DetectRuntimeTemplate extends RuntimeDetectionTestCase {
 	@Test
 	public void detectRuntime(){
 		String path = RuntimeProperties.getInstance().getRuntimePath(getPathID());
+		assertTrue("Path doesn't exists", new File(path).exists());
 		searchingForRuntimesDialog = addPath(path);
-
-		List<Runtime> runtimes = searchingForRuntimesDialog.getRuntimes(); 
-		int size = runtimes.size();
 		
-		if(size > 0){
-			assertThat(runtimes.size(), is(getExpectedRuntimes().size()));
-		}else{
-			searchingForRuntimesDialog.cancel();
-			throw new AssertionError("No runtime detected in folder: " + path);
-		}
-
-		for (Runtime runtime : getExpectedRuntimes()){
-			assertThat(runtimes, hasItem(new RuntimeMatcher(runtime)));			
-		}
+		List<Runtime> runtimes = searchingForRuntimesDialog.getRuntimes();
+		
+		searchingForRuntimesDialog.ok();
+		runtimeDetectionPreferences.ok();
+		
+		assertCountOfRuntimes(runtimes, path);
+		assertThatExpectedRuntimesArePresent(runtimes);
 	}
 
-	@After
-	public void closePreferences(){
-		searchingForRuntimesDialog.ok();
-//		runtimeDetectionPreferences.removeAllPaths();
+	@Test
+	public void removePath() {
+		runtimeDetectionPreferences.open();
+		runtimeDetectionPreferences.removeAllPaths();
+		
+		List<String> allPaths = runtimeDetectionPreferences.getAllPaths();
+		
 		runtimeDetectionPreferences.ok();
-
-		// this call to API is due to wrongly functioning of Remove button. Once it is fixed
-		// it should be changed back to removing via SWTBot
+		
+		assertThat("Not all paths were removed. There are " + Arrays.toString(allPaths.toArray()), allPaths.size(), Is.is(0));
+	}
+	
+	@After
+	public void closeShells(){
+		//close opened shells
+		String[] openedShells = new String[]{
+				SearchingForRuntimesDialog.DIALOG_TITLE,
+				RuntimeDetectionPreferencesDialog.DIALOG_TITLE};
+		for(String title : openedShells) {
+			if(new ShellWithTextIsAvailable(title).test()) {
+				new DefaultShell(title);
+				new PushButton("Cancel").click();
+			}
+		}
+	}
+	
+	@AfterClass
+	public static void cleanPaths() {
+		// make sure that paths were removed
 		for (RuntimePath path : RuntimeUIActivator.getDefault().getModel().getRuntimePaths()){
 			RuntimeUIActivator.getDefault().getModel().removeRuntimePath(path);
+		}
+	}
+	
+	private void assertCountOfRuntimes(List<Runtime> runtimes, String path) {
+		int size = runtimes.size();
+		int expectedSize = getExpectedRuntimes().size();
+		if(size > 0) {
+			assertThat("Expected " + expectedSize + " but there were " + size
+					+ ":\nExpected runtimes: "+Arrays.toString(getExpectedRuntimes().toArray())
+					+ "\nBut there were " + Arrays.toString(runtimes.toArray()), size, is(expectedSize));
+		} else {
+			searchingForRuntimesDialog.cancel();
+			fail("No runtime detected in folder: " + path);
+		}
+	}
+	
+	private void assertThatExpectedRuntimesArePresent(List<Runtime> runtimes) {
+		for (Runtime runtime : getExpectedRuntimes()){
+			assertThat(runtimes, hasItem(new RuntimeMatcher(runtime)));
 		}
 	}
 }

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/template/RuntimeDetectionTestCase.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/template/RuntimeDetectionTestCase.java
@@ -25,10 +25,13 @@ public abstract class RuntimeDetectionTestCase {
 	protected RuntimePreferencePage serverRuntimesPreferences = new RuntimePreferencePage();
 	
 	protected SearchingForRuntimesDialog addPath(String path){
-		runtimeDetectionPreferences = new RuntimeDetectionPreferencesDialog();
 		RuntimeUIActivator.getDefault().getModel().addRuntimePath(new RuntimePath(path));
+		runtimeDetectionPreferences = new RuntimeDetectionPreferencesDialog();
 		runtimeDetectionPreferences.open();
-		runtimeDetectionPreferences.addPath(path);
+		if(!runtimeDetectionPreferences.getAllPaths().contains(path)) {
+			runtimeDetectionPreferences.cancel();
+			runtimeDetectionPreferences.open();
+		}
 		return runtimeDetectionPreferences.search();
 	}
 	


### PR DESCRIPTION
Runtime detection tests were changed:
- check if the added runtime was created as runtime
- test if the runtime dialog works properly (e.g. remove button works)
- assert that provided path really exists

Operate tests were also changed to first check if the runtime is present before
tests starts.

JBoss Tools Component: runtime-detection
Author: rrabara
