### PR TITLE
Clear console after each ws test

### DIFF
--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/WSTestBase.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/WSTestBase.java
@@ -26,6 +26,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
 import org.jboss.reddeer.eclipse.core.resources.Project;
 import org.jboss.reddeer.eclipse.jdt.ui.ProjectExplorer;
+import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
 import org.jboss.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
 import org.jboss.reddeer.eclipse.ui.wizards.datatransfer.ExternalProjectImportWizardDialog;
 import org.jboss.reddeer.eclipse.ui.wizards.datatransfer.WizardProjectsImportPage;
@@ -104,6 +105,7 @@ public class WSTestBase {
 	@After
 	public void cleanup() {
 		deleteAllProjectsFromServer();
+		new ConsoleView().clearConsole();
 	}
 
 	@AfterClass
@@ -132,7 +134,7 @@ public class WSTestBase {
 		projectExplorer.open();
 		return projectExplorer.containsProject(name);
 	}
-
+	
 	protected static void deleteAllProjects() {
 		ProjectExplorer projectExplorer = new ProjectExplorer();
 		projectExplorer.open();

--- a/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/wsclient/WSClientTestTemplate.java
+++ b/tests/org.jboss.tools.ws.ui.bot.test/src/org/jboss/tools/ws/ui/bot/test/wsclient/WSClientTestTemplate.java
@@ -110,9 +110,10 @@ public class WSClientTestTemplate extends WSTestBase {
 	}
 
 	@After
+	@Override
 	public void cleanup() {
 		deleteAllPackages();
-		deleteAllProjectsFromServer();
+		super.cleanup();
 	}
 
 	protected void clientTest(String targetPkg) {


### PR DESCRIPTION
Some ws tests check if console contains errors. This will cause them to fail if there is an error introduced by a previously run test. Console will now be cleared after each test to avoid this situation.