### PR TITLE
JBIDE-23377 Fix EAP integration tests - wrong cleanup

### DIFF
--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as3/DeployJSPProjectAS3Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as3/DeployJSPProjectAS3Server.java
@@ -11,7 +11,7 @@ import org.jboss.reddeer.requirements.server.ServerReqState;
  *
  */
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS3_2)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS3_2,cleanup=false)
 public class DeployJSPProjectAS3Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as3/HotDeployJSPFileAS3Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as3/HotDeployJSPFileAS3Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS3_2)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS3_2,cleanup=false)
 public class HotDeployJSPFileAS3Server extends HotDeployJSPFileTemplate{
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as40/DeployJSPProjectAS40Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as40/DeployJSPProjectAS40Server.java
@@ -11,7 +11,7 @@ import org.jboss.reddeer.requirements.server.ServerReqState;
  *
  */
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS4_0)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS4_0,cleanup=false)
 public class DeployJSPProjectAS40Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as40/HotDeployJSPFileAS40Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as40/HotDeployJSPFileAS40Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS4_0)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS4_0,cleanup=false)
 public class HotDeployJSPFileAS40Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as42/DeployJSPProjectAS42Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as42/DeployJSPProjectAS42Server.java
@@ -10,7 +10,7 @@ import org.jboss.reddeer.requirements.server.ServerReqState;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS4_2)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS4_2,cleanup=false)
 public class DeployJSPProjectAS42Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as42/HotDeployJSPFileAS42Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as42/HotDeployJSPFileAS42Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS4_2)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS4_2,cleanup=false)
 public class HotDeployJSPFileAS42Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as50/DeployJSPProjectAS50Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as50/DeployJSPProjectAS50Server.java
@@ -10,7 +10,7 @@ import org.jboss.reddeer.requirements.server.ServerReqState;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS5_0)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS5_0,cleanup=false)
 public class DeployJSPProjectAS50Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as50/HotDeployJSPFileAS50Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as50/HotDeployJSPFileAS50Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS5_0)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS5_0,cleanup=false)
 public class HotDeployJSPFileAS50Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as51/DeployJSPProjectAS51Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as51/DeployJSPProjectAS51Server.java
@@ -10,7 +10,7 @@ import org.jboss.reddeer.requirements.server.ServerReqState;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS5_1)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS5_1,cleanup=false)
 public class DeployJSPProjectAS51Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as51/HotDeployJSPFileAS51Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as51/HotDeployJSPFileAS51Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS5_1)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS5_1,cleanup=false)
 public class HotDeployJSPFileAS51Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as6/DeployJSPProjectAS6Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as6/DeployJSPProjectAS6Server.java
@@ -10,7 +10,7 @@ import org.jboss.reddeer.requirements.server.ServerReqState;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS6x)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS6x,cleanup=false)
 public class DeployJSPProjectAS6Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as6/HotDeployJSPFileAS6Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as6/HotDeployJSPFileAS6Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS6x)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS6x,cleanup=false)
 public class HotDeployJSPFileAS6Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as70/DeployJSPProjectAS70Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as70/DeployJSPProjectAS70Server.java
@@ -10,7 +10,7 @@ import org.jboss.reddeer.requirements.server.ServerReqState;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS7_0)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS7_0,cleanup=false)
 public class DeployJSPProjectAS70Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as70/HotDeployJSPFileAS70Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as70/HotDeployJSPFileAS70Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS7_0)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS7_0,cleanup=false)
 public class HotDeployJSPFileAS70Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as71/DeployJSPProjectAS71Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as71/DeployJSPProjectAS71Server.java
@@ -10,7 +10,7 @@ import org.jboss.reddeer.requirements.server.ServerReqState;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS7_1)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS7_1,cleanup=false)
 public class DeployJSPProjectAS71Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as71/HotDeployJSPFileAS71Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/as71/HotDeployJSPFileAS71Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS7_1)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.AS7_1,cleanup=false)
 public class HotDeployJSPFileAS71Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap4/DeployJSPProjectEAP4Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap4/DeployJSPProjectEAP4Server.java
@@ -10,7 +10,7 @@ import org.jboss.reddeer.requirements.server.ServerReqState;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP4_3)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP4_3,cleanup=false)
 public class DeployJSPProjectEAP4Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap4/HotDeployJSPFileEAP4Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap4/HotDeployJSPFileEAP4Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP4_3)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP4_3,cleanup=false)
 public class HotDeployJSPFileEAP4Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap5/DeployJSPProjectEAP5Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap5/DeployJSPProjectEAP5Server.java
@@ -10,7 +10,7 @@ import org.jboss.reddeer.requirements.server.ServerReqState;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP5x)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP5x,cleanup=false)
 public class DeployJSPProjectEAP5Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap5/HotDeployJSPFileEAP5Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap5/HotDeployJSPFileEAP5Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP5x)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP5x,cleanup=false)
 public class HotDeployJSPFileEAP5Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap60/DeployJSPProjectEAP60Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap60/DeployJSPProjectEAP60Server.java
@@ -10,7 +10,7 @@ import org.jboss.reddeer.requirements.server.ServerReqState;
  * @author Lucia Jelinkova
  *
  */
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP6_0)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP6_0,cleanup=false)
 public class DeployJSPProjectEAP60Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap60/HotDeployJSPFileEAP60Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap60/HotDeployJSPFileEAP60Server.java
@@ -5,7 +5,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP6_0)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP6_0,cleanup=false)
 public class HotDeployJSPFileEAP60Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap6x/DeployJSPProjectEAP6xServer.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap6x/DeployJSPProjectEAP6xServer.java
@@ -6,7 +6,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP6_1plus, version=ServerReqVersion.EQUAL)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP6_1plus, version=ServerReqVersion.EQUAL,cleanup=false)
 public class DeployJSPProjectEAP6xServer extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap6x/HotDeployJSPFileEAP6xServer.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap6x/HotDeployJSPFileEAP6xServer.java
@@ -6,7 +6,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP6_1plus, version=ServerReqVersion.EQUAL)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP6_1plus, version=ServerReqVersion.EQUAL,cleanup=false)
 public class HotDeployJSPFileEAP6xServer extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap7/DeployJSPProjectEAP7Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap7/DeployJSPProjectEAP7Server.java
@@ -6,7 +6,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP7x, version=ServerReqVersion.EQUAL)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP7x, version=ServerReqVersion.EQUAL,cleanup=false)
 public class DeployJSPProjectEAP7Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap7/HotDeployJSPFileEAP7Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/eap7/HotDeployJSPFileEAP7Server.java
@@ -6,7 +6,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP7x, version=ServerReqVersion.EQUAL)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP7x, version=ServerReqVersion.EQUAL,cleanup=false)
 public class HotDeployJSPFileEAP7Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly10/DeployJSPProjectWildfly10Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly10/DeployJSPProjectWildfly10Server.java
@@ -6,7 +6,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.WILDFLY10x, version=ServerReqVersion.EQUAL)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.WILDFLY10x, version=ServerReqVersion.EQUAL,cleanup=false)
 public class DeployJSPProjectWildfly10Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly10/HotDeployJSPFileWildfly10Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly10/HotDeployJSPFileWildfly10Server.java
@@ -6,7 +6,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.WILDFLY10x, version=ServerReqVersion.EQUAL)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.WILDFLY10x, version=ServerReqVersion.EQUAL,cleanup=false)
 public class HotDeployJSPFileWildfly10Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly8/DeployJSPProjectWildfly8Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly8/DeployJSPProjectWildfly8Server.java
@@ -6,7 +6,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.WILDFLY8x, version=ServerReqVersion.EQUAL)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.WILDFLY8x, version=ServerReqVersion.EQUAL,cleanup=false)
 public class DeployJSPProjectWildfly8Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly8/HotDeployJSPFileWildfly8Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly8/HotDeployJSPFileWildfly8Server.java
@@ -6,7 +6,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.WILDFLY8x, version=ServerReqVersion.EQUAL)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.WILDFLY8x, version=ServerReqVersion.EQUAL,cleanup=false)
 public class HotDeployJSPFileWildfly8Server extends HotDeployJSPFileTemplate {
 
 }

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly9/DeployJSPProjectWildfly9Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly9/DeployJSPProjectWildfly9Server.java
@@ -6,7 +6,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.DeployJSPProjectTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.WILDFLY9x, version=ServerReqVersion.EQUAL)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.WILDFLY9x, version=ServerReqVersion.EQUAL,cleanup=false)
 public class DeployJSPProjectWildfly9Server extends DeployJSPProjectTemplate {
 
 	@Override

--- a/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly9/HotDeployJSPFileWildfly9Server.java
+++ b/tests/org.jboss.ide.eclipse.as.ui.bot.test/src/org/jboss/ide/eclipse/as/ui/bot/test/wildfly9/HotDeployJSPFileWildfly9Server.java
@@ -6,7 +6,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBo
 import org.jboss.ide.eclipse.as.ui.bot.test.template.HotDeployJSPFileTemplate;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.WILDFLY9x, version=ServerReqVersion.EQUAL)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.WILDFLY9x, version=ServerReqVersion.EQUAL,cleanup=false)
 public class HotDeployJSPFileWildfly9Server extends HotDeployJSPFileTemplate {
 
 }


### PR DESCRIPTION
The test cases depend on the previous project still deployed to the server,
so the automatic cleanup broke this - hot deployment will not work
if Eclipse doesn't know that the project is deployed to the server.
Likewise, there is nothing to be undeployed after a cleanup.