### PR TITLE
Fix for JBT 4.3.0.Beta1 changes for forge.

### DIFF
--- a/tests/org.jboss.tools.forge.ui.bot.test/src/org/jboss/tools/forge2/ui/bot/wizard/test/ProjectNewWizardTest.java
+++ b/tests/org.jboss.tools.forge.ui.bot.test/src/org/jboss/tools/forge2/ui/bot/wizard/test/ProjectNewWizardTest.java
@@ -49,7 +49,7 @@ public class ProjectNewWizardTest extends WizardTestBase {
 		new LabeledText("Project name:").setText(PROJECT_NAME);
 		new LabeledText("Project location:").setText(WORKSPACE);
 		new LabeledText("Top level package:").setText(GROUPID);
-		new LabeledCombo("Project type:").setSelection("Java Resources");
+		new LabeledCombo("Project type:").setSelection("Java Resources (JAR)");
 		wd.finish();
 		//asserts
 		ProjectExplorer pe = new ProjectExplorer();
@@ -70,7 +70,7 @@ public class ProjectNewWizardTest extends WizardTestBase {
 		new LabeledText("Project name:").setText(PROJECT_NAME);
 		new LabeledText("Project location:").setText(WORKSPACE);
 		new LabeledText("Top level package:").setText(GROUPID);
-		new LabeledCombo("Project type:").setSelection("Java Web Application");
+		new LabeledCombo("Project type:").setSelection("Java Web Application (WAR)");
 		wd.finish();
 		//asserts
 		ProjectExplorer pe = new ProjectExplorer();

--- a/tests/org.jboss.tools.forge.ui.bot.test/src/org/jboss/tools/forge2/ui/bot/wizard/test/WizardTestBase.java
+++ b/tests/org.jboss.tools.forge.ui.bot.test/src/org/jboss/tools/forge2/ui/bot/wizard/test/WizardTestBase.java
@@ -46,7 +46,6 @@ public abstract class WizardTestBase {
 	@BeforeClass
 	public static void setup(){
 		ForgeConsoleView view = new ForgeConsoleView();
-		view.selectRuntime(new RegexMatcher("Forge 2.*"));
 		view.start();
 	}
 	


### PR DESCRIPTION
* Removes runtimes selection (there is only one default runtime - forge2 )
* Fixies label changes in new project wizard