### PR TITLE
Update version to 4.3.1-SNAPSHOT

### DIFF
--- a/plugins/org.jboss.ide.eclipse.as.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.ide.eclipse.as.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer API for AS UI Tests
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.reddeer;singleton:=true
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.ui;bundle-version="3.105.0",

--- a/plugins/org.jboss.ide.eclipse.as.reddeer/pom.xml
+++ b/plugins/org.jboss.ide.eclipse.as.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.ide.eclipse.as</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.reddeer</artifactId>

--- a/plugins/org.jboss.tools.aerogear.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.aerogear.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer API for Aerogear UI Tests
 Bundle-SymbolicName: org.jboss.tools.aerogear.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.aerogear.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.tools.aerogear.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.aerogear.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.aerogear</groupId>
 	<artifactId>org.jboss.tools.aerogear.reddeer</artifactId>

--- a/plugins/org.jboss.tools.archives.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.archives.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer API for Archives UI Tests
 Bundle-SymbolicName: org.jboss.tools.archives.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.archives.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.tools.archives.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.archives.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.archives</groupId>
 	<artifactId>org.jboss.tools.archives.reddeer</artifactId>

--- a/plugins/org.jboss.tools.arquillian.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.arquillian.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer API for Arquillian UI Tests
 Bundle-SymbolicName: org.jboss.tools.arquillian.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Require-Bundle: org.eclipse.ui,
  org.apache.log4j,
  org.eclipse.core.runtime,
@@ -18,7 +18,7 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.jface;bundle-version="[1.0.0,1.1.0)",
  org.jboss.reddeer.workbench;bundle-version="[1.0.0,1.1.0)",
  org.jboss.reddeer.eclipse;bundle-version="[1.0.0,1.1.0)",
- org.jboss.tools.maven.reddeer;bundle-version="[4.3.0,4.4.0)"
+ org.jboss.tools.maven.reddeer;bundle-version="[4.3.1,4.4.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.eclipse.core.resources

--- a/plugins/org.jboss.tools.arquillian.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.arquillian.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.arquillian</groupId>
 	<artifactId>org.jboss.tools.arquillian.reddeer</artifactId>

--- a/plugins/org.jboss.tools.batch.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.batch.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer API for Batch UI Tests
 Bundle-SymbolicName: org.jboss.tools.batch.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Require-Bundle: org.eclipse.ui,
  org.apache.log4j,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.tools.batch.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.batch.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.batch</groupId>
 	<artifactId>org.jboss.tools.batch.reddeer</artifactId>

--- a/plugins/org.jboss.tools.browsersim.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.browsersim.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Reddeer API for Browsersim UI Tests
 Bundle-SymbolicName: org.jboss.tools.browsersim.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.browsersim.reddeer.Activator
 Bundle-Vendor: JBoss by Red Hat
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.jboss.tools.browsersim.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.browsersim.reddeer/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.browsersim</groupId>
 	<artifactId>org.jboss.tools.browsersim.reddeer</artifactId>

--- a/plugins/org.jboss.tools.cdi.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.cdi.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer API for CDI UI Tests
 Bundle-SymbolicName: org.jboss.tools.cdi.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.cdi.reddeer.Activator
 Export-Package: org.jboss.tools.cdi.reddeer,
  org.jboss.tools.cdi.reddeer.annotation,

--- a/plugins/org.jboss.tools.cdi.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.cdi.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.cdi</groupId>
 	<artifactId>org.jboss.tools.cdi.reddeer</artifactId>

--- a/plugins/org.jboss.tools.central.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.central.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Central Reddeer
 Bundle-SymbolicName: org.jboss.tools.central.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.central.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.tools.central.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.central.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.central</groupId>
 	<artifactId>org.jboss.tools.central.reddeer</artifactId>

--- a/plugins/org.jboss.tools.common.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.common.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer API for Common UI Tests
 Bundle-SymbolicName: org.jboss.tools.common.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.common.reddeer.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.jboss.reddeer.jface,

--- a/plugins/org.jboss.tools.common.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.common.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.tests.plugins</groupId>
 	<artifactId>org.jboss.tools.common.reddeer</artifactId>

--- a/plugins/org.jboss.tools.easymport.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.easymport.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer API for Easymport UI Tests
 Bundle-SymbolicName: org.jboss.tools.easymport.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Require-Bundle: org.eclipse.ui,
  org.apache.log4j,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.tools.easymport.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.easymport.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.easymport</groupId>
 	<artifactId>org.jboss.tools.easymport.reddeer</artifactId>

--- a/plugins/org.jboss.tools.forge.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.forge.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Forge RedDeer
 Bundle-SymbolicName: org.jboss.tools.forge.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.forge.reddeer.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.jboss.reddeer.swt;bundle-version="0.7.0",

--- a/plugins/org.jboss.tools.forge.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.forge.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.forge</groupId>
 	<artifactId>org.jboss.tools.forge.reddeer</artifactId>

--- a/plugins/org.jboss.tools.hibernate.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.hibernate.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer API for Hibernate UI Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.hibernate.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.tools.hibernate.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.hibernate.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.tests</groupId>
 	<artifactId>org.jboss.tools.hibernate.reddeer</artifactId>

--- a/plugins/org.jboss.tools.jsf.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.jsf.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JSF Reddeer
 Bundle-SymbolicName: org.jboss.tools.jsf.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.jsf.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.junit,

--- a/plugins/org.jboss.tools.jsf.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.jsf.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.jsf</groupId>
 	<artifactId>org.jboss.tools.jsf.reddeer</artifactId>

--- a/plugins/org.jboss.tools.jst.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.jst.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JST Reddeer
 Bundle-SymbolicName: org.jboss.tools.jst.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.jst.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.junit,

--- a/plugins/org.jboss.tools.jst.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.jst.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.jst</groupId>
 	<artifactId>org.jboss.tools.jst.reddeer</artifactId>

--- a/plugins/org.jboss.tools.jst.ui.bot/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.jst.ui.bot/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JST UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.jst.ui.bot;singleton:=true
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.ui.bot.test.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.swtbot.eclipse.finder;bundle-version="2.0.0",
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.jboss.tools.common.text.ext;bundle-version="2.0.0",
  org.eclipse.ui.ide;bundle-version="3.5.0",
  org.junit;bundle-version="4.5.0",
- org.jboss.tools.ui.bot.ext;bundle-version="[4.3.0,4.4.0)",
+ org.jboss.tools.ui.bot.ext;bundle-version="[4.3.1,4.4.0)",
  org.jboss.tools.jst.web.ui;bundle-version="3.6.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: J2SE-1.5

--- a/plugins/org.jboss.tools.jst.ui.bot/pom.xml
+++ b/plugins/org.jboss.tools.jst.ui.bot/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.jst</groupId>
 

--- a/plugins/org.jboss.tools.maven.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.maven.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Maven Reddeer
 Bundle-SymbolicName: org.jboss.tools.maven.reddeer;singleton:=true
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.maven.reddeer.Activator
 Require-Bundle: org.jboss.reddeer.go;bundle-version="1.0.0",
  org.jboss.tools.runtime.reddeer,

--- a/plugins/org.jboss.tools.maven.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.maven.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	
 	<groupId>org.jboss.tools.maven</groupId>

--- a/plugins/org.jboss.tools.mylyn.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.mylyn.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Mylyn Reddeer
 Bundle-SymbolicName: org.jboss.tools.mylyn.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.mylyn.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.swtbot.go;bundle-version="2.0.5",

--- a/plugins/org.jboss.tools.mylyn.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.mylyn.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 		<groupId>org.jboss.tools.mylyn.reddeer</groupId>
 		<artifactId>org.jboss.tools.mylyn.reddeer</artifactId>

--- a/plugins/org.jboss.tools.openshift.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer API for OpenShift UI Tests
 Bundle-SymbolicName: org.jboss.tools.openshift.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.openshift.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.tools.openshift.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.openshift.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.openshift</groupId>
 	<artifactId>org.jboss.tools.openshift.reddeer</artifactId>

--- a/plugins/org.jboss.tools.perf.test.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.perf.test.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Performance Tests Core
 Bundle-SymbolicName: org.jboss.tools.perf.test.core
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-ClassPath: .,
  resources/perftestlibs/gson-2.1.jar,
  resources/perftestlibs/sigar-1.6.5.132.jar,

--- a/plugins/org.jboss.tools.perf.test.core/pom.xml
+++ b/plugins/org.jboss.tools.perf.test.core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.tests.plugins</groupId>
 	<artifactId>org.jboss.tools.perf.test.core</artifactId>

--- a/plugins/org.jboss.tools.runtime.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.runtime.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Runtime Reddeer
 Bundle-SymbolicName: org.jboss.tools.runtime.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.runtime.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.tools.runtime.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.runtime.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.runtime</groupId>
 	<artifactId>org.jboss.tools.runtime.reddeer</artifactId>

--- a/plugins/org.jboss.tools.seam.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.seam.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Seam Reddeer
 Bundle-SymbolicName: org.jboss.tools.seam.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.seam.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.tools.seam.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.seam.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.seam</groupId>
 	<artifactId>org.jboss.tools.seam.reddeer</artifactId>

--- a/plugins/org.jboss.tools.ui.bot.ext/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.ui.bot.ext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SWTBot Extensions
 Bundle-SymbolicName: org.jboss.tools.ui.bot.ext
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-ClassPath: .,
  resources/drv/hsqldb.jar
 Bundle-Activator: org.jboss.tools.ui.bot.ext.Activator

--- a/plugins/org.jboss.tools.ui.bot.ext/pom.xml
+++ b/plugins/org.jboss.tools.ui.bot.ext/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.tests.plugins</groupId>
 	<artifactId>org.jboss.tools.ui.bot.ext</artifactId> 

--- a/plugins/org.jboss.tools.vpe.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.vpe.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: VPE Reddeer
 Bundle-SymbolicName: org.jboss.tools.vpe.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.vpe.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.tools.vpe.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.vpe.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.vpe</groupId>
 	<artifactId>org.jboss.tools.vpe.reddeer</artifactId>

--- a/plugins/org.jboss.tools.ws.reddeer/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.ws.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer API for Webservices UI Tests
 Bundle-SymbolicName: org.jboss.tools.ws.reddeer
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.ws.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.tools.ws.reddeer/pom.xml
+++ b/plugins/org.jboss.tools.ws.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws</groupId>
 	<artifactId>org.jboss.tools.ws.reddeer</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>integration-tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.integration-tests</groupId>
 	<artifactId>plugins</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>integration-tests</artifactId>
-	<version>4.3.0-SNAPSHOT</version>
+	<version>4.3.1-SNAPSHOT</version>
 	<name>integration-tests.all</name>
 	<packaging>pom</packaging>
 	<!-- 

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>integration-tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.integration-tests</groupId>
 	<artifactId>site</artifactId>

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: AS UI Bot Tests
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.ui.bot.test;singleton:=true
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.ide.eclipse.as.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.ui,
  org.apache.log4j;bundle-version="1.2.13",
  org.junit;bundle-version="4.8.1",
  org.hamcrest.core;bundle-version="1.3.0",
- org.jboss.ide.eclipse.as.reddeer;bundle-version="[4.3.0,4.4.0)",
+ org.jboss.ide.eclipse.as.reddeer;bundle-version="[4.3.1,4.4.0)",
  org.jboss.reddeer.junit;bundle-version="[1.0.0,1.1.0)",
  org.jboss.reddeer.requirements;bundle-version="[1.0.0,1.1.0)",
  org.jboss.reddeer.swt;bundle-version="[1.0.0,1.1.0)",

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/pom.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.tests</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.aerogear.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.aerogear.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Aerogear UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.aerogear.ui.bot.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.aerogear.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.jface;bundle-version="1.0.0",
  org.jboss.reddeer.eclipse;bundle-version="1.0.0",
  org.jboss.reddeer.workbench;bundle-version="1.0.0",
- org.jboss.tools.browsersim.reddeer;bundle-version="4.3.0",
+ org.jboss.tools.browsersim.reddeer;bundle-version="[4.3.1,4.4.0)",
  org.jboss.reddeer.common;bundle-version="1.0.0",
  org.jboss.reddeer.junit;bundle-version="1.0.0",
  org.jboss.reddeer.requirements;bundle-version="1.0.0",

--- a/tests/org.jboss.tools.aerogear.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.aerogear.ui.bot.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.aerogear.tests</groupId>
 	<artifactId>org.jboss.tools.aerogear.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.archives.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.archives.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Archives UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.archives.ui.bot.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.archives.ui.bot.test.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.junit;bundle-version="4.8.1",

--- a/tests/org.jboss.tools.archives.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.archives.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
         <groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jboss.tools.archives.tests</groupId>

--- a/tests/org.jboss.tools.arquillian.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.arquillian.ui.bot.test/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Bundle-ManifestVersion: 2
 Bundle-Name: Arquillian UI Tests
 Bundle-SymbolicName: org.jboss.tools.arquillian.ui.bot.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.arquillian.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.apache.log4j,
@@ -18,8 +18,8 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.jface;bundle-version="[1.0.0,1.1.0)",
  org.jboss.reddeer.workbench;bundle-version="[1.0.0,1.1.0)",
  org.jboss.reddeer.eclipse;bundle-version="[1.0.0,1.1.0)",
- org.jboss.tools.maven.reddeer;bundle-version="[4.3.0,4.4.0)",
- org.jboss.tools.arquillian.reddeer;bundle-version="[4.3.0,4.4.0)"
+ org.jboss.tools.maven.reddeer;bundle-version="[4.3.1,4.4.0)",
+ org.jboss.tools.arquillian.reddeer;bundle-version="[4.3.1,4.4.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.eclipse.core.resources

--- a/tests/org.jboss.tools.arquillian.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.arquillian.ui.bot.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jboss.tools.arquillian.tests</groupId>

--- a/tests/org.jboss.tools.batch.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.batch.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Batch UI Tests
 Bundle-SymbolicName: org.jboss.tools.batch.ui.bot.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Require-Bundle: org.eclipse.ui,
  org.apache.log4j,
  org.eclipse.core.runtime,
@@ -18,7 +18,7 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.jface;bundle-version="[1.0.0,1.1.0)",
  org.jboss.reddeer.workbench;bundle-version="[1.0.0,1.1.0)",
  org.jboss.reddeer.eclipse;bundle-version="[1.0.0,1.1.0)",
- org.jboss.tools.batch.reddeer;bundle-version="[4.3.0,4.4.0)"
+ org.jboss.tools.batch.reddeer;bundle-version="[4.3.1,4.4.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.eclipse.core.resources

--- a/tests/org.jboss.tools.batch.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.batch.ui.bot.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jboss.tools.batch.tests</groupId>

--- a/tests/org.jboss.tools.cdi.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.cdi.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: CDI UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.cdi.bot.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.cdi.bot.test.PluginActivator
 Require-Bundle: org.jboss.reddeer.go;bundle-version="1.0.0",
  org.jboss.tools.cdi.reddeer,

--- a/tests/org.jboss.tools.cdi.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
         <groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.cdi.tests</groupId>
 	<artifactId>org.jboss.tools.cdi.bot.test</artifactId>

--- a/tests/org.jboss.tools.cdi.seam3.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.cdi.seam3.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: CDI Seam3 UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.cdi.seam3.bot.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.cdi.seam3.bot.test.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.junit;bundle-version="4.8.1",

--- a/tests/org.jboss.tools.cdi.seam3.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.seam3.bot.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
         <groupId>org.jboss.tools.integration-tests</groupId>
  		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
  	</parent>
  	<groupId>org.jboss.tools.cdi.tests</groupId>
  	<artifactId>org.jboss.tools.cdi.seam3.bot.test</artifactId>

--- a/tests/org.jboss.tools.central.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.central.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Central UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.central.ui.bot.test;singleton:=true
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.ui.forms;bundle-version="3.5.101",

--- a/tests/org.jboss.tools.central.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.central.ui.bot.test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.central.tests</groupId>
 	<artifactId>org.jboss.tools.central.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.deltaspike.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.deltaspike.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Deltaspike UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.deltaspike.ui.bot.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.deltaspike.ui.bot.test.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.junit;bundle-version="4.8.1",

--- a/tests/org.jboss.tools.deltaspike.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.deltaspike.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.deltaspike.tests</groupId>
 	<artifactId>org.jboss.tools.deltaspike.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.dummy.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.dummy.ui.bot.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Eclipse-RegisterBuddy: org.apache.log4j
 Bundle-ManifestVersion: 2
 Bundle-Name: Dummy UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.dummy.ui.bot.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.dummy.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.dummy.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.dummy.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jboss.tools.tests.tests</groupId>

--- a/tests/org.jboss.tools.easymport.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.easymport.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Easymport UI Tests
 Bundle-SymbolicName: org.jboss.tools.easymport.ui.bot.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Require-Bundle: org.eclipse.ui,
  org.apache.log4j,
  org.eclipse.core.runtime,
@@ -18,7 +18,7 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.jface;bundle-version="[1.0.0,1.1.0)",
  org.jboss.reddeer.workbench;bundle-version="[1.0.0,1.1.0)",
  org.jboss.reddeer.eclipse;bundle-version="[1.0.0,1.1.0)",
- org.jboss.tools.easymport.reddeer;bundle-version="[4.3.0,4.4.0)"
+ org.jboss.tools.easymport.reddeer;bundle-version="[4.3.1,4.4.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.eclipse.core.resources

--- a/tests/org.jboss.tools.easymport.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.easymport.ui.bot.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jboss.tools.easymport.tests</groupId>

--- a/tests/org.jboss.tools.examples.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.examples.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Examples UI Tests
 Bundle-SymbolicName: org.jboss.tools.examples.ui.bot.test;singleton:=true
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.examples.ui.bot.test</groupId>
 	<artifactId>org.jboss.tools.examples.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.forge.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.forge.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,13 +2,13 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Forge UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.forge.ui.bot.test;singleton:=true
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.jboss.tools.forge.ui;bundle-version="1.0.0",
  org.jboss.tools.forge.core;bundle-version="1.0.0",
  org.jboss.tools.forge.runtime;bundle-version="1.0.0",
- org.jboss.tools.forge.reddeer;bundle-version="4.3.0",
+ org.jboss.tools.forge.reddeer;bundle-version="[4.3.1,4.4.0)",
  org.jboss.reddeer.junit;bundle-version="0.7.0",
  org.jboss.reddeer.swt;bundle-version="0.7.0",
  org.jboss.reddeer.workbench;bundle-version="0.7.0",

--- a/tests/org.jboss.tools.forge.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.forge.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.forge.tests</groupId>
 	<artifactId>org.jboss.tools.forge.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.freemarker.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.freemarker.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Freemarker UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.freemarker.ui.bot.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.freemarker.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.freemarker.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.freemarker.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.freemarker.tests</groupId>
 	<artifactId>org.jboss.tools.freemarker.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.hibernate.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.hibernate.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate UI tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.ui.bot.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.hibernate.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.hibernate.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.hibernate.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.tests</groupId>
 	<artifactId>org.jboss.tools.hibernate.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.jsf.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.jsf.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JSF UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.jsf.ui.bot.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.jsf.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.ui,
  org.junit;bundle-version="4.5.0",
  org.eclipse.swtbot.junit4_x;bundle-version="2.0.0",
  org.jboss.tools.jsf.ui;bundle-version="3.2.0",
- org.jboss.tools.ui.bot.ext;bundle-version="[4.3.0,4.4.0)",
+ org.jboss.tools.ui.bot.ext;bundle-version="[4.3.1,4.4.0)",
  org.eclipse.gef,
  org.jboss.tools.jst.ui.bot,
  org.jboss.tools.vpe.ui.bot.test;bundle-version="3.4.0",

--- a/tests/org.jboss.tools.jsf.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.jsf.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.tools.integration-tests</groupId>
     <artifactId>tests</artifactId>
-    <version>4.3.0-SNAPSHOT</version>
+    <version>4.3.1-SNAPSHOT</version>
   </parent>
   <groupId>org.jboss.tools.jsf.tests</groupId>
   <artifactId>org.jboss.tools.jsf.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.jst.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.jst.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss Tools JST Integration Tests
 Bundle-SymbolicName: org.jboss.tools.jst.ui.bot.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit,
  org.eclipse.ui,
@@ -14,7 +14,7 @@ Require-Bundle: org.junit,
  org.jboss.reddeer.core,
  org.jboss.reddeer.workbench,
  org.jboss.reddeer.eclipse;bundle-version="1.0.0",
- org.jboss.tools.jst.reddeer;bundle-version="4.3.0",
+ org.jboss.tools.jst.reddeer;bundle-version="[4.3.1,4.4.0)",
  org.eclipse.core.resources;bundle-version="3.10.0",
  org.jboss.reddeer.requirements;bundle-version="1.0.0",
  org.jboss.reddeer.common

--- a/tests/org.jboss.tools.jst.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.jst.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.jst.tests</groupId>
 	<artifactId>org.jboss.tools.jst.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.maven.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.maven.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,19 +2,19 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Maven UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.maven.ui.bot.test;singleton:=true
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.maven.ui.bot.test.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,
  org.junit,
  org.apache.log4j,
  org.jboss.reddeer.go;bundle-version="1.0.0",
- org.jboss.tools.maven.reddeer;bundle-version="4.3.0",
- org.jboss.tools.jsf.reddeer;bundle-version="4.3.0",
- org.jboss.tools.seam.reddeer;bundle-version="4.3.0",
- org.jboss.ide.eclipse.as.reddeer;bundle-version="4.3.0",
+ org.jboss.tools.maven.reddeer;bundle-version="[4.3.1,4.4.0)",
+ org.jboss.tools.jsf.reddeer;bundle-version="[4.3.1,4.4.0)",
+ org.jboss.tools.seam.reddeer;bundle-version="[4.3.1,4.4.0)",
+ org.jboss.ide.eclipse.as.reddeer;bundle-version="[4.3.1,4.4.0)",
  org.eclipse.ui.workbench,
- org.jboss.tools.central.reddeer;bundle-version="4.3.0"
+ org.jboss.tools.central.reddeer;bundle-version="[4.3.1,4.4.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Vendor: JBoss by Red Hat

--- a/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.maven.tests</groupId>
 	<artifactId>org.jboss.tools.maven.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.mylyn.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.mylyn.ui.bot.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Eclipse-RegisterBuddy: org.apache.log4j
 Bundle-ManifestVersion: 2
 Bundle-Name: Mylyn UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.mylyn.ui.bot.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.mylyn.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.mylyn.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.mylyn.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.tools.integration-tests</groupId>
         <artifactId>tests</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.3.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.tools.mylyn.tests</groupId>

--- a/tests/org.jboss.tools.openshift.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: OpenShift UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.openshift.ui.bot.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.openshift.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.openshift.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.openshift.tests</groupId>
 	<artifactId>org.jboss.tools.openshift.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.perf.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.perf.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Validation Performance Tests
 Bundle-SymbolicName: org.jboss.tools.perf.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.perf.test.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.jboss.reddeer.requirements,
  org.jboss.reddeer.junit.extension,
  org.jboss.tools.common.reddeer,
- org.jboss.tools.maven.reddeer;bundle-version=4.3.0,
+ org.jboss.tools.maven.reddeer;bundle-version="[4.3.1,4.4.0)",
  org.jboss.reddeer.junit,
  org.jboss.tools.perf.test.core
 Bundle-ActivationPolicy: lazy

--- a/tests/org.jboss.tools.perf.test/pom.xml
+++ b/tests/org.jboss.tools.perf.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
         <groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	
 	<artifactId>org.jboss.tools.perf.test</artifactId>

--- a/tests/org.jboss.tools.portlet.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.portlet.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Portal UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.portlet.ui.bot.test;singleton:=true
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.ui,
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.ui,
  org.hamcrest.core;bundle-version="1.3.0",
  org.apache.log4j;bundle-version="1.2.13",
  org.junit;bundle-version="4.8.1",
- org.jboss.tools.ui.bot.ext;bundle-version="[4.3.0,4.4.0)",
+ org.jboss.tools.ui.bot.ext;bundle-version="[4.3.1,4.4.0)",
  org.eclipse.ui.forms;bundle-version="3.5.0",
  org.jboss.reddeer.jface,
  org.jboss.reddeer.swt,

--- a/tests/org.jboss.tools.portlet.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.portlet.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.portlet.tests</groupId>
 	<artifactId>org.jboss.tools.portlet.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: AS Runtime UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.runtime.as.ui.bot.test;singleton:=true
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-ActivationPolicy: lazy
 Eclipse-BundleShape: jar
 Bundle-Localization: plugin
@@ -11,7 +11,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.swtbot.swt.finder;bundle-version="2.0.0",
- org.jboss.tools.ui.bot.ext;bundle-version="[4.3.0,4.4.0)",
+ org.jboss.tools.ui.bot.ext;bundle-version="[4.3.1,4.4.0)",
  org.apache.log4j;bundle-version="1.2.13",
  org.junit;bundle-version="4.8.1",
  org.jboss.tools.runtime.core,
@@ -26,6 +26,6 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.core;bundle-version="0.8.0",
  org.jboss.reddeer.requirements;bundle-version="0.8.0",
  org.jboss.reddeer.uiforms;bundle-version="0.8.0",
- org.jboss.ide.eclipse.as.reddeer;bundle-version="4.3.0"
+ org.jboss.ide.eclipse.as.reddeer;bundle-version="[4.3.1,4.4.0)"
 Import-Package: org.jboss.tools.runtime.reddeer.wizard
 

--- a/tests/org.jboss.tools.runtime.as.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.runtime.as.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.runtime.as.ui.bot.test</groupId>
 	<artifactId>org.jboss.tools.runtime.as.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.seam.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.seam.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Seam UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.seam.ui.bot.test;singleton:=true
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.seam.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.ui,
  org.apache.log4j;bundle-version="1.2.13",
  org.junit;bundle-version="4.8.1",
  org.eclipse.datatools.connectivity;bundle-version="1.1.2",
- org.jboss.tools.ui.bot.ext;bundle-version="[4.3.0,4.4.0)"
+ org.jboss.tools.ui.bot.ext;bundle-version="[4.3.1,4.4.0)"
 Eclipse-RegisterBuddy: org.apache.log4j
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/tests/org.jboss.tools.seam.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.seam.ui.bot.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.seam.tests</groupId>
 	<artifactId>org.jboss.tools.seam.ui.bot.test</artifactId> 

--- a/tests/org.jboss.tools.ui.bot.ext.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.ui.bot.ext.test/META-INF/MANIFEST.MF
@@ -2,12 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SWTBot Extensions Tests
 Bundle-SymbolicName: org.jboss.tools.ui.bot.ext.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.ui.bot.ext.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.apache.log4j;bundle-version="1.2.13",
- org.jboss.tools.ui.bot.ext;bundle-version="[4.3.0,4.4.0)",
+ org.jboss.tools.ui.bot.ext;bundle-version="[4.3.1,4.4.0)",
  org.eclipse.jdt.ui,
  org.eclipse.swtbot.eclipse.core;bundle-version="2.0.0",
  org.eclipse.swtbot.eclipse.finder;bundle-version="2.0.0",

--- a/tests/org.jboss.tools.ui.bot.ext.test/pom.xml
+++ b/tests/org.jboss.tools.ui.bot.ext.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
        <groupId>org.jboss.tools.integration-tests</groupId>
        <artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
     </parent>
     
 	<groupId>org.jboss.tools.tests.tests</groupId>

--- a/tests/org.jboss.tools.usercase.ticketmonster.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.usercase.ticketmonster.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss TicketMonster Integration Tests
 Bundle-SymbolicName: org.jboss.tools.usercase.ticketmonster.ui.bot.test;singleton:=true
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.jboss.tools.usercase.ticketmonster.ui.bot.test,

--- a/tests/org.jboss.tools.usercase.ticketmonster.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.usercase.ticketmonster.ui.bot.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.usercase.tests</groupId>
 	<artifactId>org.jboss.tools.usercase.ticketmonster.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.vpe.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.vpe.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: VPE UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.vpe.ui.bot.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.vpe.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
@@ -20,7 +20,7 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.tools.vpe.xulrunner;bundle-version="2.1.0",
  org.eclipse.jface.text;bundle-version="3.5.0",
  org.junit;bundle-version="4.8.0",
- org.jboss.tools.ui.bot.ext;bundle-version="[4.3.0,4.4.0)",
+ org.jboss.tools.ui.bot.ext;bundle-version="[4.3.1,4.4.0)",
  org.jboss.tools.vpe.docbook,
  org.jboss.tools.vpe.html,
  org.jboss.tools.vpe.jsp,
@@ -36,9 +36,9 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.common,
  org.jboss.tools.browsersim.browser;bundle-version="3.7.0",
  org.jboss.tools.browsersim.ui;bundle-version="3.7.0",
- org.jboss.tools.vpe.reddeer;bundle-version="4.3.0",
+ org.jboss.tools.vpe.reddeer;bundle-version="[4.3.1,4.4.0)",
  org.jboss.tools.common.resref.core;bundle-version="3.7.0",
- org.jboss.tools.browsersim.reddeer;bundle-version="4.3.0"
+ org.jboss.tools.browsersim.reddeer;bundle-version="[4.3.1,4.4.0)"
 Eclipse-RegisterBuddy: org.apache.log4j
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/tests/org.jboss.tools.vpe.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.vpe.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.tools.integration-tests</groupId>
     <artifactId>tests</artifactId>
-    <version>4.3.0-SNAPSHOT</version>
+    <version>4.3.1-SNAPSHOT</version>
   </parent>
   <groupId>org.jboss.tools.vpe.tests</groupId>
   <artifactId>org.jboss.tools.vpe.ui.bot.test</artifactId>

--- a/tests/org.jboss.tools.ws.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.ws.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Webservices UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.ws.ui.bot.test
-Bundle-Version: 4.3.0.qualifier
+Bundle-Version: 4.3.1.qualifier
 Bundle-Activator: org.jboss.tools.ws.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.ws.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.ws.ui.bot.test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.jboss.tools.integration-tests</groupId>
 		<artifactId>tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.tests</groupId>
 	<artifactId>org.jboss.tools.ws.ui.bot.test</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>integration-tests</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.integration-tests</groupId>
 	<artifactId>tests</artifactId>


### PR DESCRIPTION
Because parent pom is now set to 4.3.1.Beta1,
this means that our plugins will have the version of
4.3.0.Beta1 (the qualifier is inherited) and that is lower
than 4.3.0.Final, so older dependencies will be prefered which is
wrong.