### PR TITLE
Change parent pom to 4.2.0.Final-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.2.0.CR1-SNAPSHOT</version>
+		<version>4.2.0.Final-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>integration-tests</artifactId>


### PR DESCRIPTION
This is a bit overdue.
Once applied, this will be followed by tagging 4.2.0.Final. And then we'll move to 4.3.0.Alpha1.
