### PR TITLE
Update RedDeer master url: mars -> luna

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<!-- URLs needed to resolve dependencies at build time (see <repositories> below) and at install time (see site/pom.xml#associateSites) -->
 
 		<!-- predefined RedDeer sites, if you need to change default please redefine reddeer-site property in your test -->
-		<reddeer-master-site>http://download.jboss.org/jbosstools/mars/snapshots/builds/RedDeer_master/</reddeer-master-site>
+		<reddeer-master-site>http://download.jboss.org/jbosstools/luna/snapshots/builds/RedDeer_master/</reddeer-master-site>
 		<reddeer-stable-site>http://download.jboss.org/jbosstools/updates/stable/luna/core/reddeer/0.7.0/</reddeer-stable-site>
 		<reddeer-site>${reddeer-master-site}</reddeer-site>
 


### PR DESCRIPTION
Vlado or Jirka pointed out today that RedDeer is not on mars yet,
so I changed the jenkins job to publish to luna in the url.