### PR TITLE
Wait for installation timeout extended in DnD tests.

### DIFF
--- a/tests/org.jboss.tools.central.ui.bot.test/src/org/jboss/tools/central/test/ui/reddeer/DnDTest.java
+++ b/tests/org.jboss.tools.central.ui.bot.test/src/org/jboss/tools/central/test/ui/reddeer/DnDTest.java
@@ -63,7 +63,7 @@ public class DnDTest {
 	}
 
 	private boolean installationStartedCheck() {
-		new WaitWhile(new JobIsRunning());
+		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
 		try {
 			new DefaultShell("Install New Software");
 		} catch (RedDeerException e) {


### PR DESCRIPTION
I saw this failing on Central CI slaves. This should prevent it from happening.