### PR TITLE
Disable mylyn tests - JBIDE-18000 plus RedDeer refactorings

### DIFF
--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -27,7 +27,9 @@
 		<module>org.jboss.tools.jst.reddeer</module>
 		<module>org.jboss.tools.seam.reddeer</module>
 		<module>org.jboss.tools.perf.test.core</module>
+<!-- Disable mylyn.reddeer - need to update for https://github.com/jboss-reddeer/reddeer/pull/527
 		<module>org.jboss.tools.mylyn.reddeer</module>
+-->
 		<module>org.jboss.tools.central.reddeer</module>
 		<module>org.jboss.tools.runtime.reddeer</module>
 	</modules>

--- a/site/category.xml
+++ b/site/category.xml
@@ -45,7 +45,9 @@
 <bundle id="org.jboss.tools.jsf.ui.bot.test"><category name="JBoss Tools Core - Integration Tests"/></bundle>
 <bundle id="org.jboss.tools.maven.ui.bot.test"><category name="JBoss Tools Core - Integration Tests"/></bundle>
 <bundle id="org.jboss.tools.maven.reddeer"><category name="JBoss Tools Core - Integration Tests"/></bundle>
+<!-- Disabled mylyn until https://issues.jboss.org/browse/JBIDE-18000 is fixed
 <bundle id="org.jboss.tools.mylyn.ui.bot.test"><category name="JBoss Tools Core - Integration Tests"/></bundle>
+-->
 <bundle id="org.jboss.tools.openshift.ui.bot.test"><category name="JBoss Tools Core - Integration Tests"/></bundle>
 <bundle id="org.jboss.tools.portlet.ui.bot.test"><category name="JBoss Tools Core - Integration Tests"/></bundle>
 <bundle id="org.jboss.tools.runtime.as.ui.bot.test"><category name="JBoss Tools Core - Integration Tests"/></bundle>
@@ -54,7 +56,9 @@
 <bundle id="org.jboss.tools.vpe.ui.bot.test"><category name="JBoss Tools Core - Integration Tests"/></bundle>
 <bundle id="org.jboss.tools.ws.ui.bot.test"><category name="JBoss Tools Core - Integration Tests"/></bundle>
 <bundle id="org.jboss.tools.usercase.ticketmonster.ui.bot.test"><category name="JBoss Tools Core - Integration Tests"/></bundle>
+<!-- Disable mylyn.reddeer - need to update for https://github.com/jboss-reddeer/reddeer/pull/527
 <bundle id="org.jboss.tools.mylyn.reddeer"><category name="JBoss Tools Core - Integration Tests"/></bundle>
+-->
 
 <!-- sources -->
 
@@ -88,7 +92,9 @@
 <bundle id="org.jboss.tools.jsf.ui.bot.test.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle>
 <bundle id="org.jboss.tools.maven.ui.bot.test.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle>
 <bundle id="org.jboss.tools.maven.reddeer.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle>
+<!-- Disabled mylyn until https://issues.jboss.org/browse/JBIDE-18000 is fixed
 <bundle id="org.jboss.tools.mylyn.ui.bot.test.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle>
+-->
 <bundle id="org.jboss.tools.openshift.ui.bot.test.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle>
 <bundle id="org.jboss.tools.portlet.ui.bot.test.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle>
 <bundle id="org.jboss.tools.runtime.as.ui.bot.test.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle>
@@ -97,6 +103,8 @@
 <bundle id="org.jboss.tools.vpe.ui.bot.test.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle>
 <bundle id="org.jboss.tools.ws.ui.bot.test.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle>
 <bundle id="org.jboss.tools.usercase.ticketmonster.ui.bot.test.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle>
+<!-- Disable mylyn.reddeer - need to update for https://github.com/jboss-reddeer/reddeer/pull/527
 <bundle id="org.jboss.tools.mylyn.reddeer.source"><category name="JBoss Tools Core - Integration Test Sources"/></bundle>
+-->
 
 </site>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -38,7 +38,9 @@
 		<module>org.jboss.tools.hibernate.ui.bot.test</module>
 		<module>org.jboss.tools.jsf.ui.bot.test</module>
 		<module>org.jboss.tools.maven.ui.bot.test</module>
+<!-- Disable mylyn until https://issues.jboss.org/browse/JBIDE-18000 is resolved
 		<module>org.jboss.tools.mylyn.ui.bot.test</module>
+-->
 		<module>org.jboss.tools.openshift.ui.bot.test</module>
 		<module>org.jboss.tools.portlet.ui.bot.test</module>
 		<module>org.jboss.tools.runtime.as.ui.bot.test</module>


### PR DESCRIPTION
The integration tests repo fails to compile. This is because mylyn
test defines integration stack Alpha2 repo and that disappeared.
See https://issues.jboss.org/browse/JBIDE-18000 .
Also, mylyn.reddeer fails to compile because of changes introduced
in https://github.com/jboss-reddeer/reddeer/pull/527 . So that is
disabled as well.
