### PR TITLE
Set root pom to use RedDeer 0.8.0.M1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<!-- URLs needed to resolve dependencies at build time (see <repositories> below) and at install time (see site/pom.xml#associateSites) -->
 
 		<!-- predefined RedDeer sites, if you need to change default please redefine reddeer-site property in your test -->
-		<reddeer-master-site>http://download.jboss.org/jbosstools/luna/snapshots/builds/RedDeer_master/</reddeer-master-site>
+		<reddeer-master-site>http://download.jboss.org/jbosstools/updates/development/core/reddeer/0.8.0.M1/</reddeer-master-site>
 		<reddeer-stable-site>http://download.jboss.org/jbosstools/updates/stable/luna/core/reddeer/0.7.0/</reddeer-stable-site>
 		<reddeer-site>${reddeer-master-site}</reddeer-site>
 


### PR DESCRIPTION
Before tagging our tests for JBoss Tools 4.3.0.Beta1,
we want to set the RedDeer url to one that doesn't change.