### PR TITLE
Remove Experimental from WilFly 10 and EAP 7 labels

### DIFF
--- a/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerRequirement.java
+++ b/plugins/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerRequirement.java
@@ -155,7 +155,7 @@ public class ServerRequirement extends ServerReqBase implements Requirement<JBos
 				}
 				
 				if(version.equals("10.x")){
-					serverTypeLabelText = label+" "+ "10.0" +" (Experimental)";
+					serverTypeLabelText = label+" "+ "10.0";
 				}
 			}
 			for (TreeItem item : new DefaultTreeItem("Red Hat JBoss Middleware").getItems()){
@@ -165,7 +165,7 @@ public class ServerRequirement extends ServerReqBase implements Requirement<JBos
 				String label = config.getServerFamily().getLabel();
 				String version = config.getServerFamily().getVersion();
 				if(version.equals("7.x")){
-					serverTypeLabelText = label+" 7.0 (Experimental)";
+					serverTypeLabelText = label+" 7.0";
 				}
 			}
 			sp.selectType(config.getServerFamily().getCategory(), serverTypeLabelText);


### PR DESCRIPTION
From JBDS 9.1 and JBoss Tools onwards, the server adapter
labels for WildFly 10 and EAP 7 no longer contain the suffix
(Experimental), so it needs to be removed in the requirements
definition also, otherwise these server would not be created
successfully in tests.