### PR TITLE
[JBIDE-23629] fixed AddConnectionTest to lookup conns by host

### DIFF
--- a/plugins/org.jboss.tools.docker.reddeer/src/org/jboss/tools/docker/reddeer/core/ui/wizards/NewDockerConnectionPage.java
+++ b/plugins/org.jboss.tools.docker.reddeer/src/org/jboss/tools/docker/reddeer/core/ui/wizards/NewDockerConnectionPage.java
@@ -35,7 +35,6 @@ import org.jboss.tools.docker.reddeer.ui.DockerExplorerView;
  * @author jkopriva@redhat.com
  *
  */
-
 public class NewDockerConnectionPage extends WizardPage {
 	private static final String NEW_DOCKER_CONNECTION_SHELL = "New Docker Connection";
 
@@ -66,7 +65,6 @@ public class NewDockerConnectionPage extends WizardPage {
 		setConnectionName(unixSocket);
 		new CheckBox("Use custom connection settings:").toggle(true);
 		new LabeledText("Location:").setText(unixSocket);
-
 	}
 
 	public void setTcpConnection(String uri) {

--- a/tests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/CDKDevstudioBaseTest.java
+++ b/tests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/CDKDevstudioBaseTest.java
@@ -225,7 +225,7 @@ public class CDKDevstudioBaseTest {
 		startServerAdapter();
 		DockerExplorerView dockerExplorer = new DockerExplorerView();
 		dockerExplorer.open();
-		DockerConnection connection =  dockerExplorer.getDockerConnection(DOCKER_DAEMON_CONNECTION);
+		DockerConnection connection =  dockerExplorer.getDockerConnectionByName(DOCKER_DAEMON_CONNECTION);
 		if (connection == null) {
 			fail("Could not find Docker connection " + DOCKER_DAEMON_CONNECTION);
 		}

--- a/tests/org.jboss.tools.docker.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.docker.ui.bot.test/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit,
+ org.eclipse.linuxtools.docker.ui;bundle-version="2.1.0",
  org.jboss.reddeer.go,
  org.jboss.tools.docker.reddeer;bundle-version="[4.4.2,4.5.0)",
  org.jboss.reddeer.eclipse,
@@ -14,7 +15,8 @@ Require-Bundle: org.junit,
  org.jboss.reddeer.workbench,
  org.jboss.reddeer.junit,
  org.jboss.reddeer.core,
- org.jboss.ide.eclipse.as.reddeer
+ org.jboss.ide.eclipse.as.reddeer,
+ org.apache.commons.lang;bundle-version="2.6.0"
 Import-Package: org.eclipse.core.resources
 Eclipse-BundleShape: jar
 

--- a/tests/org.jboss.tools.docker.ui.bot.test/README
+++ b/tests/org.jboss.tools.docker.ui.bot.test/README
@@ -1,10 +1,64 @@
-Parameters:
--Dusage_reporting_enabled=false							disable reporting
--DdockerServerURI=tcp://localhost:2375					docker server uri(ex. "tcp://localhost:2375")*
--DunixSocket=unix:///var/run/docker.sock				docker server socket(ex. "unix:///var/run/docker.sock")*
--DsearchConnection=true									use search for finding docker host
--DdockerHubUsername=<username>							username for Docker hub account
--DdockerHubEmail=<email>								email for Docker hub account
--DdockerHubPassword=<password>							password for Docker hub account
+Running in Eclipse
+------------------
+* Launch configuration: 
+ ** use a Red Deer launcher
+ ** "Red Deer" Tab:
+ rd.closeWelcomeScreen = true
+ ** "Arguments" Tab:
+   -Dusage_reporting_enabled=false
+   -DdockerServerURI=
+   -DunixSocket=unix:///var/run/docker.sock 
+   -DdockerMachineName=
+   -DdockerHubUsername=<username>
+   -DdockerHubEmail=<email>
+   -DdockerHubPassword=<password>
+   -DskipTests=false
 
-*User should use one of from these parameters, if he not specify any, then unixSocket with default value "unix:///var/run/docker.sock" is used.
+Running in Command Line
+-----------------------
+mvn clean verify
+-Dusage_reporting_enabled=false \
+-DdockerServerURI= \
+-DunixSocket=unix:///var/run/docker.sock \ 
+-DdockerMachineName=
+-DdockerHubUsername=<username> \
+-DdockerHubEmail=<email> \
+-DdockerHubPassword=<password> \
+-DskipTests=false
+
+
+usage_reporting_enabled
+-----------------------
+disables reporting
+
+dockerServerURI*
+---------------
+Docker server uri (ex. "tcp://localhost:2375"). Typically used in Windows.
+Takes precedence over unix socket.
+The user should either specify server uri or unix socket. 
+If he doesnt, unix socket with default value "unix:///var/run/docker.sock" is used
+
+unixSocket*
+----------
+Docker server unix socket (ex. "unix:///var/run/docker.sock"). Typically used in Linux or MacOS
+The user should either specify server uri or unix socket. 
+If he doesnt, unix socket with default value "unix:///var/run/docker.sock" is used
+
+dockerMachineName
+-----------------
+The docker-machine name that the tests should use to connect to (ex. "default").   
+This only works if you have docker-machine set up and running. 
+Takes precedence over server uri or unix socket that are provided.
+
+dockerHubUsername
+-----------------
+Username for the Docker hub account.
+
+dockerHubEmail
+--------------
+Email for the Docker hub account.
+
+dockerHubPassword
+-----------------
+Password for the Docker hub account.
+

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/connection/AddConnectionTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/connection/AddConnectionTest.java
@@ -12,7 +12,6 @@
 package org.jboss.tools.docker.ui.bot.test.connection;
 
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -20,23 +19,17 @@ import org.junit.Test;
  * 
  * 
  * @author jkopriva
+ * @contributor adietish@redhat.com
  */
-
 public class AddConnectionTest extends AbstractDockerBotTest {
 
 	@Before
-	public void before() {
-		openDockerPerspective();
+	public void setUp() {
+		deleteAllConnections();
 	}
-
+	
 	@Test
 	public void testAddConnection() {
 		createConnection();
 	}
-
-	@After
-	public void after() {
-		deleteConnection();
-	}
-
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/container/DockerContainerTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/container/DockerContainerTest.java
@@ -20,10 +20,8 @@ import org.jboss.reddeer.core.exception.CoreLayerException;
 import org.jboss.reddeer.eclipse.condition.ConsoleHasNoChange;
 import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
 import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunSelectionPage;
-import org.jboss.tools.docker.reddeer.ui.DockerExplorerView;
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -36,15 +34,8 @@ public class DockerContainerTest extends AbstractDockerBotTest {
 	private String imageName = "docker/whalesay";
 	private String containerName = "test_run";
 
-	@Before
-	public void before() {
-		openDockerPerspective();
-		createConnection();
-	}
-
 	@Test
 	public void testDockerContainer() {
-		String dockerServer = getDockerServer();
 		ConsoleView cview = new ConsoleView();
 		cview.open();
 		try {
@@ -55,7 +46,7 @@ public class DockerContainerTest extends AbstractDockerBotTest {
 		pullImage(imageName);
 		assertTrue("Image has not been found!", imageIsDeployed(getCompleteImageName(imageName)));
 
-		new DockerExplorerView().getDockerConnection(dockerServer).getImage(getCompleteImageName(imageName)).run();
+		getConnection().getImage(getCompleteImageName(imageName)).run();
 		ImageRunSelectionPage firstPage = new ImageRunSelectionPage();
 		firstPage.setName(this.containerName);
 		firstPage.finish();
@@ -67,7 +58,6 @@ public class DockerContainerTest extends AbstractDockerBotTest {
 	@After
 	public void after() {
 		deleteImageContainerAfter(containerName, imageName);
-		deleteConnection();
 	}
 
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/container/ExposePortTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/container/ExposePortTest.java
@@ -22,7 +22,6 @@ import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunSelectionPage;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -36,12 +35,6 @@ public class ExposePortTest extends AbstractDockerBotTest {
 	private String imageName = "jboss/wildfly";
 	private String imageTag = "10.0.0.Final";
 	private String containerName = "test_run_wildfly";
-
-	@Before
-	public void before() {
-		openDockerPerspective();
-		createConnection();
-	}
 
 	@Test
 	public void testExposePort() throws IOException {
@@ -67,7 +60,6 @@ public class ExposePortTest extends AbstractDockerBotTest {
 	public void after() {
 		deleteContainer(containerName);
 		deleteImage(imageName, imageTag);
-		deleteConnection();
 	}
 
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/container/LabelsTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/container/LabelsTest.java
@@ -16,9 +16,8 @@ import static org.junit.Assert.assertTrue;
 import org.jboss.reddeer.common.wait.WaitWhile;
 import org.jboss.reddeer.core.condition.JobIsRunning;
 import org.jboss.reddeer.eclipse.ui.views.properties.PropertiesView;
-import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunSelectionPage;
 import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunResourceVolumesVariablesPage;
-import org.jboss.tools.docker.reddeer.ui.DockerExplorerView;
+import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunSelectionPage;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
@@ -35,12 +34,6 @@ public class LabelsTest extends AbstractDockerBotTest {
 	private String imageName = "debian";
 	private String imageTag = "jessie";
 	private String containerName = "test_run_debian_label";
-
-	@Before
-	public void before() {
-		openDockerPerspective();
-		createConnection();
-	}
 
 	@Test
 	public void testLabels() {
@@ -60,7 +53,7 @@ public class LabelsTest extends AbstractDockerBotTest {
 		secondPage.addLabel("foo", "bar");
 		secondPage.finish();
 		new WaitWhile(new JobIsRunning());
-		new DockerExplorerView().getDockerConnection(getDockerServer()).getContainer(containerName).select();
+		getConnection().getContainer(containerName).select();
 		PropertiesView propertiesView = new PropertiesView();
 		propertiesView.open();
 		propertiesView.selectTab("Inspect");
@@ -71,7 +64,6 @@ public class LabelsTest extends AbstractDockerBotTest {
 	@After
 	public void after() {
 		deleteImageContainerAfter(containerName,imageName + ":" + imageTag);
-		deleteConnection();
 	}
 
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/container/LinkContainersTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/container/LinkContainersTest.java
@@ -18,14 +18,12 @@ import org.jboss.reddeer.common.wait.WaitWhile;
 import org.jboss.reddeer.core.condition.JobIsRunning;
 import org.jboss.reddeer.eclipse.condition.ConsoleHasNoChange;
 import org.jboss.reddeer.eclipse.ui.views.properties.PropertiesView;
-import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunSelectionPage;
 import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunResourceVolumesVariablesPage;
-import org.jboss.tools.docker.reddeer.ui.DockerExplorerView;
+import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunSelectionPage;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
 import org.jboss.tools.docker.reddeer.ui.DockerTerminal;
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -40,12 +38,6 @@ public class LinkContainersTest extends AbstractDockerBotTest {
 	private String imageTag = "latest";
 	private String containerNameDB = "test_run_mariadb";
 	private String containerNameClient = "test_connect_mariadb";
-
-	@Before
-	public void before() {
-		openDockerPerspective();
-		createConnection();
-	}
 
 	@Test
 	public void testLinkContainers() {
@@ -74,7 +66,7 @@ public class LinkContainersTest extends AbstractDockerBotTest {
 	}
 
 	public String getDBAddress() {
-		new DockerExplorerView().getDockerConnection(getDockerServer()).getContainer(containerNameDB).select();
+		getConnection().getContainer(containerNameDB).select();
 		PropertiesView propertiesView = new PropertiesView();
 		propertiesView.open();
 		propertiesView.selectTab("Inspect");
@@ -108,7 +100,6 @@ public class LinkContainersTest extends AbstractDockerBotTest {
 	@After
 	public void after() {
 		deleteImageContainerAfter(containerNameClient, containerNameDB, imageName + ":" + imageTag);
-		deleteConnection();
 	}
 
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/container/PrivilegedModeTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/container/PrivilegedModeTest.java
@@ -17,11 +17,9 @@ import org.jboss.reddeer.common.wait.WaitWhile;
 import org.jboss.reddeer.core.condition.JobIsRunning;
 import org.jboss.reddeer.eclipse.ui.views.properties.PropertiesView;
 import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunSelectionPage;
-import org.jboss.tools.docker.reddeer.ui.DockerExplorerView;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -35,12 +33,6 @@ public class PrivilegedModeTest extends AbstractDockerBotTest {
 	private String imageName = "debian";
 	private String imageTag = "jessie";
 	private String containerName = "test_run_debian";
-
-	@Before
-	public void before() {
-		openDockerPerspective();
-		createConnection();
-	}
 
 	@Test
 	public void testPrivilegedMode() {
@@ -57,7 +49,7 @@ public class PrivilegedModeTest extends AbstractDockerBotTest {
 		firstPage.setGiveExtendedPrivileges();
 		firstPage.finish();
 		new WaitWhile(new JobIsRunning());
-		new DockerExplorerView().getDockerConnection(getDockerServer()).getContainer(containerName).select();
+		getConnection().getContainer(containerName).select();
 		PropertiesView propertiesView = new PropertiesView();
 		propertiesView.open();
 		propertiesView.selectTab("Inspect");
@@ -69,7 +61,6 @@ public class PrivilegedModeTest extends AbstractDockerBotTest {
 	public void after() {
 		deleteContainer(this.containerName);
 		deleteImage(imageName, imageTag);
-		deleteConnection();
 	}
 
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/container/VariablesTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/container/VariablesTest.java
@@ -23,12 +23,11 @@ import org.jboss.reddeer.common.wait.WaitWhile;
 import org.jboss.reddeer.core.condition.JobIsRunning;
 import org.jboss.reddeer.eclipse.condition.ConsoleHasNoChange;
 import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
-import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunSelectionPage;
 import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunResourceVolumesVariablesPage;
+import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunSelectionPage;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -39,12 +38,6 @@ import org.junit.Test;
 
 public class VariablesTest extends AbstractDockerBotTest {
 	private static String imageName = "test_variables";
-
-	@Before
-	public void before() {
-		openDockerPerspective();
-		createConnection();
-	}
 
 	@Test
 	public void testVariables() {
@@ -87,7 +80,6 @@ public class VariablesTest extends AbstractDockerBotTest {
 		deleteContainer(imageName + "_run");
 		deleteImage(imageName);
 		deleteImage("busybox");
-		deleteConnection();
 	}
 
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/container/VolumeMountTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/container/VolumeMountTest.java
@@ -21,12 +21,11 @@ import org.jboss.reddeer.common.wait.WaitWhile;
 import org.jboss.reddeer.core.condition.JobIsRunning;
 import org.jboss.reddeer.eclipse.condition.ConsoleHasNoChange;
 import org.jboss.reddeer.eclipse.ui.browser.BrowserView;
-import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunSelectionPage;
 import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunResourceVolumesVariablesPage;
+import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunSelectionPage;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -43,12 +42,6 @@ public class VolumeMountTest extends AbstractDockerBotTest {
 	private String deploymentPath = "resources/wildfly-deployments";
 	private String containerPath = "/opt/jboss/wildfly/standalone/deployments/";
 	private String quickstartURL = "wildfly-helloworld";
-
-	@Before
-	public void before() {
-		openDockerPerspective();
-		createConnection();
-	}
 
 	@Test
 	public void testVolumeMount() throws IOException {
@@ -85,7 +78,6 @@ public class VolumeMountTest extends AbstractDockerBotTest {
 	public void after() {
 		deleteContainer(this.containerName);
 		deleteImage(imageName, imageTag);
-		deleteConnection();
 	}
 
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/BuildImageTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/BuildImageTest.java
@@ -25,7 +25,6 @@ import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -36,11 +35,6 @@ import org.junit.Test;
 
 public class BuildImageTest extends AbstractDockerBotTest {
 	private static String imageName = "test_build";
-
-	@Before
-	public void before() {
-		prepareWorkspace();
-	}
 
 	@Test
 	public void testBuildImage() {

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/HierarchyViewTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/HierarchyViewTest.java
@@ -25,12 +25,10 @@ import org.jboss.reddeer.core.condition.JobIsRunning;
 import org.jboss.reddeer.core.condition.ShellWithTextIsAvailable;
 import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
 import org.jboss.reddeer.swt.api.TreeItem;
-import org.jboss.tools.docker.reddeer.ui.DockerExplorerView;
 import org.jboss.tools.docker.reddeer.ui.DockerImageHierarchyTab;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -41,11 +39,6 @@ import org.junit.Test;
 
 public class HierarchyViewTest extends AbstractDockerBotTest {
 	private static String imageName = "test_build";
-
-	@Before
-	public void before() {
-		prepareWorkspace();
-	}
 
 	@Test
 	public void testHierarchyView() {
@@ -65,7 +58,7 @@ public class HierarchyViewTest extends AbstractDockerBotTest {
 		consoleView.open();
 		assertFalse("Console has no output!", consoleView.getConsoleText().isEmpty());
 		assertTrue("Build has not been successful", consoleView.getConsoleText().contains("Successfully built"));
-		new DockerExplorerView().getDockerConnection(getDockerServer()).getImage(imageName).openImageHierarchy();
+		getConnection().getImage(imageName).openImageHierarchy();
 		new WaitWhile(new ShellWithTextIsAvailable("Docker Image Hierarchy"));
 		DockerImageHierarchyTab hierarchyTab = new DockerImageHierarchyTab();
 		hierarchyTab.open();

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/ImageTagTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/ImageTagTest.java
@@ -22,7 +22,6 @@ import org.jboss.reddeer.swt.impl.button.OkButton;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -36,11 +35,6 @@ public class ImageTagTest extends AbstractDockerBotTest {
 	private static String imageNameToPull = "busybox:latest";
 	private static String imageTag = "testtag";
 	private static String imageTagUppercase = "UPPERCASETAG";
-
-	@Before
-	public void before() {
-		prepareWorkspace();
-	}
 
 	@Test
 	public void testAddRemoveTagToImage() {

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/PullImageTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/PullImageTest.java
@@ -19,7 +19,6 @@ import org.jboss.reddeer.core.exception.CoreLayerException;
 import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -31,12 +30,6 @@ import org.junit.Test;
 public class PullImageTest extends AbstractDockerBotTest {
 	private String imageName = "busybox";
 	private String imageNameNoTag = "jboss/wildfly";
-
-	@Before
-	public void before() {
-		openDockerPerspective();
-		createConnection();
-	}
 
 	@Test
 	public void testPullImage() {
@@ -70,7 +63,6 @@ public class PullImageTest extends AbstractDockerBotTest {
 	@After
 	public void after() {
 		deleteImageContainerAfter(imageName,imageNameNoTag);
-		deleteConnection();
 	}
 
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/PushImageTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/PushImageTest.java
@@ -22,11 +22,9 @@ import org.jboss.reddeer.common.wait.TimePeriod;
 import org.jboss.reddeer.common.wait.WaitWhile;
 import org.jboss.reddeer.core.condition.JobIsRunning;
 import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
-import org.jboss.tools.docker.reddeer.ui.DockerExplorerView;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -36,23 +34,23 @@ import org.junit.Test;
  */
 
 public class PushImageTest extends AbstractDockerBotTest {
+
+	private static final String DOCKER_HUB_PASSWORD = "dockerHubPassword";
+	private static final String DOCKER_HUB_EMAIL = "dockerHubEmail";
+	private static final String DOCKER_HUB_USERNAME = "dockerHubUsername";
+
 	private static String imageName = "test_push";
-	private static String registryAccount = System.getProperty("dockerHubUsername") + "@https://index.docker.io";
+	private static String registryAccount = System.getProperty(DOCKER_HUB_USERNAME) + "@https://index.docker.io";
 	private static String registryAddress = "https://index.docker.io";
-	private static String imageTag = System.getProperty("dockerHubUsername") + "/variables";
+	private static String imageTag = System.getProperty(DOCKER_HUB_USERNAME) + "/variables";
 	private String seconds = "";
 	private String imageNewTag = "";
 
-	@Before
-	public void before() {
-		prepareWorkspace();
-	}
-
 	@Test
 	public void pushImage() {
-		String dockerHubUsername = System.getProperty("dockerHubUsername");
-		String dockerHubEmail = System.getProperty("dockerHubEmail");
-		String dockerHubPassword = System.getProperty("dockerHubPassword");
+		String dockerHubUsername = System.getProperty(DOCKER_HUB_USERNAME);
+		String dockerHubEmail = System.getProperty(DOCKER_HUB_EMAIL);
+		String dockerHubPassword = System.getProperty(DOCKER_HUB_PASSWORD);
 		if (dockerHubUsername == null || dockerHubUsername.isEmpty() || dockerHubEmail == null
 				|| dockerHubEmail.isEmpty() || dockerHubPassword == null || dockerHubPassword.isEmpty()) {
 			fail("At least one of credentials is null or empty! dockerHubUsername:" + dockerHubUsername + " dockerHubEmail:"
@@ -79,12 +77,12 @@ public class PushImageTest extends AbstractDockerBotTest {
 		java.util.Date date = new java.util.Date();
 		seconds = String.valueOf(date.getTime());
 		imageNewTag = imageTag + ":" + seconds;
-		new DockerExplorerView().getDockerConnection(getDockerServer()).getImage(imageName).addTagToImage(imageNewTag);
-		new DockerExplorerView().getDockerConnection(getDockerServer()).getImage(imageTag, seconds)
+		getConnection().getImage(imageName).addTagToImage(imageNewTag);
+		getConnection().getImage(imageTag, seconds)
 				.pushImage(registryAccount, false, false);
 		new WaitWhile(new JobIsRunning(), TimePeriod.VERY_LONG);
 		deleteImage(imageTag, seconds);
-		new DockerExplorerView().getDockerConnection(getDockerServer()).pullImage(imageTag, seconds, registryAddress);
+		getConnection().pullImage(imageTag, seconds, registryAddress);
 		new WaitWhile(new JobIsRunning(), TimePeriod.VERY_LONG);
 		assertTrue("Image has not been pushed/pulled!", imageIsDeployed(imageTag));
 	}

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/ComposeTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/ComposeTest.java
@@ -40,7 +40,6 @@ import org.jboss.tools.docker.reddeer.preferences.DockerComposePreferencePage;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -53,11 +52,6 @@ public class ComposeTest extends AbstractDockerBotTest {
 	private static String imageName = "test_compose";
 	private static final String URL = "http://0.0.0.0:5000/";
 	private static final String DOCKER_COMPOSE_PATH = "/usr/local/bin";
-
-	@Before
-	public void before() {
-		prepareWorkspace();
-	}
 
 	@Test
 	public void testCompose() {

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/ContainerTabTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/ContainerTabTest.java
@@ -20,11 +20,9 @@ import org.jboss.reddeer.eclipse.ui.views.properties.PropertiesView;
 import org.jboss.reddeer.swt.api.TableItem;
 import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunSelectionPage;
 import org.jboss.tools.docker.reddeer.ui.DockerContainersTab;
-import org.jboss.tools.docker.reddeer.ui.DockerExplorerView;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -37,12 +35,6 @@ public class ContainerTabTest extends AbstractDockerBotTest {
 
 	private String imageName = "docker/whalesay";
 	private String containerName = "test_run_docker_whalesay";
-
-	@Before
-	public void before() {
-		openDockerPerspective();
-		createConnection();
-	}
 
 	@Test
 	public void testContainerTab() {
@@ -82,7 +74,7 @@ public class ContainerTabTest extends AbstractDockerBotTest {
 			}
 		}
 
-		new DockerExplorerView().getDockerConnection(getDockerServer()).getContainer(containerName).select();
+		getConnection().getContainer(containerName).select();
 
 		// get values from Properties view
 		PropertiesView propertiesView = new PropertiesView();
@@ -128,7 +120,6 @@ public class ContainerTabTest extends AbstractDockerBotTest {
 	@After
 	public void after() {
 		deleteImageContainerAfter(containerName,imageName);
-		deleteConnection();
 	}
 
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/DifferentRegistryTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/DifferentRegistryTest.java
@@ -17,7 +17,6 @@ import org.jboss.reddeer.core.exception.CoreLayerException;
 import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -32,12 +31,6 @@ public class DifferentRegistryTest extends AbstractDockerBotTest {
 	private String userName = "test";
 	private String password = "password";
 	private String imageName = "devstudio/atomicapp:latest";
-
-	@Before
-	public void before() {
-		openDockerPerspective();
-		createConnection();
-	}
 
 	@Test
 	public void testDifferentRegistry() {
@@ -57,7 +50,6 @@ public class DifferentRegistryTest extends AbstractDockerBotTest {
 	@After
 	public void after() {
 		deleteImageContainerAfter(serverAddress + "/devstudio/atomicapp");
-		deleteConnection();
 		deleteRegister(serverAddress);
 	}
 

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/ImageTabTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/ImageTabTest.java
@@ -18,11 +18,9 @@ import org.jboss.reddeer.common.wait.WaitWhile;
 import org.jboss.reddeer.core.condition.JobIsRunning;
 import org.jboss.reddeer.eclipse.ui.views.properties.PropertiesView;
 import org.jboss.reddeer.swt.api.TableItem;
-import org.jboss.tools.docker.reddeer.ui.DockerExplorerView;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -34,12 +32,6 @@ import org.junit.Test;
 public class ImageTabTest extends AbstractDockerBotTest {
 
 	private String imageName = "hello-world";
-
-	@Before
-	public void before() {
-		openDockerPerspective();
-		createConnection();
-	}
 
 	@Test
 	public void testImageTab() {
@@ -65,7 +57,7 @@ public class ImageTabTest extends AbstractDockerBotTest {
 		}
 		idFromTable = idFromTable.replace("sha256:", "");
 
-		new DockerExplorerView().getDockerConnection(getDockerServer()).getImage(getCompleteImageName(imageName)).select();
+		getConnection().getImage(getCompleteImageName(imageName)).select();
 
 		PropertiesView propertiesView = new PropertiesView();
 		propertiesView.open();
@@ -96,7 +88,6 @@ public class ImageTabTest extends AbstractDockerBotTest {
 	@After
 	public void after() {
 		deleteImageContainerAfter(imageName);
-		deleteConnection();
 	}
 
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/LaunchDockerImageTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/LaunchDockerImageTest.java
@@ -13,11 +13,9 @@ package org.jboss.tools.docker.ui.bot.test.ui;
 
 import static org.junit.Assert.assertTrue;
 
-import org.jboss.tools.docker.reddeer.ui.DockerExplorerView;
 import org.jboss.tools.docker.reddeer.ui.RunDockerImageLaunchConfiguration;
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -31,19 +29,13 @@ public class LaunchDockerImageTest extends AbstractDockerBotTest {
 	private String containerName = "test_variables";
 	private String configurationName = "test_configuration";
 
-	@Before
-	public void before() {
-		openDockerPerspective();
-		createConnection();
-	}
-
 	@Test
 	public void testLaunchConfiguration() {
 
 		pullImage(imageName);
 		String completeImageName = getCompleteImageName(imageName);
 		
-		new DockerExplorerView().getDockerConnection(getDockerServer()).enableConnection();
+		getConnection().enableConnection();
 		
 		RunDockerImageLaunchConfiguration runImageConf = new RunDockerImageLaunchConfiguration();
 		runImageConf.open();
@@ -63,7 +55,6 @@ public class LaunchDockerImageTest extends AbstractDockerBotTest {
 	@After
 	public void after() {
 		deleteImageContainerAfter(containerName,imageName);
-		deleteConnection();
 	}
 
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/PerspectiveTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/PerspectiveTest.java
@@ -23,23 +23,15 @@ import org.junit.Test;
  * @author jkopriva
  *
  */
-
 public class PerspectiveTest extends AbstractDockerBotTest {
 
 	@Test
-	public void testPerspective() {
-		openDockerPerspective();
-	}
-	
-	@Test
 	public void testDockerExplorerViewPresent() {
-		openDockerPerspective();
 		new DockerExplorerView().open();
 	}
 	
 	@Test
 	public void testDockerImagesTabPresent() {
-		openDockerPerspective();
 		DockerImagesTab tab = new DockerImagesTab();
 		tab.open();
 		tab.refresh();
@@ -47,7 +39,6 @@ public class PerspectiveTest extends AbstractDockerBotTest {
 	
 	@Test
 	public void testDockerContainersTabPresent() {
-		openDockerPerspective();
 		DockerContainersTab tab = new DockerContainersTab();
 		tab.open();
 		tab.refresh();
@@ -55,7 +46,7 @@ public class PerspectiveTest extends AbstractDockerBotTest {
 
 	@After
 	public void clear() {
-		cleanupShells();
+		cleanUpWorkspace();
 	}
 
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/PropertiesViewTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/PropertiesViewTest.java
@@ -39,8 +39,6 @@ public class PropertiesViewTest extends AbstractDockerBotTest {
 
 	@Before
 	public void before() {
-		openDockerPerspective();
-		createConnection();
 		pullImage(this.imageName);
 	}
 
@@ -89,7 +87,6 @@ public class PropertiesViewTest extends AbstractDockerBotTest {
 	@After
 	public void after() {
 		deleteImageContainerAfter(containerName,imageName);
-		deleteConnection();
 	}
 
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/SearchDialogTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/SearchDialogTest.java
@@ -25,10 +25,8 @@ import org.jboss.reddeer.swt.impl.button.PushButton;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageSearchPage;
 import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageTagSelectionPage;
-import org.jboss.tools.docker.reddeer.ui.DockerExplorerView;
 import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -43,17 +41,10 @@ public class SearchDialogTest extends AbstractDockerBotTest {
 	private String expectedImageName = "busybox";
 	private String registryAddress = "https://index.docker.io";
 
-	@Before
-	public void before() {
-		openDockerPerspective();
-		createConnection();
-	}
-
 	@Test
 	public void testSearchDialog() {
-		checkConnection();
-		new DockerExplorerView().getDockerConnection(getDockerServer()).openImageSearchDialog(this.imageName, null,
-				this.registryAddress);
+		getConnection()
+			.openImageSearchDialog(this.imageName, null, this.registryAddress);
 		ImageSearchPage pageOne = new ImageSearchPage();
 		pageOne.searchImage();
 		assertFalse("Search result is empty!", pageOne.getSearchResults().isEmpty());
@@ -81,7 +72,6 @@ public class SearchDialogTest extends AbstractDockerBotTest {
 	@After
 	public void after() {
 		deleteImageContainerAfter(imageName+":"+imageTag);
-		deleteConnection();
 	}
 
 }

--- a/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/integration/docker/DeployDockerImageTest.java
+++ b/tests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/integration/docker/DeployDockerImageTest.java
@@ -83,12 +83,12 @@ public class DeployDockerImageTest {
 	private static void prepareDockerConnection() {
 		dockerExplorer = new DockerExplorerView();
 		dockerExplorer.open();
-		List<String> connectionsNames = dockerExplorer.getDockerConnectionsNames();
+		List<String> connectionsNames = dockerExplorer.getDockerConnectionNames();
 		if (connectionsNames.isEmpty()) {
 			if (RunningPlatform.isWindows() || RunningPlatform.isOSX()) {
-				dockerExplorer.createDockerConnection(DOCKER_CONNECTION);
+				dockerExplorer.createDockerConnectionSearch(DOCKER_CONNECTION);
 			} else {
-				dockerExplorer.createDockerConnection(DOCKER_CONNECTION, 
+				dockerExplorer.createDockerConnectionUnix(DOCKER_CONNECTION, 
 						"unix:///var/run/docker.sock");
 			}
 		} else {
@@ -101,7 +101,7 @@ public class DeployDockerImageTest {
 	 */
 	private static void pullHelloImageIfDoesNotExist() {
 		DockerExplorerView dockerExplorer = new DockerExplorerView();
-		DockerConnection dockerConnection = dockerExplorer.getDockerConnection(DOCKER_CONNECTION); 
+		DockerConnection dockerConnection = dockerExplorer.getDockerConnectionByName(DOCKER_CONNECTION); 
 		if (dockerConnection.getImage(HELLO_OS_DOCKER_IMAGE, TAG) == null) {
 			dockerConnection.pullImage(HELLO_OS_DOCKER_IMAGE, TAG);
 		}
@@ -281,7 +281,7 @@ public class DeployDockerImageTest {
 	 * Opens a Deploy Image to OpenShift wizard from context menu of a docker image
 	 */
 	private void openDeployToOpenShiftWizardFromDockerExplorer() {
-		dockerExplorer.getDockerConnection(DOCKER_CONNECTION).getImage(
+		dockerExplorer.getDockerConnectionByName(DOCKER_CONNECTION).getImage(
 				HELLO_OS_DOCKER_IMAGE, TAG).select();
 		new ContextMenu(OpenShiftLabel.ContextMenu.DEPLOY_TO_OPENSHIFT).select();
 		


### PR DESCRIPTION
Connections in the Docker explorer must be unique in name and unique in
host. AddConnectionTest thus can fail if there already is a connection
using the same host with a different name.
This should be fixed by looking up connections by their host.