### PR TITLE
Unify the use of swtbot.test.skip

### DIFF
--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/pom.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/pom.xml
@@ -12,7 +12,6 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
-		<swtbot.test.skip>false</swtbot.test.skip>
 		<maven.test.failure.ignore>true</maven.test.failure.ignore>
 		<requirementsDirectory>${project.build.directory}/requirements</requirementsDirectory>
 		<runtimesProperties></runtimesProperties>
@@ -33,8 +32,8 @@
 				<platformSystemProperties> -d32 -Dosgi.arch=x86 -XstartOnFirstThread -Dorg.eclipse.swtbot.keyboard.layout=MAC_EN_US</platformSystemProperties>
 			</properties>
 		</profile>
-		
-		
+
+
 		<profile>
 			<id>projects</id>
 			<activation>
@@ -58,7 +57,7 @@
 			<build>
 			<plugins><plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>maven-download-plugin</artifactId>
+				<artifactId>download-maven-plugin</artifactId>
 				<executions>
 					<execution>
 						<id>install-as-3.2.8</id>
@@ -176,7 +175,7 @@
 			</plugin></plugins>
 			</build>
 		</profile>
-		
+
 		<profile>
 			<id>projects-stable</id>
 			<activation>
@@ -196,7 +195,7 @@
 			<build>
 			<plugins><plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>maven-download-plugin</artifactId>
+				<artifactId>download-maven-plugin</artifactId>
 				<executions>
 					<execution>
 						<id>install-as-6.1.0</id>
@@ -249,7 +248,7 @@
 			</plugin></plugins>
 			</build>
 		</profile>
-		
+
 		<profile>
 			<id>eap5</id>
 			<activation>
@@ -268,7 +267,7 @@
 			<build>
 			<plugins><plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>maven-download-plugin</artifactId>
+				<artifactId>download-maven-plugin</artifactId>
 				<executions>
 					<execution>
 						<id>install-eap-5</id>
@@ -304,7 +303,7 @@
 			<build>
 			<plugins><plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>maven-download-plugin</artifactId>
+				<artifactId>download-maven-plugin</artifactId>
 				<executions>
 					<execution>
 						<id>install-eap-6.0</id>
@@ -340,7 +339,7 @@
 			<build>
 			<plugins><plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>maven-download-plugin</artifactId>
+				<artifactId>download-maven-plugin</artifactId>
 				<executions>
 					<execution>
 						<id>install-eap-6.x</id>
@@ -376,7 +375,7 @@
 			<build>
 			<plugins><plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>maven-download-plugin</artifactId>
+				<artifactId>download-maven-plugin</artifactId>
 				<executions>
 					<execution>
 						<id>install-wildfly-8</id>
@@ -394,7 +393,7 @@
 			</build>
 		</profile>
 	</profiles>
-	
+
 	<build>
 		<resources>
 				<resource>
@@ -409,14 +408,12 @@
 		<plugins>
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>maven-download-plugin</artifactId>
-				<version>0.2-SNAPSHOT</version>
+				<artifactId>download-maven-plugin</artifactId>
 				<configuration>
-					<skip>${skipRequirements}</skip>
 					<outputDirectory>${requirementsDirectory}</outputDirectory>
 				</configuration>
 			</plugin>
-		
+
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
@@ -426,7 +423,6 @@
 					<forkedProcessTimeoutInSeconds>7200</forkedProcessTimeoutInSeconds>
 					<testSuite>org.jboss.ide.eclipse.as.ui.bot.test</testSuite>
 					<testClass>${test.class}</testClass>
-					<skip>${swtbot.test.skip}</skip>
 					<explodedBundles>
 						<bundle>org.mozilla.xulrunner.cocoa.macosx</bundle>
 						<bundle>org.mozilla.xulrunner.gtk.linux.x86</bundle>

--- a/tests/org.jboss.tools.aerogear.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.aerogear.ui.bot.test/pom.xml
@@ -21,8 +21,6 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
-					<skip>${swtbot.test.skip}</skip>
-					<useUIThread>false</useUIThread>
 					<testSuite>org.jboss.tools.aerogear.ui.bot.test</testSuite>
 					<testClass>org.jboss.tools.aerogear.ui.bot.test.AerogearAllBotTests</testClass>
 					<dependencies combine.children="append">

--- a/tests/org.jboss.tools.archives.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.archives.ui.bot.test/pom.xml
@@ -7,7 +7,7 @@
 		<artifactId>tests</artifactId>
 		<version>4.2.0-SNAPSHOT</version>
 	</parent>
-	
+
 	<groupId>org.jboss.tools.archives.tests</groupId>
 	<artifactId>org.jboss.tools.archives.ui.bot.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
@@ -32,6 +32,7 @@
 							<goal>unpack</goal>
 						</goals>
 						<configuration>
+							<skip>${swtbot.test.skip}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.jboss.as</groupId>
@@ -50,8 +51,6 @@
 				<configuration>
 					<testSuite>org.jboss.tools.archives.ui.bot.test</testSuite>
 					<testClass>${suiteClass}</testClass>
-					<useUIThread>false</useUIThread>
-					<skip>${swtbot.test.skip}</skip>
 					<dependencies combine.children="append">
 						<dependency>
 							<type>p2-installable-unit</type>
@@ -113,7 +112,7 @@
 				</plugin>
 				<plugin>
 					<groupId>com.googlecode.maven-download-plugin</groupId>
-					<artifactId>maven-download-plugin</artifactId>
+					<artifactId>download-maven-plugin</artifactId>
 					<executions>
 						<execution>
 							<id>install-as-7.1.1</id>

--- a/tests/org.jboss.tools.cdi.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.bot.test/pom.xml
@@ -60,8 +60,6 @@
 				<configuration>
 					<testSuite>org.jboss.tools.cdi.bot.test</testSuite>
 					<testClass>${suiteClass}</testClass>
-					<useUIThread>false</useUIThread>
-					<skip>${swtbot.test.skip}</skip>
 					<!-- Kill swt bot test take more than 3 hours minutes (10800 seconds) 
 						to finish -->
 					<dependencies combine.children="append">

--- a/tests/org.jboss.tools.cdi.seam3.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.seam3.bot.test/pom.xml
@@ -48,8 +48,6 @@
 				<configuration>
 					<testSuite>org.jboss.tools.cdi.seam3.bot.test</testSuite>
 					<testClass>${suiteClass}</testClass>
-					<useUIThread>false</useUIThread>
-					<skip>${swtbot.test.skip}</skip>
 					<dependencies combine.children="append">
 						<dependency>
 							<type>p2-installable-unit</type>

--- a/tests/org.jboss.tools.central.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.central.ui.bot.test/pom.xml
@@ -30,7 +30,7 @@
 				<plugins>
 					<plugin>
 						<groupId>com.googlecode.maven-download-plugin</groupId>
-						<artifactId>maven-download-plugin</artifactId>
+						<artifactId>download-maven-plugin</artifactId>
 						<executions>
 							<execution>
 								<id>install-wildfly-8</id>
@@ -67,8 +67,6 @@
 				<configuration>
 					<testSuite>org.jboss.tools.central.ui.bot.test</testSuite>
 					<testClass>org.jboss.tools.central.test.ui.reddeer.AllTestsSuite</testClass>
-					<useUIThread>false</useUIThread>
-					<skip>false</skip>
 					<dependencies combine.children="append">
 						<dependency>
 							<type>p2-installable-unit</type>

--- a/tests/org.jboss.tools.deltaspike.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.deltaspike.ui.bot.test/pom.xml
@@ -84,8 +84,6 @@
 				<configuration>
 					<testSuite>org.jboss.tools.deltaspike.ui.bot.test</testSuite>
 					<testClass>${suiteClass}</testClass>
-					<useUIThread>false</useUIThread>
-					<skip>${swtbot.test.skip}</skip>
 					<dependencies combine.children="append">
 						<dependency>
 							<type>p2-installable-unit</type>

--- a/tests/org.jboss.tools.dummy.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.dummy.ui.bot.test/pom.xml
@@ -18,10 +18,8 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
-					<useUIThread>false</useUIThread>
 					<testSuite>org.jboss.tools.dummy.ui.bot.test</testSuite>
 					<testClass>org.jboss.tools.dummy.ui.bot.test.DummySuite</testClass>
-					<skip>${swtbot.test.skip}</skip>
 					<dependencies combine.children="append">
 						<dependency>
 							<type>p2-installable-unit</type>

--- a/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
@@ -23,7 +23,6 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
-					<useUIThread>false</useUIThread>
 					<testSuite>org.jboss.tools.examples.ui.bot.test</testSuite>
 					<testClass>org.jboss.tools.examples.ui.bot.test.ImportExamplesTest</testClass>
 					<dependencies>

--- a/tests/org.jboss.tools.forge.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.forge.ui.bot.test/pom.xml
@@ -41,7 +41,7 @@
 										<type>zip</type>
 									</artifactItem>
 								</artifactItems>
-							<skip>${skipRequirements}</skip>
+							<skip>${swtbot.test.skip}</skip>
 						</configuration>
 					</execution>
                                         <execution>
@@ -59,7 +59,7 @@
                                                                                 <type>zip</type>
                                                                         </artifactItem>
                                                                 </artifactItems>
-                                                        <skip>${skipRequirements}</skip>
+                                                        <skip>${swtbot.test.skip}</skip>
                                                 </configuration>
                                         </execution>
                                 </executions>
@@ -70,8 +70,6 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
-					<useUIThread>false</useUIThread>
-					<skip>${swtbot.test.skip}</skip>
 					<testSuite>org.jboss.tools.forge.ui.bot.test</testSuite>
 					<testClass>org.jboss.tools.forge.ui.bot.test.suite.ForgeAllTest</testClass>
 					<dependencies combine.children="append">

--- a/tests/org.jboss.tools.freemarker.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.freemarker.ui.bot.test/pom.xml
@@ -19,10 +19,8 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
-					<useUIThread>false</useUIThread>
 					<testSuite>org.jboss.tools.freemarker.ui.bot.test</testSuite>
 					<testClass>org.jboss.tools.freemarker.ui.bot.test.FreeMarkerSuite</testClass>
-					<skip>${swtbot.test.skip}</skip>
 					<dependencies combine.children="append">
 						<dependency>
 							<type>p2-installable-unit</type>

--- a/tests/org.jboss.tools.hibernate.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.hibernate.ui.bot.test/pom.xml
@@ -23,8 +23,6 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
-					<useUIThread>false</useUIThread>
-					<skip>${swtbot.test.skip}</skip>
 					<testSuite>org.jboss.tools.hibernate.ui.bot.test</testSuite>
 					<testClass>org.jboss.tools.hibernate.ui.bot.test.HibernateAllTest</testClass>
 					<!-- <dependencies combine.children="append"> <dependency> <type>p2-installable-unit</type> 
@@ -39,7 +37,7 @@
 			</plugin>
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>maven-download-plugin</artifactId>
+				<artifactId>download-maven-plugin</artifactId>
 				<executions>
 					<execution>
 						<id>install-h2-driver</id>

--- a/tests/org.jboss.tools.jsf.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.jsf.ui.bot.test/pom.xml
@@ -57,8 +57,6 @@
         <configuration>
           <testSuite>org.jboss.tools.jsf.ui.bot.test</testSuite>
           <testClass>${test.suite.class}</testClass>
-          <useUIThread>false</useUIThread>
-          <skip>${swtbot.test.skip}</skip>
           <product>org.eclipse.platform.ide</product>
           <dependencies combine.children="append">
             <dependency>

--- a/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
@@ -54,7 +54,7 @@
 									<type>zip</type>
 								</artifactItem>
 							</artifactItems>
-							<skip>${skipRequirements}</skip>
+							<skip>${swtbot.test.skip}</skip>
 						</configuration>
 					</execution>
 					<execution>
@@ -73,7 +73,7 @@
 									<type>jar</type>
 								</artifactItem>
 							</artifactItems>
-							<skip>${skipRequirements}</skip>
+							<skip>${swtbot.test.skip}</skip>
 						</configuration>
 					</execution>
 					<execution>
@@ -92,14 +92,14 @@
 									<type>zip</type>
 								</artifactItem>
 							</artifactItems>
-							<skip>${skipRequirements}</skip>
+							<skip>${swtbot.test.skip}</skip>
 						</configuration>
 					</execution>
 				</executions>
 			</plugin>
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>maven-download-plugin</artifactId>
+				<artifactId>download-maven-plugin</artifactId>
 				<executions>
 					<execution>
 						<id>install-seam22</id>
@@ -131,8 +131,6 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
-					<useUIThread>false</useUIThread>
-					<skip>${swtbot.test.skip}</skip>
 					<testSuite>org.jboss.tools.maven.ui.bot.test</testSuite>
 					<testClass>${suiteClass}</testClass>
 				</configuration>

--- a/tests/org.jboss.tools.mylyn.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.mylyn.ui.bot.test/pom.xml
@@ -24,10 +24,8 @@
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
                     <product>${tychoPluginProductParameter}</product>
-                    <useUIThread>false</useUIThread>
                     <testSuite>org.jboss.tools.mylyn.ui.bot.test</testSuite>
                     <testClass>org.jboss.tools.mylyn.ui.bot.test.MylynSuite</testClass>
-                    <skip>${swtbot.test.skip}</skip>
                     <dependencies combine.children="append">
 
 <dependency>

--- a/tests/org.jboss.tools.openshift.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/pom.xml
@@ -23,8 +23,6 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
-					<skip>${swtbot.test.skip}</skip>
-					<useUIThread>false</useUIThread>
 					<testSuite>org.jboss.tools.openshift.ui.bot.test</testSuite>
 					<testClass>org.jboss.tools.openshift.ui.bot.test.OpenShift${scope}BotTests</testClass>
 					<dependencies combine.children="append">

--- a/tests/org.jboss.tools.portlet.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.portlet.ui.bot.test/pom.xml
@@ -39,7 +39,7 @@
 		<plugins>
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>maven-download-plugin</artifactId>
+				<artifactId>download-maven-plugin</artifactId>
 				<executions>
 					<execution>
 						<id>install-gatein-3.4</id>
@@ -126,7 +126,7 @@
 					</execution>
 				</executions>
 			</plugin>
-			
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
@@ -138,6 +138,7 @@
 							<goal>copy</goal>
 						</goals>
 						<configuration>
+							<skip>${swtbot.test.skip}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.jboss.tools.portlet.tests</groupId>
@@ -171,10 +172,8 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
-					<useUIThread>false</useUIThread>
 					<testSuite>org.jboss.tools.portlet.ui.bot.test</testSuite>
 					<testClass>${test.class}</testClass>
-					<skip>${swtbot.test.skip}</skip>
 					<explodedBundles>
 						<bundle>org.mozilla.xulrunner.cocoa.macosx</bundle>
 						<bundle>org.mozilla.xulrunner.gtk.linux.x86</bundle>

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/pom.xml
@@ -42,7 +42,7 @@
 				<jboss-jpp-6.1.x>${requirementsDirectory}/jboss-jpp-6.1.x/jboss-portal-6.1/</jboss-jpp-6.1.x>
 
 				<jboss-seam-2.3.x>${requirementsDirectory}/jboss-seam-2.3.x/jboss-wfk-2.5.0/jboss-seam-2.3.3.Final-redhat-1/</jboss-seam-2.3.x>
-				
+
 				<product-download-properties-file>resources/products-download.properties</product-download-properties-file>
 			</properties>
 			<build>
@@ -67,8 +67,7 @@
 					</plugin>
 					<plugin>
 						<groupId>com.googlecode.maven-download-plugin</groupId>
-						<artifactId>maven-download-plugin</artifactId>
-						<version>1.0.0</version>
+						<artifactId>download-maven-plugin</artifactId>
 						<executions>
 							<execution>
 								<id>install-eap-6.3</id>
@@ -194,6 +193,7 @@
 							<goal>unpack</goal>
 						</goals>
 						<configuration>
+							<skip>${swtbot.test.skip}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.wildfly</groupId>
@@ -212,6 +212,7 @@
 							<goal>unpack</goal>
 						</goals>
 						<configuration>
+							<skip>${swtbot.test.skip}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.wildfly</groupId>
@@ -230,6 +231,7 @@
 							<goal>unpack</goal>
 						</goals>
 						<configuration>
+							<skip>${swtbot.test.skip}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.jboss.as</groupId>
@@ -245,8 +247,7 @@
 			</plugin>
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>maven-download-plugin</artifactId>
-				<version>1.0.0</version>
+				<artifactId>download-maven-plugin</artifactId>
 				<executions>
 					<execution>
 						<id>install-seam-2.3.0.Final</id>
@@ -281,7 +282,6 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tychoVersion}</version>
 				<configuration>
-					<useUIThread>false</useUIThread>
 					<testSuite>org.jboss.tools.runtime.as.ui.bot.test</testSuite>
 					<testClass>${test.class}</testClass>
 					<dependencies combine.children="append">
@@ -295,7 +295,7 @@
 							<artifactId>org.jboss.tools.runtime.core.feature.feature.group</artifactId>
 							<version>0.0.0</version>
 						</dependency>
-						<!-- JBIDE-12583 o.j.t.runtime.as.detector classes are now in o.j.i.e.as.core, 
+						<!-- JBIDE-12583 o.j.t.runtime.as.detector classes are now in o.j.i.e.as.core,
 							so use o.j.i.e.as.feature instead -->
 						<dependency>
 							<type>p2-installable-unit</type>
@@ -338,7 +338,7 @@
 		</plugins>
 		<pluginManagement>
 			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings 
+				<!--This plugin's configuration is used to store Eclipse m2e settings
 					only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>

--- a/tests/org.jboss.tools.seam.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.seam.ui.bot.test/pom.xml
@@ -56,8 +56,6 @@
 			<configuration>
 				<testSuite>org.jboss.tools.seam.ui.bot.test</testSuite>
 				<testClass>${test.suite.class}</testClass>
-				<useUIThread>false</useUIThread>
-				<skip>${swtbot.test.skip}</skip>
 				<product>org.eclipse.platform.ide</product>
 				<dependencies combine.children="append">
 					<dependency>

--- a/tests/org.jboss.tools.usercase.ticketmonster.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.usercase.ticketmonster.ui.bot.test/pom.xml
@@ -19,7 +19,7 @@
 				<plugins>
 				<plugin>
 					<groupId>com.googlecode.maven-download-plugin</groupId>
-					<artifactId>maven-download-plugin</artifactId>
+					<artifactId>download-maven-plugin</artifactId>
 					<executions>
 						<execution>
 							<id>download_h2console</id>
@@ -63,8 +63,6 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
-					<useUIThread>false</useUIThread>
-					<skip>${swtbot.test.skip}</skip>
 					<testSuite>org.jboss.tools.usercase.ticketmonster.ui.bot.test</testSuite>
 					<testClass>org.jboss.tools.usercase.ticketmonster.ui.bot.test.TicketMonsterAllBotTest</testClass>
 				</configuration>

--- a/tests/org.jboss.tools.vpe.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.vpe.ui.bot.test/pom.xml
@@ -30,7 +30,7 @@
 						<goal>unpack</goal>
 					</goals>
 					<configuration>
-						<skip>${skipRequirements}</skip>
+						<skip>${swtbot.test.skip}</skip>
 						<artifactItems>
 							<artifactItem>
 								<groupId>org.jboss.as</groupId>
@@ -49,15 +49,13 @@
 				</execution>
 			</executions>
 		</plugin>
-    
+
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <configuration>
           <testSuite>org.jboss.tools.vpe.ui.bot.test</testSuite>
           <testClass>${test.suite.class}</testClass>
-          <useUIThread>false</useUIThread>
-          <skip>${swtbot.test.skip}</skip>
           <product>org.eclipse.platform.ide</product>
           <dependencies combine.children="append">
             <dependency>
@@ -94,7 +92,7 @@
               <type>p2-installable-unit</type>
               <artifactId>org.eclipse.jdt.feature.group</artifactId>
               <version>0.0.0</version>
-            </dependency> 
+            </dependency>
             <dependency>
               <type>p2-installable-unit</type>
               <artifactId>org.jboss.tools.vpe.browsersim.feature.feature.group</artifactId>

--- a/tests/org.jboss.tools.ws.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.ws.ui.bot.test/pom.xml
@@ -60,7 +60,7 @@
 							<goal>unpack</goal>
 						</goals>
 						<configuration>
-							<skip>${skipRequirements}</skip>
+							<skip>${swtbot.test.skip}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.wildfly</groupId>
@@ -75,8 +75,7 @@
 			</plugin>
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>maven-download-plugin</artifactId>
-				<version>1.0.0</version>
+				<artifactId>download-maven-plugin</artifactId>
 				<executions>
 					<execution>
 						<id>install-apache-cxf-2.x</id>
@@ -99,8 +98,6 @@
 				<configuration>
 					<testSuite>org.jboss.tools.ws.ui.bot.test</testSuite>
 					<testClass>org.jboss.tools.ws.ui.bot.test.WSAllBotTests</testClass>
-					<useUIThread>false</useUIThread>
-					<skip>${swtbot.test.skip}</skip>
 					<dependencies combine.children="append">
 						<dependency>
 							<type>p2-installable-unit</type>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -11,7 +11,7 @@
 	<artifactId>tests</artifactId>
 	<name>integration-tests.tests</name>
 	<packaging>pom</packaging>
-  
+
         <properties>
             <surefire.timeout>7200</surefire.timeout>
             <memoryOptions2>-XX:MaxPermSize=384m</memoryOptions2>
@@ -30,7 +30,7 @@
 		<module>org.jboss.tools.cdi.bot.test</module>
 		<module>org.jboss.tools.cdi.seam3.bot.test</module>
 		<module>org.jboss.tools.central.ui.bot.test</module>
-		<module>org.jboss.tools.deltaspike.ui.bot.test</module>		
+		<module>org.jboss.tools.deltaspike.ui.bot.test</module>
 		<module>org.jboss.tools.dummy.ui.bot.test</module>
 		<module>org.jboss.tools.examples.ui.bot.test</module>
 		<module>org.jboss.tools.forge.ui.bot.test</module>
@@ -62,13 +62,15 @@
 		        <memoryOptions2>-XX:MaxPermSize=384m</memoryOptions2>
 			</properties>
 		</profile>
-	</profiles>	
+	</profiles>
     <build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
+					<skip>${swtbot.test.skip}</skip>
+					<useUIThread>false</useUIThread>
 					<explodedBundles>
 						<bundle>org.mozilla.xulrunner.cocoa.macosx</bundle>
 						<bundle>org.mozilla.xulrunner.gtk.linux.x86</bundle>
@@ -95,7 +97,13 @@
 					</dependencies>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.googlecode.maven-download-plugin</groupId>
+				<artifactId>download-maven-plugin</artifactId>
+				<configuration>
+					<skip>${swtbot.test.skip}</skip>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>
-


### PR DESCRIPTION
The property swtbot.test.skip is set in the jbt parent pom.
in the past most, but not all, tests used it to configure
<skip> for tycho-surefire-plugin. Now I moved this config to
tests/pom.xml so that it's consistently used everywhere.
At the same time, I changed maven-download-plugin definitions
to download-maven-plugin where applicable - this is the new artifactID.
And I set up the skip there as well. Same for maven-dependency-plugin.
