### PR TITLE
JBQA-11696 Unify properties for tests skipping in jbosstools-integration-tests

### DIFF
--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/pom.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/pom.xml
@@ -18,7 +18,7 @@
 		test.class - which test suite 
 	 -->
 	<properties>
-		<swtbot.test.skip>false</swtbot.test.skip>
+		<skipTests>false</skipTests>
 		<usage_reporting_enabled>false</usage_reporting_enabled>
 		<!-- Maven configuration -->
 		<maven.test.failure.ignore>true</maven.test.failure.ignore>

--- a/tests/org.jboss.tools.archives.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.archives.ui.bot.test/pom.xml
@@ -32,7 +32,7 @@
 							<goal>unpack</goal>
 						</goals>
 						<configuration>
-							<skip>${swtbot.test.skip}</skip>
+							<skip>${skipTests}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.jboss.as</groupId>

--- a/tests/org.jboss.tools.arquillian.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.arquillian.ui.bot.test/pom.xml
@@ -13,7 +13,7 @@
 	<artifactId>org.jboss.tools.arquillian.ui.bot.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
-		<swtbot.test.skip>false</swtbot.test.skip>
+		<skipTests>false</skipTests>
 		<usage_reporting_enabled>false</usage_reporting_enabled>
 		<maven.test.failure.ignore>true</maven.test.failure.ignore>
 		
@@ -120,4 +120,3 @@
 		</resources>
 	</build>
 </project>
-

--- a/tests/org.jboss.tools.cdi.bot.test/dep-aggregator/pom.xml
+++ b/tests/org.jboss.tools.cdi.bot.test/dep-aggregator/pom.xml
@@ -14,10 +14,6 @@
 
 	<packaging>pom</packaging>
 
-	<properties>
-		<swtbot.test.skip>true</swtbot.test.skip>
-		<skipTests>true</skipTests>
-	</properties>
 	
 	<modules>
 		<module>..</module>

--- a/tests/org.jboss.tools.cdi.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.bot.test/pom.xml
@@ -44,7 +44,7 @@
 							<goal>unpack</goal>
 						</goals>
 						<configuration>
-							<skip>${swtbot.test.skip}</skip>
+							<skip>${skipTests}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.jboss.as</groupId>
@@ -62,7 +62,7 @@
 							<goal>unpack</goal>
 						</goals>
 						<configuration>
-							<skip>${swtbot.test.skip}</skip>
+							<skip>${skipTests}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.wildfly</groupId>
@@ -80,7 +80,7 @@
 							<goal>copy</goal>
 						</goals>
 						<configuration>
-							<skip>${swtbot.test.skip}</skip>
+							<skip>${skipTests}</skip>
 							<artifactItems>
 								<artifactItem>
 									 <groupId>org.jboss.weld.se</groupId>

--- a/tests/org.jboss.tools.cdi.seam3.bot.test/dep-aggregator/pom.xml
+++ b/tests/org.jboss.tools.cdi.seam3.bot.test/dep-aggregator/pom.xml
@@ -14,11 +14,6 @@
 
 	<packaging>pom</packaging>
 
-	<properties>
-		<swtbot.test.skip>true</swtbot.test.skip>
-		<skipTests>true</skipTests>
-	</properties>
-	
 	<modules>
 		<module>..</module>
 		<module>../../org.jboss.tools.cdi.bot.test/dep-aggregator</module>

--- a/tests/org.jboss.tools.cdi.seam3.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.seam3.bot.test/pom.xml
@@ -29,7 +29,7 @@
 							<goal>unpack</goal>
 						</goals>
 						<configuration>
-							<skip>${swtbot.test.skip}</skip>
+							<skip>${skipTests}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.jboss.as</groupId>

--- a/tests/org.jboss.tools.deltaspike.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.deltaspike.ui.bot.test/pom.xml
@@ -30,7 +30,7 @@
 							<goal>unpack</goal>
 						</goals>
 						<configuration>
-							<skip>${swtbot.test.skip}</skip>
+							<skip>${skipTests}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.jboss.as</groupId>
@@ -48,7 +48,7 @@
 							<goal>copy</goal>
 						</goals>
 						<configuration>
-							<skip>${swtbot.test.skip}</skip>
+							<skip>${skipTests}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.apache.deltaspike.core</groupId>
@@ -96,7 +96,7 @@
 							<goal>unpack</goal>
 						</goals>
 						<configuration>
-							<skip>${swtbot.test.skip}</skip>
+							<skip>${skipTests}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.wildfly</groupId>

--- a/tests/org.jboss.tools.jsf.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.jsf.ui.bot.test/pom.xml
@@ -31,7 +31,7 @@
 						<goal>unpack</goal>
 					</goals>
 					<configuration>
-						<skip>${swtbot.test.skip}</skip>
+						<skip>${skipTests}</skip>
 						<artifactItems>
 							<artifactItem>
 								<groupId>org.jboss.as</groupId>

--- a/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
@@ -60,7 +60,7 @@
 									<type>zip</type>
 								</artifactItem>
 							</artifactItems>
-							<skip>${swtbot.test.skip}</skip>
+							<skip>${skipTests}</skip>
 						</configuration>
 					</execution>
 					<!-- 
@@ -80,7 +80,7 @@
 									<type>jar</type>
 								</artifactItem>
 							</artifactItems>
-							<skip>${swtbot.test.skip}</skip>
+							<skip>${skipTests}</skip>
 						</configuration>
 					</execution>
 					-->
@@ -100,7 +100,7 @@
 									<type>zip</type>
 								</artifactItem>
 							</artifactItems>
-							<skip>${swtbot.test.skip}</skip>
+							<skip>${skipTests}</skip>
 						</configuration>
 					</execution>
 				</executions>

--- a/tests/org.jboss.tools.perf.test/pom.xml
+++ b/tests/org.jboss.tools.perf.test/pom.xml
@@ -24,7 +24,6 @@
 					<testSuite>org.jboss.tools.perf.test</testSuite>
 					<testClass>${suiteClass}</testClass>
 					<useUIThread>false</useUIThread>
-					<skip>${swtbot.test.skip}</skip>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/tests/org.jboss.tools.portlet.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.portlet.ui.bot.test/pom.xml
@@ -138,7 +138,7 @@
 							<goal>copy</goal>
 						</goals>
 						<configuration>
-							<skip>${swtbot.test.skip}</skip>
+							<skip>${skipTests}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.jboss.tools.portlet.tests</groupId>

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/pom.xml
@@ -194,7 +194,7 @@
 							<goal>unpack</goal>
 						</goals>
 						<configuration>
-							<skip>${swtbot.test.skip}</skip>
+							<skip>${skipTests}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.wildfly</groupId>
@@ -213,7 +213,7 @@
 							<goal>unpack</goal>
 						</goals>
 						<configuration>
-							<skip>${swtbot.test.skip}</skip>
+							<skip>${skipTests}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.wildfly</groupId>
@@ -232,7 +232,7 @@
 							<goal>unpack</goal>
 						</goals>
 						<configuration>
-							<skip>${swtbot.test.skip}</skip>
+							<skip>${skipTests}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.jboss.as</groupId>

--- a/tests/org.jboss.tools.seam.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.seam.ui.bot.test/pom.xml
@@ -30,7 +30,7 @@
 						<goal>unpack</goal>
 					</goals>
 					<configuration>
-						<skip>${swtbot.test.skip}</skip>
+						<skip>${skipTests}</skip>
 						<artifactItems>
 							<artifactItem>
 								<groupId>org.jboss.as</groupId>

--- a/tests/org.jboss.tools.vpe.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.vpe.ui.bot.test/pom.xml
@@ -14,7 +14,6 @@
     <jbosstools.test.jboss-as.home>${requirementsDirectory}/jboss-as-7.0.2.Final</jbosstools.test.jboss-as.home>
     <org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location>${requirementsDirectory}/richfaces-4.2.1.Final/artifacts/ui/richfaces-components-ui-4.2.1.Final.jar</org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location>
     <systemProperties>${integrationTestsSystemProperties}
-      -Dswtbot.test.skip=false
       -Dtest.configurations.dir=resources/properties/
       -Djbosstools.test.jboss-as.home=${jbosstools.test.jboss-as.home}
       -Dorg.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location=${org.jboss.tools.vpe.ui.bot.test.richfaces.ui.jar.location}</systemProperties>
@@ -34,7 +33,7 @@
               <goal>unpack</goal>
             </goals>
             <configuration>
-              <skip>${swtbot.test.skip}</skip>
+              <skip>${skipTests}</skip>
               <artifactItems>
                 <artifactItem>
                   <groupId>org.jboss.as</groupId>

--- a/tests/org.jboss.tools.ws.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.ws.ui.bot.test/pom.xml
@@ -60,7 +60,7 @@
 							<goal>unpack</goal>
 						</goals>
 						<configuration>
-							<skip>${swtbot.test.skip}</skip>
+							<skip>${skipTests}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.wildfly</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -21,6 +21,7 @@
             <reddeer.disable.maven.download.repo.index.on.startup>true</reddeer.disable.maven.download.repo.index.on.startup>
             <junitExtensionsProperties>-Dreddeer.close.shells=${reddeer.close.shells} -Dreddeer.close.welcome.screen=${reddeer.close.welcome.screen} -Dreddeer.disable.maven.download.repo.index.on.startup=${reddeer.disable.maven.download.repo.index.on.startup}</junitExtensionsProperties>
             <integrationTestsSystemProperties>-Dswt.bot.test.record.screencast=${swt.bot.test.record.screencast} -Dorg.eclipse.swtbot.screenshots.dir=${project.build.directory}/screenshots -Dusage_reporting_enabled=false -Dcom.atlassian.connector.eclipse.monitor.usage.first.time=false -Dcom.atlassian.connector.eclipse.monitor.usage.enabled=false ${junitExtensionsProperties}</integrationTestsSystemProperties>
+						<skipTests>true</skipTests>
         </properties>
 
 	<modules>
@@ -72,7 +73,6 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
-					<skip>${swtbot.test.skip}</skip>
 					<useUIThread>false</useUIThread>
 					<appArgLine>-pluginCustomization ${basedir}/../pluginCustomization.ini</appArgLine>
 					<explodedBundles>
@@ -105,7 +105,7 @@
 				<groupId>com.googlecode.maven-download-plugin</groupId>
 				<artifactId>download-maven-plugin</artifactId>
 				<configuration>
-					<skip>${swtbot.test.skip}</skip>
+					<skip>${skipTests}</skip>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Until now we used swtbot.test.skip which was set to true in tests/pom.xml.
But it seems this property is redundant - we can simply use skipTests
everywhere and it will be clearer for people outside our team.
skipTests is also the property that is taken by tycho surefire plugin.