### PR TITLE
JBIDE-21405 Remove RedDeer repo definition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,6 @@
 		<tycho.scmUrl>scm:git:https://github.com/jbosstools/jbosstools-integration-tests.git</tycho.scmUrl>
 		<!-- URLs needed to resolve dependencies at build time (see <repositories> below) and at install time (see site/pom.xml#associateSites) -->
 
-		<!-- predefined RedDeer sites, if you need to change default please redefine reddeer-site property in your test -->
-		<reddeer-master-site>http://download.jboss.org/jbosstools/mars/snapshots/builds/reddeer_master/</reddeer-master-site>
-		<reddeer-stable-site>http://download.jboss.org/jbosstools/updates/stable/mars/core/reddeer/1.0.0/</reddeer-stable-site>
-		<reddeer-site>${reddeer-stable-site}</reddeer-site>
 
 		<jbosstools-integrationtests-site>http://download.jboss.org/jbosstools/mars/snapshots/updates/integration-tests/${jbosstools_site_stream}/</jbosstools-integrationtests-site>
 		<jbosstools-site>http://download.jboss.org/jbosstools/mars/snapshots/updates/core/${jbosstools_site_stream}/</jbosstools-site>
@@ -61,11 +57,6 @@
 
 	<repositories>
 		<repository>
-			<id>reddeer-site</id>
-			<url>${reddeer-site}</url>
-			<layout>p2</layout>
-		</repository>
-		<repository>
 			<id>jbosstools</id>
 			<layout>p2</layout>
 			<url>${jbosstools-site}</url>
@@ -77,4 +68,3 @@
 		</repository>
 	</repositories>
 </project>
-


### PR DESCRIPTION
RedDeer is now included in JBT TP so a special
repo definition is no longer needed.
Whenever we need a newer version, we have to create
a JBIDE JIRA.