### PR TITLE
Runtime detection tests fixes fo JBDS 8.0.1.CR1

### DIFF
--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/download/RuntimeDownloadTestBase.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/download/RuntimeDownloadTestBase.java
@@ -77,8 +77,8 @@ public class RuntimeDownloadTestBase extends RuntimeDetectionTestCase {
 		new PushButton("Finish").click();
 		runtimeDownloadWizard = null;
 		
-		new WaitUntil(new JobIsRunning(), TimePeriod.NORMAL, false);
-		new WaitWhile(new JobIsRunning(), TimePeriod.VERY_LONG);
+		new WaitUntil(new JobIsRunning(), TimePeriod.VERY_LONG, false);
+		new WaitWhile(new JobIsRunning(), TimePeriod.getCustom(900));
 		
 		runtimeDetectionPage.ok();
 	}

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/template/OperateServerTemplate.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/template/OperateServerTemplate.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.fail;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.jboss.reddeer.eclipse.condition.ConsoleHasNoChange;
 import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
 import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
 import org.jboss.reddeer.eclipse.wst.server.ui.view.Server;
@@ -63,7 +64,7 @@ public abstract class OperateServerTemplate {
 	@Before
 	public void setUp(){
 		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
-		
+		serversView.open();
 		for(Server server : serversView.getServers()){
 			if(!server.getLabel().getName().equals(serversView.getServer(getServerName()).getLabel().getName())){
 				server.delete();
@@ -75,6 +76,7 @@ public abstract class OperateServerTemplate {
 	@After
 	public void cleanServerAndConsoleView() {
 		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
+		serversView.open();
 		for (Server server : serversView.getServers()) {
 			server.delete(true);
 		}
@@ -85,6 +87,7 @@ public abstract class OperateServerTemplate {
 	public void startServer() {
 		serversView.getServer(getServerName()).start();
 		final String state = "Started";
+		new WaitUntil(new ConsoleHasNoChange(TimePeriod.getCustom(5)), TimePeriod.LONG);
 		new WaitUntil(new ServerHasState(state));
 		
 		assertNoException("Starting server");
@@ -94,6 +97,7 @@ public abstract class OperateServerTemplate {
 	public void restartServer() {
 		serversView.getServer(getServerName()).restart();
 		final String state = "Started";
+		new WaitUntil(new ConsoleHasNoChange(TimePeriod.getCustom(5)), TimePeriod.LONG);
 		new WaitUntil(new ServerHasState(state));
 
 		assertNoException("Restarting server");
@@ -105,6 +109,7 @@ public abstract class OperateServerTemplate {
 	public void stopServer() {
 		serversView.getServer(getServerName()).stop();
 		final String state = "Stopped";
+		new WaitUntil(new ConsoleHasNoChange(TimePeriod.getCustom(5)), TimePeriod.LONG);
 		new WaitUntil(new ServerHasState(state));
 
 		assertNoException("Stopping server");

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/template/RuntimeDetectionTestCase.java
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/src/org/jboss/tools/runtime/as/ui/bot/test/template/RuntimeDetectionTestCase.java
@@ -33,9 +33,11 @@ public abstract class RuntimeDetectionTestCase {
 	protected SearchingForRuntimesDialog addPath(String path){
 		RuntimeUIActivator.getDefault().getModel().addRuntimePath(new RuntimePath(path));
 		runtimeDetectionPage = new RuntimeDetectionPreferencePage();
+		preferences.open();
 		preferences.select(runtimeDetectionPage);
 		if(!runtimeDetectionPage.getAllPaths().contains(path)) {
-			runtimeDetectionPage.cancel();
+			preferences.cancel();
+			preferences.open();
 			preferences.select(runtimeDetectionPage);
 		}
 		return runtimeDetectionPage.search();
@@ -43,40 +45,46 @@ public abstract class RuntimeDetectionTestCase {
 
 	protected SearchingForRuntimesDialog searchFirstPath(){
 		runtimeDetectionPage = new RuntimeDetectionPreferencePage();
+		preferences.open();
 		preferences.select(runtimeDetectionPage);
 		return runtimeDetectionPage.search();
 	}
 
 	protected void removeAllPaths(){
+		preferences.open();
 		preferences.select(runtimeDetectionPage);
 		runtimeDetectionPage.removeAllPaths();
-		runtimeDetectionPage.ok();
+		preferences.ok();
 	}
 
 	protected void removeAllSeamRuntimes(){
+		preferences.open();
 		preferences.select(seamPreferencePage);
 		seamPreferencePage.removeAllRuntimes();
-		seamPreferencePage.ok();
+		preferences.ok();
 	}
 
 	protected void removeAllServerRuntimes(){
+		preferences.open();
 		preferences.select(runtimePreferencePage);
 		runtimePreferencePage.removeAllRuntimes();
-		runtimePreferencePage.ok();
+		preferences.ok();
 	}
 
 	protected void assertSeamRuntimesNumber(int expected) {
+		preferences.open();
 		preferences.select(seamPreferencePage);
 		assertThat(seamPreferencePage.getRuntimes().size(), is(expected));
-		seamPreferencePage.ok();
+		preferences.ok();
 	}
 
 	protected void assertServerRuntimesNumber(int expected) {
+		preferences.open();
 		preferences.select(runtimePreferencePage);
 		List<org.jboss.reddeer.eclipse.wst.server.ui.Runtime> runtimes = 
 				runtimePreferencePage.getServerRuntimes();
 		assertThat("Expected are " + expected + " runtimes but there are:\n"
 				+ Arrays.toString(runtimes.toArray()), runtimes.size(), is(expected));
-		runtimePreferencePage.ok();
+		preferences.ok();
 	}
 }


### PR DESCRIPTION
open() methods were added when working with views.
Wait for console is not changing was added when starting/restarting
server.
