### PR TITLE
JBIDE-21621 Remove RedDeer repo definition as it is in TP now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,11 +57,6 @@
 
 	<repositories>
 		<repository>
-			<id>reddeer-site</id>
-			<url>${reddeer-site}</url>
-			<layout>p2</layout>
-		</repository>
-		<repository>
 			<id>jbosstools</id>
 			<layout>p2</layout>
 			<url>${jbosstools-site}</url>


### PR DESCRIPTION
JBIDE-21621 added RedDeer to 4.60.0.Alpha1-SNAPSHOT TP,
so from JBoss Tools 4.4.0.Alpha1 onward, we can rely on that
and do not need our own repo definition anymore. When we need to
update RedDeer in TP, we request that in a JIRA.