### PR TITLE
Lower -XX:MaxPermSize to 384m because of Windows 32-bit

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -14,7 +14,7 @@
   
         <properties>
             <surefire.timeout>7200</surefire.timeout>
-            <memoryOptions2>-XX:MaxPermSize=512m</memoryOptions2>
+            <memoryOptions2>-XX:MaxPermSize=384m</memoryOptions2>
             <swt.bot.test.record.screencast>false</swt.bot.test.record.screencast>
             <reddeer.close.shells>true</reddeer.close.shells>
             <reddeer.close.welcome.screen>true</reddeer.close.welcome.screen>


### PR DESCRIPTION
On Windows 8 32-bit, there is a problem where not enough memory
can be reserved for Java and the Eclipse process fails to start.

Let's see if this helps :)
