### PR TITLE
Added a note to README about branching

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ In the newly created maintenance branch, these steps are needed:
 *   Update integration tests repo url in root pom.xml to point to a maintenance repo, e.g.:
     
          http://download.jboss.org/jbosstools/updates/nightly/integrationtests/4.1.kepler/
+         
+    This is a chicken-egg problem. In order to add this repo to the pom, you need the url
+    to be working. But to create the Jenkins job you need to have this branch ready.
+         
+    So either create the job using master branch first and later change it to use
+    the maintenance branch once it's ready. Or first do the rest of these steps,
+    create the job, publish the site and eventually change the url in the pom.
 
 In the master branch, these steps are needed:
 


### PR DESCRIPTION
When creating a new maintenance branch,
it is important to have a jenkins job that publishes
the maintenance branch to a URL and have this URL in the pom.
(It's sort of a chicken-egg problem - you will probably need
to do the rest of the steps first, then create the new job, publish it
and finally add the new repo to the pom.)
