### PR TITLE
Update RedDeer master repo url to the one currently in use

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<!-- URLs needed to resolve dependencies at build time (see <repositories> below) and at install time (see site/pom.xml#associateSites) -->
 
 		<!-- predefined RedDeer sites, if you need to change default please redefine reddeer-site property in your test -->
-		<reddeer-master-site>http://download.jboss.org/jbosstools/builds/staging/RedDeer_master/all/repo/</reddeer-master-site>
+		<reddeer-master-site>http://download.jboss.org/jbosstools/mars/snapshots/builds/RedDeer_master/</reddeer-master-site>
 		<reddeer-stable-site>http://download.jboss.org/jbosstools/updates/stable/luna/core/reddeer/0.7.0/</reddeer-stable-site>
 		<reddeer-site>${reddeer-master-site}</reddeer-site>
 


### PR DESCRIPTION
It turns out that our root pom was referring an outdated
url which was last updated on April 30.
Now it points to the correct one.