### PR TITLE
Reflects changes in JBT 4.2.0.Beta3

### DIFF
--- a/tests/org.jboss.tools.vpe.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.vpe.ui.bot.test/META-INF/MANIFEST.MF
@@ -32,7 +32,8 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.tools.vpe.browsersim;bundle-version="3.5.0",
  org.jboss.tools.vpe.browsersim.browser;bundle-version="3.5.1",
  org.jboss.tools.vpe.preview.editor;bundle-version="3.5.100",
- org.eclipse.debug.core;bundle-version="3.9.0"
+ org.eclipse.debug.core;bundle-version="3.9.0",
+ org.jboss.reddeer.swt;bundle-version="0.6.0"
 Eclipse-RegisterBuddy: org.apache.log4j
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/tests/org.jboss.tools.vpe.ui.bot.test/src/org/jboss/tools/vpe/ui/bot/test/editor/pagedesign/IncludedCssFilesTest.java
+++ b/tests/org.jboss.tools.vpe.ui.bot.test/src/org/jboss/tools/vpe/ui/bot/test/editor/pagedesign/IncludedCssFilesTest.java
@@ -30,6 +30,7 @@ import org.jboss.tools.ui.bot.ext.parts.SWTBotEditorExt;
 import org.jboss.tools.ui.bot.ext.types.IDELabel;
 import org.jboss.tools.ui.bot.ext.types.JobName;
 import org.jboss.tools.vpe.ui.bot.test.VPEAutoTestCase;
+import org.junit.Ignore;
 
 /**
  * Tests functionality of Included CSS Files tab page of Page Design Options Dialog 
@@ -43,7 +44,8 @@ public class IncludedCssFilesTest extends PageDesignTestCase {
   
   private SWTBot addCssReferenceDialogBot = null;
   private SWTBot optionsDialogBot  = null;
-    
+  // Page Design option is not supported for HTML for now
+  @Ignore  
   public void testIncludedCssFiles() throws IOException{
     SWTBotTree tree = packageExplorer.show().bot().tree();
     tree.expandNode(VPEAutoTestCase.JBT_TEST_PROJECT_NAME)

--- a/tests/org.jboss.tools.vpe.ui.bot.test/src/org/jboss/tools/vpe/ui/bot/test/editor/pagedesign/ToolbarTextFormattingTest.java
+++ b/tests/org.jboss.tools.vpe.ui.bot.test/src/org/jboss/tools/vpe/ui/bot/test/editor/pagedesign/ToolbarTextFormattingTest.java
@@ -96,7 +96,7 @@ public class ToolbarTextFormattingTest extends VPEAutoTestCase {
 	  SWTBotToolbarToggleButton italicButton = editorBot.toolbarToggleButtonWithTooltip(IDELabel.VisualPageEditor.ITALIC_TOOLBAR_BUTTON_LABEL);
 	  SWTBotToolbarToggleButton underlinedButton = editorBot.toolbarToggleButtonWithTooltip(IDELabel.VisualPageEditor.UNDERLINE_TOOLBAR_BUTTON_LABEL);
 	  // Check if Text Format Buttons buttons are enabled within VPE Editor
-	  assertToolbarButtonIsEnabled(boldButton);
+	  assertToolbarButtonIsEnabled(boldButton,"https://issues.jboss.org/browse/JBIDE-16938");
 	  assertToolbarButtonIsEnabled(italicButton);
 	  assertToolbarButtonIsEnabled(underlinedButton);
 	  boldButton.click();
@@ -177,14 +177,29 @@ public class ToolbarTextFormattingTest extends VPEAutoTestCase {
 	      "Expected text is: '" + expectedLineText + "'.",
 	    lineText.endsWith(expectedLineText ));
 	}
-	 /**
-   * Asserts if Toolbar Button is enabled
-   * @param toolbarButton
-   */
-  private void assertToolbarButtonIsEnabled (SWTBotToolbarButton toolbarButton){
-    assertTrue (toolbarButton.getToolTipText() + " Toolbar Button has to be enabled but it is not.",
-      toolbarButton.isEnabled());
-  }
+
+	/**
+	 * Asserts if Toolbar Button is enabled
+	 * 
+	 * @param toolbarButton
+	 */
+	private void assertToolbarButtonIsEnabled(SWTBotToolbarButton toolbarButton) {
+		assertToolbarButtonIsEnabled(toolbarButton,toolbarButton.getToolTipText()
+				+ " Toolbar Button has to be enabled but it is not.");
+	}
+
+	/**
+	 * Asserts if Toolbar Button is enabled
+	 * 
+	 * @param toolbarButton
+	 */
+	private void assertToolbarButtonIsEnabled(
+			SWTBotToolbarButton toolbarButton, String message) {
+		assertTrue(toolbarButton.getToolTipText()
+				+ " Toolbar Button has to be enabled but it is not."
+				+ ((message == null || message.length() == 0) ? "" : message),
+				toolbarButton.isEnabled());
+	}
   /**
    * Asserts Toolbar Button selection
    * @param expectedSelection

--- a/tests/org.jboss.tools.vpe.ui.bot.test/src/org/jboss/tools/vpe/ui/bot/test/editor/preferences/AlwaysHideSelectionBarWithoutPromptTest.java
+++ b/tests/org.jboss.tools.vpe.ui.bot.test/src/org/jboss/tools/vpe/ui/bot/test/editor/preferences/AlwaysHideSelectionBarWithoutPromptTest.java
@@ -27,7 +27,7 @@ public class AlwaysHideSelectionBarWithoutPromptTest extends PreferencesTestCase
 		
 		closePage();
 		openPage();
-		checkIsHide();
+		checkIsHide("https://issues.jboss.org/browse/JBIDE-17896");
 		
 		//Test Show Selection Bar
 		
@@ -60,13 +60,17 @@ public class AlwaysHideSelectionBarWithoutPromptTest extends PreferencesTestCase
 	}
 	
 	private void checkIsHide(){
+		checkIsHide("Toolbar button " + HID_SEL_BAR + " is not hidden");
+	}
+	
+	private void checkIsHide(String message){
 		WidgetNotFoundException exception = null;
 		try {
 			bot.toolbarButtonWithTooltip(HID_SEL_BAR);
 		} catch (WidgetNotFoundException e) {
 			exception = e;
 		}
-		assertNotNull(exception);
+		assertNotNull(message,exception);
 	}
 	
 	private void checkIsShow(){

--- a/tests/org.jboss.tools.vpe.ui.bot.test/src/org/jboss/tools/vpe/ui/bot/test/editor/preferences/ShowSelectionTagBarTest.java
+++ b/tests/org.jboss.tools.vpe.ui.bot.test/src/org/jboss/tools/vpe/ui/bot/test/editor/preferences/ShowSelectionTagBarTest.java
@@ -27,7 +27,7 @@ public class ShowSelectionTagBarTest extends PreferencesTestCase{
 		
 		closePage();
 		openPage();
-		checkIsHide();
+		checkIsHide("https://issues.jboss.org/browse/JBIDE-17896");
 		
 		//Test Show Selection Bar
 		
@@ -54,13 +54,17 @@ public class ShowSelectionTagBarTest extends PreferencesTestCase{
 	}
 
 	private void checkIsHide(){
+		checkIsHide("Toolbar" + HID_SEL_BAR + " is not hidden");
+	}
+	
+	private void checkIsHide(String message){
 		WidgetNotFoundException exception = null;
 		try {
 			bot.toolbarButtonWithTooltip(HID_SEL_BAR);
 		} catch (WidgetNotFoundException e) {
 			exception = e;
 		}
-		assertNotNull(exception);
+		assertNotNull(message,exception);
 	}
 	
 	private void checkIsShow(){

--- a/tests/org.jboss.tools.vpe.ui.bot.test/src/org/jboss/tools/vpe/ui/bot/test/wizard/ExternalizeStringsDialogTest.java
+++ b/tests/org.jboss.tools.vpe.ui.bot.test/src/org/jboss/tools/vpe/ui/bot/test/wizard/ExternalizeStringsDialogTest.java
@@ -12,6 +12,7 @@ package org.jboss.tools.vpe.ui.bot.test.wizard;
 
 import java.awt.event.KeyEvent;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEclipseEditor;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEditor;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
@@ -23,6 +24,7 @@ import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTable;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotText;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotToolbarButton;
+import org.jboss.reddeer.swt.keyboard.KeyboardFactory;
 import org.jboss.tools.vpe.ui.bot.test.VPEAutoTestCase;
 import org.jboss.tools.jst.web.ui.internal.editor.messages.JstUIMessages;
 import org.jboss.tools.ui.bot.ext.SWTJBTExt;
@@ -47,8 +49,8 @@ public class ExternalizeStringsDialogTest extends VPEAutoTestCase {
 		+ "\t ;.df:,ee {df}df[ty]"; //$NON-NLS-1$
 	private final String COMPLEX_KEY_RESULT = "HELLO_Input_User_Name_Page_and" + //$NON-NLS-1$
 			"_some_more_text_vc_yy_ghg_l_kk_mmm_fdg_df_ee_df_df_ty"; //$NON-NLS-1$
-	private final String COMPLEX_VALUE_RESULT = "\\r\\n!! HELLO ~ Input User, Name.Page ? \\r\\n\\r\\n and some more text " + //$NON-NLS-1$
-      "\\r\\n \\r\\n @ \\# vc \\$ % yy^ &*(ghg ) _l-kk+mmm\\/fdg\\ \\t ;.df:,ee {df}df[ty]\\r\\n\\t\\t";; //$NON-NLS-1$
+	private final String COMPLEX_VALUE_RESULT = "\\r\\n!! HELLO ~ Input User, Name.Page ? \\r\\n and some more text " + //$NON-NLS-1$
+      "\\r\\n@ \\# vc \\$ % yy^ &*(ghg ) _l-kk+mmm\\/fdg\\ \\t ;.df:,ee {df}df[ty]\\r\\n\\t\\t";; //$NON-NLS-1$
 	
 	private boolean isUnusedDialogOpened = false;
 	
@@ -159,6 +161,7 @@ public class ExternalizeStringsDialogTest extends VPEAutoTestCase {
 		SWTBotEditor editor2 = SWTTestExt.eclipse.openFile(
 				JBT_TEST_PROJECT_NAME, "JavaSource", "demo", //$NON-NLS-1$ //$NON-NLS-2$
 				"Messages.properties"); //$NON-NLS-1$
+		editor2.bot().cTabItem("Source").activate();
 		editor2.toTextEditor().selectLine(3);
 		String line = editor2.toTextEditor().getSelection();
 		assertEquals("'Messages.properties' was updated incorrectly", "User=User", line); //$NON-NLS-1$ //$NON-NLS-2$
@@ -217,7 +220,8 @@ public class ExternalizeStringsDialogTest extends VPEAutoTestCase {
 		 * And externalize the same string again.
 		 */
 		bot.cTabItem("Source").activate(); //$NON-NLS-1$
-		editor2.toTextEditor().typeText(3,9, "1"); //$NON-NLS-1$
+ 		editor2.setFocus();
+		editor2.toTextEditor().setText(editor2.toTextEditor().getText() + "1");
 		editor2.saveAndClose();
 		editor = SWTTestExt.packageExplorer.openFile(JBT_TEST_PROJECT_NAME,
 				"WebContent", "pages", TEST_PAGE); //$NON-NLS-1$ //$NON-NLS-2$
@@ -351,6 +355,7 @@ public class ExternalizeStringsDialogTest extends VPEAutoTestCase {
 		 * In the 3rd line should be results from the previous test "User=User".
 		 * If previous test failed -- it could crash this one as well.
 		 */
+		editor2.bot().cTabItem("Source").activate();
 		editor2.toTextEditor().selectLine(5);
 		String line = editor2.toTextEditor().getSelection();
 		assertEquals("'Messages.properties' was updated incorrectly", "user.compoundKey=User", line); //$NON-NLS-1$ //$NON-NLS-2$
@@ -498,12 +503,12 @@ public class ExternalizeStringsDialogTest extends VPEAutoTestCase {
 		/*
 		 * Select some text
 		 */
-		editor.toTextEditor().navigateTo(21, 40);
+		editor.toTextEditor().navigateTo(21, 50);
 		/*
 		 * Send key press event to fire VPE listeners
 		 */
 		editor.setFocus();
-		KeyboardHelper.typeKeyCodeUsingAWT(KeyEvent.VK_LEFT);
+		KeyboardFactory.getKeyboard().invokeKeyCombination(SWT.ARROW_RIGHT);
 		/*
 		 * Activate the dialog
 		 */
@@ -529,7 +534,9 @@ public class ExternalizeStringsDialogTest extends VPEAutoTestCase {
 		/*
 		 * Type some text outside the tag
 		 */
-		editor.toTextEditor().typeText(13, 0, COMPLEX_TEXT);
+		editor.setFocus();
+		editor.toTextEditor().selectRange(13, 0, 0);
+		editor.toTextEditor().insertText(COMPLEX_TEXT);
 		/*
 		 * Select nothing and call the dialog --
 		 * the whole text should be selected.
@@ -566,7 +573,8 @@ public class ExternalizeStringsDialogTest extends VPEAutoTestCase {
 		/*
 		 * Check selection in the attribute's value
 		 */
-		editor.toTextEditor().selectRange(22, 50, 0);
+		editor.save();
+ 		editor.toTextEditor().selectRange(19, 109, 0);
 		KeyboardHelper.typeKeyCodeUsingAWT(KeyEvent.VK_RIGHT);
 		util.waitForAll();
 		/*
@@ -603,7 +611,9 @@ public class ExternalizeStringsDialogTest extends VPEAutoTestCase {
 		 * Select some text
 		 */
 		editor.toTextEditor().selectLine(3);
-		editor.toTextEditor().typeText("Plain text"); //$NON-NLS-1$
+		editor.toTextEditor().insertText("Plain text"); //$NON-NLS-1$
+		editor.toTextEditor().selectRange(3, 3, 0);
+		editor.save();
 		/*
 		 * Activate the dialog
 		 */
@@ -683,9 +693,10 @@ public class ExternalizeStringsDialogTest extends VPEAutoTestCase {
 		SWTBotEditor editor2 = SWTTestExt.eclipse.openFile(
 				JBT_TEST_PROJECT_NAME, "JavaSource", //$NON-NLS-1$
 				"hello.properties"); //$NON-NLS-1$
+		editor2.bot().cTabItem("Source").activate();
 		editor2.toTextEditor().selectLine(0);
 		String line = editor2.toTextEditor().getSelection();
-		assertEquals("Created file is incorrect", "Plain_text=\\r\\n\\r\\nPlain text\\r\\n\\r\\n", line); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals("Created file is incorrect", "Plain_text=\\r\\n\\r\\nPlain\\ text\\r\\n\\r\\n", line); //$NON-NLS-1$ //$NON-NLS-2$
 		/*
 		 * Reopen the page, and check that the new file 
 		 * for existed properties file won't be created.
@@ -698,7 +709,9 @@ public class ExternalizeStringsDialogTest extends VPEAutoTestCase {
 		 * Select some text
 		 */
 		editor.toTextEditor().selectLine(3);
-		editor.toTextEditor().typeText("Plain text"); //$NON-NLS-1$
+		editor.toTextEditor().insertText("Plain text"); //$NON-NLS-1$
+		editor.toTextEditor().selectRange(3, 3, 0);
+		editor.save();
 		/*
 		 * Activate the dialog
 		 */
@@ -901,7 +914,7 @@ public class ExternalizeStringsDialogTest extends VPEAutoTestCase {
 		editor.setFocus();
 		editor.save();
 		editor.toTextEditor().selectLine(1);
-		assertEquals("Taglig insertion failed!", //$NON-NLS-1$
+		assertEquals("https://issues.jboss.org/browse/JBIDE-17920\nTaglig insertion failed!", //$NON-NLS-1$
 				"<%@ taglib uri=\"http://java.sun.com/jsf/core\" prefix=\"f\"%>", //$NON-NLS-1$
 				editor.toTextEditor().getSelection());
 	}
@@ -983,7 +996,7 @@ public class ExternalizeStringsDialogTest extends VPEAutoTestCase {
 		 */
 		editor.setFocus();
 		editor.toTextEditor().selectLine(6);
-		assertEquals("Taglig insertion failed!", //$NON-NLS-1$
+		assertEquals("https://issues.jboss.org/browse/JBIDE-17920\nTaglig insertion failed!", //$NON-NLS-1$
 			      "      xmlns:f=\"http://java.sun.com/jsf/core\">", //$NON-NLS-1$
 				editor.toTextEditor().getSelection());
 	}
@@ -1009,7 +1022,7 @@ public class ExternalizeStringsDialogTest extends VPEAutoTestCase {
 		/*
 		 * Send key press event to fire VPE listeners
 		 */
-		KeyboardHelper.typeKeyCodeUsingAWT(KeyEvent.VK_LEFT);
+		KeyboardHelper.typeKeyCodeUsingAWT(KeyEvent.VK_RIGHT);
 		bot.sleep(Timing.time1S());
 		/*
 		 * Get toolbar button


### PR DESCRIPTION
- fixes changed labels of VPE toolbar items
- fixes OpenOnHelper using RedDeer Keyboard
- fixes editing issues when externalization test runs
- activate Source tab when editing properties via Properties editor
- add links to Jira to assertions of failed tests
- ignore IncludedCSSFilesTest
