### PR TITLE
Remove old version of repository-utils from site/pom.xml

### DIFF
--- a/site/pom.xml
+++ b/site/pom.xml
@@ -26,7 +26,6 @@
 			<plugin>
 				<groupId>org.jboss.tools.tycho-plugins</groupId>
 				<artifactId>repository-utils</artifactId>
-				<version>0.16.0.CR1</version>
 				<executions>
 					<execution>
 						<id>generate-facade</id>


### PR DESCRIPTION
The build was failing because we were using a very old version of repository-utils.
It's better to inherit the version from parent pom.