### PR TITLE
Remove dependency on first test class

### DIFF
--- a/tests/org.jboss.tools.batch.ui.bot.test/src/org/jboss/tools/batch/ui/bot/test/AbstractBatchTest.java
+++ b/tests/org.jboss.tools.batch.ui.bot.test/src/org/jboss/tools/batch/ui/bot/test/AbstractBatchTest.java
@@ -16,6 +16,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.jboss.reddeer.common.exception.RedDeerException;
 import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.common.wait.AbstractWait;
 import org.jboss.reddeer.common.wait.TimePeriod;
@@ -81,6 +86,7 @@ public abstract class AbstractBatchTest {
 		importProject();
 		new WaitWhile(new JobIsRunning());
 		getProject().select();
+		createJobXMLFile(JOB_ID);
 	}
 	
 	/**
@@ -103,7 +109,16 @@ public abstract class AbstractBatchTest {
 	 */
 	protected static void removeProject(Logger log) {
 		log.info("Removing " + PROJECT_NAME);
-		getProject().delete(true);
+		IProject project = ResourcesPlugin.getPlugin().getWorkspace().getRoot().getProject(PROJECT_NAME);
+		try {
+			project.delete(true, true, null);
+		} catch (CoreException coreExc) {
+			log.error("Could not delete project or its content");
+			throw new RedDeerException("Project delete operation was not possible to process");
+		} catch (OperationCanceledException cancelExc) {
+			log.error("Delete operation was canceled");
+			throw new RedDeerException("Project delete operation was canceled");
+		}
 		new WaitWhile(new JobIsRunning());
 	}
 	

--- a/tests/org.jboss.tools.batch.ui.bot.test/src/org/jboss/tools/batch/ui/bot/test/editor/design/DesignFlowElementsTestTemplate.java
+++ b/tests/org.jboss.tools.batch.ui.bot.test/src/org/jboss/tools/batch/ui/bot/test/editor/design/DesignFlowElementsTestTemplate.java
@@ -27,6 +27,7 @@ import static org.jboss.tools.batch.reddeer.editor.jobxml.JobXMLEditorSourcePage
 import static org.jboss.tools.batch.reddeer.editor.jobxml.JobXMLEditorSourcePage.REF;
 import static org.jboss.tools.batch.reddeer.editor.jobxml.JobXMLEditorSourcePage.SPLIT;
 
+import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.tools.batch.reddeer.editor.jobxml.JobXMLEditor;
 import org.jboss.tools.batch.reddeer.editor.jobxml.JobXMLEditorDesignPage;
@@ -36,7 +37,9 @@ import org.jboss.tools.batch.reddeer.wizard.NewBatchArtifactWizardDialog;
 import org.jboss.tools.batch.reddeer.wizard.NewBatchArtifactWizardPage;
 import org.jboss.tools.batch.ui.bot.test.AbstractBatchTest;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 @RunWith(RedDeerSuite.class)
@@ -44,10 +47,22 @@ public abstract class DesignFlowElementsTestTemplate extends AbstractBatchTest {
 	
 	protected JobXMLEditor editor;
 	
+	private static Logger log = Logger.getLogger(DesignFlowElementsTestTemplate.class);
+	
 	@Override
 	protected String getPackage(){
 		return "batch.test.editor.design";
 	}
+	
+	@BeforeClass
+	public static void setUpBeforeClass() {
+		initTestResources(log);
+	}
+	
+	@AfterClass
+	public static void tearDownAfterClass() {
+		removeProject(log);
+	}	
 	
 	@Before
 	public void setupEditor(){

--- a/tests/org.jboss.tools.batch.ui.bot.test/src/org/jboss/tools/batch/ui/bot/test/wizard/AbstractCreateArtifactTest.java
+++ b/tests/org.jboss.tools.batch.ui.bot.test/src/org/jboss/tools/batch/ui/bot/test/wizard/AbstractCreateArtifactTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.core.exception.CoreLayerException;
 import org.jboss.reddeer.eclipse.wst.xml.ui.tabletree.XMLMultiPageEditor;
 import org.jboss.reddeer.eclipse.wst.xml.ui.tabletree.XMLSourcePage;
@@ -14,6 +15,8 @@ import org.jboss.tools.batch.reddeer.wizard.NewBatchArtifactWizardDialog;
 import org.jboss.tools.batch.reddeer.wizard.NewBatchArtifactWizardPage;
 import org.jboss.tools.batch.ui.bot.test.AbstractBatchTest;
 import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 public abstract class AbstractCreateArtifactTest extends AbstractBatchTest {
 
@@ -25,9 +28,21 @@ public abstract class AbstractCreateArtifactTest extends AbstractBatchTest {
 
 	protected abstract void createArtifactHook(NewBatchArtifactWizardPage page);
 	
+	private static Logger log = Logger.getLogger(AbstractCreateArtifactTest.class);
+	
 	@Override
 	protected String getPackage() {
 		return "batch.test.wizard.artifact";
+	}
+	
+	@BeforeClass
+	public static void setUpBeforeClass() {
+		initTestResources(log);
+	}
+	
+	@AfterClass
+	public static void tearDownAfterClass() {
+		removeProject(log);
 	}
 
 	@After

--- a/tests/org.jboss.tools.batch.ui.bot.test/src/org/jboss/tools/batch/ui/bot/test/wizard/CreateJobXMLFileTest.java
+++ b/tests/org.jboss.tools.batch.ui.bot.test/src/org/jboss/tools/batch/ui/bot/test/wizard/CreateJobXMLFileTest.java
@@ -1,8 +1,6 @@
 package org.jboss.tools.batch.ui.bot.test.wizard;
 
 import org.jboss.reddeer.common.logging.Logger;
-import org.jboss.reddeer.common.wait.WaitWhile;
-import org.jboss.reddeer.core.condition.JobIsRunning;
 import org.jboss.reddeer.eclipse.ui.perspectives.JavaPerspective;
 import org.jboss.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.jboss.tools.batch.reddeer.editor.jobxml.JobXMLEditor;
@@ -25,8 +23,11 @@ public class CreateJobXMLFileTest extends AbstractBatchTest {
 	@BeforeClass
 	public static void setUpBeforeClass() {
 		initTestResources(log);
-		getProject().select();
-		createJobXMLFile(JOB_ID);
+	}
+	
+	@AfterClass
+	public static void tearDownAfterClass() {
+		removeProject(log);
 	}
 	
 	@Test


### PR DESCRIPTION
To make each test class independent.

Due to upstream bug that causes looping of workspace building,
it was not possible to import/remove project for each test class via UI.
Eclipse API is used to delete project and thus, bug is avoided.