### PR TITLE
JBIDE-23624 Remove swtbot.test.skip

### DIFF
--- a/tests/org.jboss.tools.easymport.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.easymport.ui.bot.test/pom.xml
@@ -13,7 +13,7 @@
 	<artifactId>org.jboss.tools.easymport.ui.bot.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
-		<swtbot.test.skip>false</swtbot.test.skip>
+		<skipTests>false</skipTests>
 		<usage_reporting_enabled>false</usage_reporting_enabled>
 		<maven.test.failure.ignore>true</maven.test.failure.ignore>
 	</properties>


### PR DESCRIPTION
A reference of swtbot.test.skip
was left out in easymport test pom.
We don't use this property anymore.

In the near future, we should also remove skipTests definitions from the poms - all tests should run by default. But that will come later.