### PR TITLE
Remove products-download.properties from eap compat profiles

### DIFF
--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/pom.xml
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/pom.xml
@@ -1040,7 +1040,6 @@
 			<properties>
 				<test.class>org.jboss.ide.eclipse.as.ui.bot.test.allsuites.products.compatibility.EAP6xCompatibilitySuite</test.class>
 				<reddeer.config>${reddeer.product.config}/eap-6.x.xml</reddeer.config>
-				<download-properties-file>${product-download-properties-file}</download-properties-file>
 			</properties>
 			<build>
 				<plugins>
@@ -1076,7 +1075,6 @@
 			<properties>
 				<test.class>org.jboss.ide.eclipse.as.ui.bot.test.allsuites.products.compatibility.EAP7xCompatibilitySuite</test.class>
 				<reddeer.config>${reddeer.product.config}/eap-7.x.xml</reddeer.config>
-				<download-properties-file>${product-download-properties-file}</download-properties-file>
 			</properties>
 			<build>
 				<plugins>


### PR DESCRIPTION
products-download.properties is needed to kick off products/eap profiles
of the as tests - it has all the eap urls and md5s. But for
the eap compatibility profiles used by eap team, this is not needed
because the urls are always provided for the specific build in
jenkins.