### PR TITLE
OpenShift 3 fixes

### DIFF
--- a/plugins/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/condition/ConsoleHasSomeText.java
+++ b/plugins/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/condition/ConsoleHasSomeText.java
@@ -11,26 +11,34 @@
 package org.jboss.tools.openshift.reddeer.condition;
 
 import org.jboss.reddeer.common.condition.AbstractWaitCondition;
+import org.jboss.reddeer.common.exception.RedDeerException;
 import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
 
 /**
  * Condition notifies about not empty console.
  * 
+ * TODO replace this condition by RedDeer implementation of ConsoleHasText, once
+ * RedDeer implementation is updated
+ * 
  * @author mlabuda@redhat.com
  *
  */
-public class ConsoleHasText extends AbstractWaitCondition{
+public class ConsoleHasSomeText extends AbstractWaitCondition{
 
 	private ConsoleView consoleView;
 	
-	public ConsoleHasText() {
+	public ConsoleHasSomeText() {
 		consoleView = new ConsoleView();
 		consoleView.open();
 	}
 	
 	@Override
 	public boolean test() {
-		return !consoleView.getConsoleText().isEmpty();
+		try {
+			return !consoleView.getConsoleText().isEmpty();
+		} catch (RedDeerException ex) {
+			return false;
+		}
 	}
 
 	@Override

--- a/plugins/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/requirement/OpenShiftCommandLineToolsRequirement.java
+++ b/plugins/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/requirement/OpenShiftCommandLineToolsRequirement.java
@@ -156,14 +156,14 @@ public class OpenShiftCommandLineToolsRequirement implements Requirement<OCBinar
 	private String getDownloadLink() {
 		if (Platform.OS_LINUX.equals(Platform.getOS())) {
 			if (Platform.getOSArch().equals(Platform.ARCH_X86)) {
-				return ClientVersion.LINUX_1_2_32.getDownloadLink();
+				return ClientVersion.LINUX_1_3_32.getDownloadLink();
 			} else { 
-				return ClientVersion.LINUX_1_2_64.getDownloadLink();
+				return ClientVersion.LINUX_1_3_64.getDownloadLink();
 			}
 		} else if (Platform.OS_WIN32.equals(Platform.getOSArch())){
-			return ClientVersion.WINDOWS_1_2_64.getDownloadLink();
+			return ClientVersion.WINDOWS_1_3_64.getDownloadLink();
 		} else if (Platform.OS_MACOSX.equals(Platform.getOSArch())){
-			return ClientVersion.MAC_1_2.getDownloadLink();
+			return ClientVersion.MAC_1_3.getDownloadLink();
 		} else {
 			return null;
 		}
@@ -184,7 +184,17 @@ public class OpenShiftCommandLineToolsRequirement implements Requirement<OCBinar
 		WINDOWS_1_2_64("https://github.com/openshift/origin/releases/download/"
 				+ "v1.2.0/openshift-origin-client-tools-v1.2.0-2e62fab-windows.zip"),
 		MAC_1_2("https://github.com/openshift/origin/releases/download/" 
-				+ "v1.2.0/openshift-origin-client-tools-v1.2.0-2e62fab-mac.zip");
+				+ "v1.2.0/openshift-origin-client-tools-v1.2.0-2e62fab-mac.zip"),
+		
+		LINUX_1_3_32("https://github.com/openshift/origin/releases/download/"
+				+ "v1.3.1/openshift-origin-client-tools-v1.3.1-dad658de7465ba8a234a4fb40b5b446a45a4cee1-linux-32bit.tar.gz"),
+		LINUX_1_3_64("https://github.com/openshift/origin/releases/download/"
+				+ "v1.3.1/openshift-origin-client-tools-v1.3.1-dad658de7465ba8a234a4fb40b5b446a45a4cee1-linux-64bit.tar.gz"),
+		WINDOWS_1_3_64("https://github.com/openshift/origin/releases/download/"
+				+ "v1.3.1/openshift-origin-client-tools-v1.3.1-dad658de7465ba8a234a4fb40b5b446a45a4cee1-windows.zip"),
+		MAC_1_3("https://github.com/openshift/origin/releases/download/"
+				+ "v1.3.1/openshift-origin-client-tools-v1.3.1-2748423-mac.zip");
+		
 		String url;
 		
 		private ClientVersion(String url) {

--- a/plugins/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/OpenShiftLabel.java
+++ b/plugins/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/OpenShiftLabel.java
@@ -334,7 +334,7 @@ public class OpenShiftLabel {
 	public static class Others {
 		public static final String CONNECT_TOOL_ITEM = "Connection...";
 		public static final String EAP_TEMPLATE = "eap64-basic-s2i (eap, javaee, java, jboss, xpaas) - openshift";
-		public static final String EAP_BUILDER_IMAGE = "jboss-eap64-openshift:1.2 (builder, eap, javaee, java, jboss, xpaas) - openshift";
+		public static final String EAP_BUILDER_IMAGE = "jboss-eap64-openshift:1.3 (builder, eap, javaee, java, jboss, xpaas) - openshift";
 		public static final String NODEJS_TEMPLATE = "nodejs-example (quickstart, nodejs) - openshift";
 		public static final String RED_HAT_CENTRAL = "Red Hat Central";
 		public static final String[] NEW_APP_MENU = {"File", "New", "OpenShift Application"};

--- a/plugins/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/wizard/v3/TemplatesCreator.java
+++ b/plugins/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/wizard/v3/TemplatesCreator.java
@@ -12,7 +12,6 @@ package org.jboss.tools.openshift.reddeer.wizard.v3;
 
 import java.util.List;
 
-import org.eclipse.ui.actions.ImportResourcesAction;
 import org.jboss.reddeer.common.exception.WaitTimeoutExpiredException;
 import org.jboss.reddeer.common.wait.TimePeriod;
 import org.jboss.reddeer.common.wait.WaitUntil;

--- a/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/handle/ID705TailFilesTest.java
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/handle/ID705TailFilesTest.java
@@ -29,7 +29,7 @@ import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.swt.impl.table.DefaultTable;
 import org.jboss.reddeer.swt.impl.text.LabeledText;
 import org.jboss.reddeer.workbench.api.View;
-import org.jboss.tools.openshift.reddeer.condition.ConsoleHasText;
+import org.jboss.tools.openshift.reddeer.condition.ConsoleHasSomeText;
 import org.jboss.tools.openshift.reddeer.utils.DatastoreOS2;
 import org.jboss.tools.openshift.reddeer.utils.OpenShiftLabel;
 import org.jboss.tools.openshift.reddeer.view.OpenShiftExplorerView;
@@ -106,7 +106,7 @@ public class ID705TailFilesTest extends IDXXXCreateTestingApplication {
 		console.open();
 		
 		try {
-			new WaitUntil(new ConsoleHasText(), TimePeriod.LONG);
+			new WaitUntil(new ConsoleHasSomeText(), TimePeriod.LONG);
 		} catch (WaitTimeoutExpiredException ex) {
 			fail("Console should not be empty.");
 		}

--- a/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/v3/adapter/CreateServerAdapterTest.java
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/v3/adapter/CreateServerAdapterTest.java
@@ -48,10 +48,8 @@ public class CreateServerAdapterTest extends AbstractCreateApplicationTest {
 
 	@BeforeClass
 	public static void waitTillApplicationIsRunning() {
-		new WaitUntil(new OpenShiftResourceExists(Resource.BUILD, "eap-app-1", ResourceState.RUNNING),
-				TimePeriod.getCustom(60), false);
 		new WaitWhile(new OpenShiftResourceExists(Resource.BUILD, "eap-app-1", ResourceState.RUNNING),
-				TimePeriod.getCustom(360), false);
+				TimePeriod.getCustom(600));
 		new WaitUntil(new AmountOfResourcesExists(Resource.POD, 2), TimePeriod.LONG, false);
 	}
 	

--- a/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/v3/adapter/ServerAdapterWizardHandlingTest.java
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/v3/adapter/ServerAdapterWizardHandlingTest.java
@@ -18,6 +18,7 @@ import org.jboss.reddeer.common.exception.WaitTimeoutExpiredException;
 import org.jboss.reddeer.common.wait.TimePeriod;
 import org.jboss.reddeer.common.wait.WaitUntil;
 import org.jboss.reddeer.common.wait.WaitWhile;
+import org.jboss.reddeer.core.condition.JobIsKilled;
 import org.jboss.reddeer.core.condition.JobIsRunning;
 import org.jboss.reddeer.core.condition.ShellWithTextIsActive;
 import org.jboss.reddeer.core.util.Display;
@@ -194,6 +195,8 @@ public class ServerAdapterWizardHandlingTest extends AbstractCreateApplicationTe
 		dialog.open();
 		page.selectType(OpenShiftLabel.Others.OS3_SERVER_ADAPTER);
 		dialog.next();
+		
+		new WaitUntil(new JobIsKilled("Refreshing server adapter list"), TimePeriod.LONG);
 	}
 	
 	@After

--- a/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/v3/advanced/DeleteResourceTest.java
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/v3/advanced/DeleteResourceTest.java
@@ -32,7 +32,7 @@ public class DeleteResourceTest extends AbstractCreateApplicationTest {
 
 	@BeforeClass
 	public static void waitForApplication() {
-		new WaitUntil(new OpenShiftResourceExists(Resource.POD, "eap-app-1-build", ResourceState.SUCCEEDED), 
+		new WaitUntil(new OpenShiftResourceExists(Resource.BUILD, "eap-app-1", ResourceState.COMPLETE), 
 				TimePeriod.getCustom(600), true, TimePeriod.getCustom(8));
 		
 		new WaitUntil(new AmountOfResourcesExists(Resource.POD, 2), TimePeriod.VERY_LONG, true,

--- a/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/v3/advanced/DeployEclipseProjectTest.java
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/v3/advanced/DeployEclipseProjectTest.java
@@ -215,7 +215,7 @@ public class DeployEclipseProjectTest {
 		new WaitWhile(new ShellWithTextIsAvailable(OpenShiftLabel.Shell.NEW_APP_WIZARD), TimePeriod.LONG);
 		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
 		
-		new WaitUntil(new OpenShiftResourceExists(Resource.POD, "eap-app-1-build", ResourceState.SUCCEEDED), 
+		new WaitUntil(new OpenShiftResourceExists(Resource.BUILD, "eap-app-1", ResourceState.COMPLETE), 
 				TimePeriod.getCustom(1000), true, TimePeriod.getCustom(8));
 		new WaitUntil(new AmountOfResourcesExists(Resource.POD, 2), TimePeriod.VERY_LONG, true,
 				TimePeriod.getCustom(5));

--- a/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/v3/advanced/ImportApplicationTest.java
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/v3/advanced/ImportApplicationTest.java
@@ -110,7 +110,7 @@ public class ImportApplicationTest extends AbstractCreateApplicationTest {
 		
 		ProjectExplorer projectExplorer = new ProjectExplorer();
 		projectExplorer.open();
-		assertTrue("There should be imported kitchen sink project, but there is not",
+		assertTrue("There should be imported " + projectName + "project, but there is not",
 				projectExplorer.containsProject(projectName));
 		
 		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);

--- a/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/v3/advanced/PortForwardingTest.java
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/v3/advanced/PortForwardingTest.java
@@ -46,8 +46,8 @@ public class PortForwardingTest extends AbstractCreateApplicationTest {
 	public static void setUpOCBinaryAndWaitForApplication() {
 		TestUtils.setUpOcBinary();
 		
-		new WaitUntil(new OpenShiftResourceExists(Resource.POD, "eap-app-1-build",
-				ResourceState.SUCCEEDED), TimePeriod.getCustom(600),
+		new WaitUntil(new OpenShiftResourceExists(Resource.BUILD, "eap-app-1",
+				ResourceState.COMPLETE), TimePeriod.getCustom(600),
 				true, TimePeriod.getCustom(7));
 		
 		new WaitUntil(new AmountOfResourcesExists(Resource.POD, 2), TimePeriod.VERY_LONG,

--- a/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/v3/create/AbstractCreateApplicationTest.java
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/v3/create/AbstractCreateApplicationTest.java
@@ -22,6 +22,7 @@ import org.jboss.tools.openshift.reddeer.utils.OpenShiftLabel;
 import org.jboss.tools.openshift.reddeer.utils.TestUtils;
 import org.jboss.tools.openshift.reddeer.view.OpenShiftExplorerView;
 import org.jboss.tools.openshift.reddeer.view.resources.OpenShift3Connection;
+import org.jboss.tools.openshift.reddeer.wizard.v3.TemplateParameter;
 import org.jboss.tools.openshift.reddeer.wizard.v3.TemplatesCreator;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -30,8 +31,11 @@ import org.junit.BeforeClass;
 public class AbstractCreateApplicationTest {
 
 	public static String gitFolder = "jboss-eap-quickstarts";
-	public static String projectName = "jboss-kitchensink";
+	public static String projectName = "jboss-helloworld";
 	public static String buildConfigName = "eap-app";
+	
+	// context dir for new applications is helloworld
+	public static String CONTEXT_DIR = "helloworld";
 	
 	protected static TreeViewerHandler treeViewerHandler = TreeViewerHandler.getInstance();
 	
@@ -45,7 +49,8 @@ public class AbstractCreateApplicationTest {
 			new OpenShiftExplorerView().getOpenShift3Connection().createNewProject();
 		}
 		
-		new TemplatesCreator().createOpenShiftApplicationBasedOnServerTemplate(OpenShiftLabel.Others.EAP_TEMPLATE);
+		new TemplatesCreator().createOpenShiftApplicationBasedOnServerTemplate(
+				OpenShiftLabel.Others.EAP_TEMPLATE, new TemplateParameter("CONTEXT_DIR", "helloworld"));
 	}
 	
 	@AfterClass


### PR DESCRIPTION
OpenShift 3 Smoke suite should be almost OK. Publish Test will need more love, but for now it is better.
What has been done:
- oc version upgraded
- fixed issue of ConsoleHasText if no console is available/there is no styled  text in console
- updated builder image, started to use 1.3 instead of 1.2
- server adapter test stabilized by killing refreshing server adapter info
- revamped port wizard page in builder image wizard
- logged tests revamped, removed 2 out of dated