### PR TITLE
Set root pom to use RedDeer 0.6.1

### DIFF
--- a/plugins/org.jboss.tools.aerogear.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.aerogear.reddeer/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.swt;bundle-version="0.6.0",
  org.jboss.reddeer.workbench;bundle-version="0.6.0",
  org.jboss.reddeer.eclipse;bundle-version="0.6.0",
- org.jboss.reddeer.common;bundle-version="0.7.0"
+ org.jboss.reddeer.common;bundle-version="0.6.1"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Eclipse-BundleShape: jar

--- a/plugins/org.jboss.tools.common.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.common.reddeer/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.jboss.reddeer.swt,
  org.jboss.reddeer.junit,
  org.jboss.reddeer.common;bundle-version="0.6.0",
- org.jboss.reddeer.workbench;bundle-version="0.7.0"
+ org.jboss.reddeer.workbench;bundle-version="0.6.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Export-Package: org.jboss.tools.common.reddeer.preferences,

--- a/plugins/org.jboss.tools.forge.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.forge.reddeer/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.jboss.tools.forge.reddeer
 Bundle-Version: 4.2.0.qualifier
 Bundle-Activator: org.jboss.tools.forge.reddeer.Activator
 Require-Bundle: org.eclipse.core.runtime,
- org.jboss.reddeer.swt;bundle-version="0.7.0",
+ org.jboss.reddeer.swt;bundle-version="0.6.1",
  org.jboss.reddeer.workbench,
  org.jboss.reddeer.common,
  org.eclipse.ui,

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<!-- URLs needed to resolve dependencies at build time (see <repositories> below) and at install time (see site/pom.xml#associateSites) -->
 
 		<!-- predefined RedDeer sites, if you need to change default please redefine reddeer-site property in your test -->
-		<reddeer-master-site>http://download.jboss.org/jbosstools/builds/staging/RedDeer_master/all/repo/</reddeer-master-site>
+		<reddeer-master-site>http://download.jboss.org/jbosstools/updates/stable/luna/core/reddeer/0.6.1/</reddeer-master-site>
 		<reddeer-stable-site>http://download.jboss.org/jbosstools/updates/stable/luna/core/reddeer/0.5.0/</reddeer-stable-site>
 		<reddeer-site>${reddeer-master-site}</reddeer-site>
 

--- a/tests/org.jboss.tools.aerogear.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.aerogear.ui.bot.test/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.jface;bundle-version="0.6.0",
  org.jboss.tools.vpe.ui.bot.test;bundle-version="4.2.0",
  org.jboss.reddeer.eclipse;bundle-version="0.6.0",
- org.jboss.reddeer.workbench;bundle-version="0.7.0"
+ org.jboss.reddeer.workbench;bundle-version="0.6.1"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Eclipse-BundleShape: jar

--- a/tests/org.jboss.tools.dummy.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.dummy.ui.bot.test/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.ui,
  org.junit,
  org.jboss.reddeer.eclipse;bundle-version="0.6.0",
  org.jboss.reddeer.workbench;bundle-version="0.6.0",
- org.jboss.reddeer.common;bundle-version="0.7.0",
+ org.jboss.reddeer.common;bundle-version="0.6.1",
  org.jboss.reddeer.jface;bundle-version="0.6.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/tests/org.jboss.tools.examples.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.examples.ui.bot.test/META-INF/MANIFEST.MF
@@ -6,8 +6,8 @@ Bundle-Version: 4.2.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Require-Bundle: org.jboss.reddeer.common;bundle-version="0.7.0",
+Require-Bundle: org.jboss.reddeer.common;bundle-version="0.6.1",
  org.jboss.reddeer.swt,
  org.jboss.reddeer.eclipse,
  org.junit;bundle-version="4.8.2",
- org.jboss.reddeer.junit;bundle-version="0.7.0"
+ org.jboss.reddeer.junit;bundle-version="0.6.1"


### PR DESCRIPTION
This commited fixes the dependency on RedDeer to version 0.6.1
(which was released today for this purpose) so that the integration
tests are reproducible in the future.
