### PR TITLE
Revert "Temporarily disable artifacts from experimental nexus in perf plugin"

### DIFF
--- a/plugins/org.jboss.tools.perf.test.core/pom.xml
+++ b/plugins/org.jboss.tools.perf.test.core/pom.xml
@@ -31,7 +31,6 @@
 						</goals>
 						<configuration>
 							<artifactItems>
-<!-- Temporarily commented out artifacts from the experimental repo - access denied - reported at https://issues.jboss.org/browse/ORG-2244
 								<artifactItem>
 									<groupId>org.jboss.perf.test</groupId>
 									<artifactId>perf-test-client</artifactId>
@@ -48,7 +47,6 @@
 									<overWrite>true</overWrite>
 									<outputDirectory>${basedir}/resources/perftestlibs</outputDirectory>
 								</artifactItem>
--->
 								<artifactItem>
 									<groupId>com.google.code.gson</groupId>
 									<artifactId>gson</artifactId>


### PR DESCRIPTION
This reverts commit 687f33aa7d5d85b78be928264f723933810b3435.
https://issues.jboss.org/browse/ORG-2244 is now resolved -
 the jbosstools-experiments nexus repo is public again, so
the dependencies can be downloaded again.
