### PR TITLE
Add 'Known Problems' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,7 @@ In the master branch, these steps are needed:
 *   Update range for bot.ext in all manifests to the new version, e.g.:
 
         $ find . -iname manifest.mf|xargs perl -pi -e 's/\[4.1.0,4.2.0\)/[4.2.0,4.3.0)/' 
+
+## Known Problems 
+
+*   Ubuntu vncviewer skips 's' during input (see https://bugs.launchpad.net/ubuntu/+source/vnc4/+bug/658723 for workaround).


### PR DESCRIPTION
This fix adds reference to ubuntu related problem with vncserver when it skips
's' chars in input. This leads to test failures, because of test projects with
's' char in name could not be located in Projects. For example if test creates
projetc with name 'CordovaTestProject' the actula project created in workspace
has name 'CordovaTetProject' and test fails.
