### PR TITLE
Another fix for mac: Add java 1.8 to condition + direct call to MacSpecifics.

### DIFF
--- a/plugins/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/MacSpecifics.java
+++ b/plugins/org.jboss.tools.ui.bot.ext/src/org/jboss/tools/ui/bot/ext/MacSpecifics.java
@@ -26,7 +26,7 @@ public class MacSpecifics {
 		 String javaVersion = System.getProperty("java.specification.version");
 		  log.info("Is running on MacOS: " + SWTJBTExt.isRunningOnMacOs());
 		  log.info("Java version: " + javaVersion);
-		  if ("1.7".equals(javaVersion)){
+		  if ("1.7".equals(javaVersion) || "1.8".equals(javaVersion)){
 			  log.info("default AWT toolkit: " + System.getProperty("awt.toolkit"));
 			  System.setProperty("awt.toolkit", "sun.lwawt.macosx.LWCToolkit");
 			  log.info("AWT toolkit changed to: " + System.getProperty("awt.toolkit"));

--- a/tests/org.jboss.tools.dummy.ui.bot.test/src/org/jboss/tools/dummy/ui/bot/test/DummyTest.java
+++ b/tests/org.jboss.tools.dummy.ui.bot.test/src/org/jboss/tools/dummy/ui/bot/test/DummyTest.java
@@ -9,6 +9,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.jboss.tools.ui.bot.ext.config.Annotations.Require;
+import org.jboss.tools.ui.bot.ext.MacSpecifics;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -25,6 +26,7 @@ public class DummyTest {
 	
 	@BeforeClass
 	public static void before() {		
+		MacSpecifics.setupToolkit();
 	}
 
 	@Test


### PR DESCRIPTION
This should finally make the dummy test work on all macs again. First, it adds
a new condition so that the awt.toolkit property is set correctly for both
java 1.7 and 1.8 on mac. Also, this commit adds a direct call to MacSpecifics
from within the dummy test (which does not use RequirementAwareSuite).
