### PR TITLE
[JBIDE-23633] use small docker images to speed up the suite

### DIFF
--- a/plugins/org.jboss.tools.docker.reddeer/src/org/jboss/tools/docker/reddeer/condition/ContainerIsDeployedCondition.java
+++ b/plugins/org.jboss.tools.docker.reddeer/src/org/jboss/tools/docker/reddeer/condition/ContainerIsDeployedCondition.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.docker.reddeer.condition;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.reddeer.common.condition.AbstractWaitCondition;
+import org.jboss.tools.docker.reddeer.ui.resources.DockerConnection;
+
+/**
+ * @author adietish@redhat.com
+ */
+public class ContainerIsDeployedCondition extends AbstractWaitCondition {
+
+	private String name;
+	private DockerConnection connection;
+
+	public ContainerIsDeployedCondition(String name, DockerConnection connection) {
+		assertNotNull(this.name = name);
+		assertNotNull(this.connection = connection);
+	}
+
+	@Override
+	public boolean test() {
+		return connection.getContainer(name) != null;
+	}
+}

--- a/plugins/org.jboss.tools.docker.reddeer/src/org/jboss/tools/docker/reddeer/ui/resources/DockerConnection.java
+++ b/plugins/org.jboss.tools.docker.reddeer/src/org/jboss/tools/docker/reddeer/ui/resources/DockerConnection.java
@@ -194,7 +194,7 @@ public class DockerConnection extends AbstractDockerExplorerItem {
 	public int deployedImagesCount(String imageName) {
 		int count = 0;
 		select();
-		List<String> imagesNames = getImagesNames();
+		List<String> imagesNames = getImagesNames(true);
 		for (String imageNameFromList : imagesNames) {
 			if (imageNameFromList.contains(imageName)) {
 				count++;
@@ -223,14 +223,38 @@ public class DockerConnection extends AbstractDockerExplorerItem {
 		}
 	}
 
+	/**
+	 * Returns all the names of all image, without the tag.
+	 * @return
+	 */
 	public List<String> getImagesNames() {
+		return getImagesNames(false);
+	}
+
+	public List<String> getImagesNames(boolean withTag) {
 		select();
 		List<String> imagesNames = new ArrayList<String>();
 		List<TreeItem> images = treeViewerHandler.getTreeItem(item, "Images").getItems();
 		for (TreeItem item : images) {
-			imagesNames.add(treeViewerHandler.getNonStyledText(item));
+			String imageName = treeViewerHandler.getNonStyledText(item);
+			if (withTag) {
+				String imageTag = getImageTag(item);
+				imagesNames.add(imageName + imageTag);
+			} else {
+				imagesNames.add(imageName);
+			}
+			
 		}
 		return imagesNames;
+	}
+
+	private String getImageTag(TreeItem item) {
+		String[] styledTexts = treeViewerHandler.getStyledTexts(item);
+		if (styledTexts == null
+				|| styledTexts.length == 0) {
+			return null;
+		}
+		return styledTexts[0];
 	}
 
 	public List<String> getContainersNames() {

--- a/tests/org.jboss.tools.docker.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.docker.ui.bot.test/META-INF/MANIFEST.MF
@@ -11,7 +11,8 @@ Require-Bundle: org.junit,
  org.jboss.reddeer.go;bundle-version="[1.2.0,2.0.0)",
  org.jboss.tools.docker.reddeer;bundle-version="[4.4.2,4.5.0)",
  org.jboss.ide.eclipse.as.reddeer,
- org.apache.commons.lang;bundle-version="2.6.0"
+ org.apache.commons.lang;bundle-version="2.6.0",
+ org.apache.commons.io;bundle-version="2.2.0"
 Import-Package: org.eclipse.core.resources
 Eclipse-BundleShape: jar
 

--- a/tests/org.jboss.tools.docker.ui.bot.test/README
+++ b/tests/org.jboss.tools.docker.ui.bot.test/README
@@ -12,6 +12,7 @@ Running in Eclipse
    -DdockerHubUsername=<username>
    -DdockerHubEmail=<email>
    -DdockerHubPassword=<password>
+   -DdockerComposePath=/usr/bin
    -DskipTests=false
 
 Running in Command Line

--- a/tests/org.jboss.tools.docker.ui.bot.test/resources/test-build/Dockerfile
+++ b/tests/org.jboss.tools.docker.ui.bot.test/resources/test-build/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.3
+MAINTAINER Andre Dietisheim <adietish@redhat.com>

--- a/tests/org.jboss.tools.docker.ui.bot.test/resources/test-volumes/index.html
+++ b/tests/org.jboss.tools.docker.ui.bot.test/resources/test-volumes/index.html
@@ -1,0 +1,5 @@
+<html>
+	<body>
+	Hello World!
+	</body>
+</html>

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/container/DockerContainerTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/container/DockerContainerTest.java
@@ -16,39 +16,37 @@ import static org.junit.Assert.assertTrue;
 import org.jboss.reddeer.common.wait.TimePeriod;
 import org.jboss.reddeer.common.wait.WaitWhile;
 import org.jboss.reddeer.core.condition.JobIsRunning;
-import org.jboss.reddeer.core.exception.CoreLayerException;
 import org.jboss.reddeer.eclipse.condition.ConsoleHasNoChange;
-import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
 import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunSelectionPage;
-import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
+import org.jboss.tools.docker.ui.bot.test.image.AbstractImageBotTest;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
- * 
  * @author jkopriva
+ * @contributor adietish@redhat.com
  *
  */
 
-public class DockerContainerTest extends AbstractDockerBotTest {
-	private String imageName = "docker/whalesay";
-	private String containerName = "test_run";
+public class DockerContainerTest extends AbstractImageBotTest {
 
+	private static final String IMAGE_NAME = IMAGE_BUSYBOX;
+	private static final String CONTAINER_NAME = "test_run";
+
+	@Before
+	public void before() {
+		clearConsole();
+		pullImage(IMAGE_NAME);
+	}
+	
 	@Test
-	public void testDockerContainer() {
-		ConsoleView cview = new ConsoleView();
-		cview.open();
-		try {
-			cview.clearConsole();
-		} catch (CoreLayerException ex) {
-
-		}
-		pullImage(imageName);
-		assertTrue("Image has not been found!", imageIsDeployed(getCompleteImageName(imageName)));
-
-		getConnection().getImage(getCompleteImageName(imageName)).run();
+	public void testRunDockerContainer() {
+		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
+		assertTrue("Image has not been found!", imageIsDeployed(getCompleteImageName(IMAGE_NAME)));
+		getConnection().getImage(getCompleteImageName(IMAGE_NAME)).run();
 		ImageRunSelectionPage firstPage = new ImageRunSelectionPage();
-		firstPage.setName(this.containerName);
+		firstPage.setName(CONTAINER_NAME);
 		firstPage.finish();
 		new WaitWhile(new JobIsRunning(), TimePeriod.NORMAL);
 		new WaitWhile(new ConsoleHasNoChange());
@@ -57,7 +55,7 @@ public class DockerContainerTest extends AbstractDockerBotTest {
 
 	@After
 	public void after() {
-		deleteImageContainerAfter(containerName, imageName);
+		deleteImageContainerAfter(CONTAINER_NAME);
 	}
 
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/container/VolumeMountTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/container/VolumeMountTest.java
@@ -11,12 +11,11 @@
 
 package org.jboss.tools.docker.ui.bot.test.container;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
 
-import org.jboss.ide.eclipse.as.reddeer.server.deploy.DeployOnServer;
 import org.jboss.reddeer.common.wait.WaitWhile;
 import org.jboss.reddeer.core.condition.JobIsRunning;
 import org.jboss.reddeer.eclipse.condition.ConsoleHasNoChange;
@@ -24,60 +23,66 @@ import org.jboss.reddeer.eclipse.ui.browser.BrowserView;
 import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunResourceVolumesVariablesPage;
 import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunSelectionPage;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
-import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
+import org.jboss.tools.docker.ui.bot.test.image.AbstractImageBotTest;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
  * 
  * @author jkopriva
- *
+ * @contributor adietish@redhat.com
  */
+public class VolumeMountTest extends AbstractImageBotTest {
 
-public class VolumeMountTest extends AbstractDockerBotTest {
-
-	private String imageName = "jboss/wildfly";
-	private String imageTag = "10.0.0.Final";
-	private String containerName = "test_run_wildfly_volumes";
-	private String deploymentPath = "resources/wildfly-deployments";
-	private String containerPath = "/opt/jboss/wildfly/standalone/deployments/";
-	private String quickstartURL = "wildfly-helloworld";
-
+	private static final String IMAGE_NAME = "fnichol/uhttpd";
+	private static final String IMAGE_TAG = "latest";
+	private static final String CONTAINER_NAME = "test_mount_volumes";
+	private static final String VOLUME_PATH = "resources/test-volumes";
+	private static final String CONTAINER_PATH = "/www";
+	private static final String INDEX_PAGE = "index.html";
+	private static final String INDEX_PAGE_PATH = VOLUME_PATH + "/" + INDEX_PAGE;
+	private static final String HOST_PORT = "80";
+	
+	@Before
+	public void before() {
+		pullImage(IMAGE_NAME, IMAGE_TAG);
+	}
+	
 	@Test
 	public void testVolumeMount() throws IOException {
-		pullImage(imageName, imageTag);
-		DockerImagesTab imageTab = new DockerImagesTab();
-		imageTab.activate();
-		imageTab.refresh();
-		new WaitWhile(new JobIsRunning());
-		imageTab.runImage(imageName + ":" + imageTag);
+		DockerImagesTab imagesTab = openDockerImagesTab();
+		imagesTab.runImage(IMAGE_NAME + ":" + IMAGE_TAG);
+
 		ImageRunSelectionPage firstPage = new ImageRunSelectionPage();
-		firstPage.setName(this.containerName);
-		firstPage.setPublishAllExposedPorts(false);
+		firstPage.setName(CONTAINER_NAME);
+		firstPage.setPublishAllExposedPorts(true);
 		firstPage.next();
+		
 		ImageRunResourceVolumesVariablesPage secondPage = new ImageRunResourceVolumesVariablesPage();
-		String deploymentPath = "";
-		try {
-			deploymentPath = (new File(this.deploymentPath)).getCanonicalPath();
-		} catch (IOException ex) {
-			fail("Resource file not found!");
-		}
-		secondPage.addDataVolumeToHost(containerPath, deploymentPath);
+		String volumePath = (new File(VOLUME_PATH)).getCanonicalPath();
+		secondPage.addDataVolumeToHost(CONTAINER_PATH, volumePath);
 		secondPage.finish();
 		new WaitWhile(new JobIsRunning());
 		new WaitWhile(new ConsoleHasNoChange());
-		String url = createURL(":8080" + "/" + quickstartURL);
+
+		String indexPage = getIndexPageContent();
+		String indexPageResource = getResourceAsString(INDEX_PAGE_PATH);
+		assertEquals(INDEX_PAGE_PATH + " wasnt mounted/displayed properly.", indexPage, indexPageResource);
+	}
+
+	private String getIndexPageContent() {
+		String containerIP = getContainerIP(CONTAINER_NAME);
+		String url = "http://" + containerIP + ":" + HOST_PORT + "/" + INDEX_PAGE;
 		BrowserView browserView = new BrowserView();
 		browserView.open();
 		browserView.openPageURL(url);
-		DeployOnServer.checkBrowserForErrorPage(browserView, url);
-
+		return browserView.getText();
 	}
 
 	@After
 	public void after() {
-		deleteContainer(this.containerName);
-		deleteImage(imageName, imageTag);
+		deleteContainerIfExists(CONTAINER_NAME);
 	}
 
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/AbstractImageBotTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/AbstractImageBotTest.java
@@ -1,0 +1,250 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.docker.ui.bot.test.image;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.jboss.reddeer.common.exception.RedDeerException;
+import org.jboss.reddeer.common.exception.WaitTimeoutExpiredException;
+import org.jboss.reddeer.common.wait.TimePeriod;
+import org.jboss.reddeer.common.wait.WaitWhile;
+import org.jboss.reddeer.core.condition.JobIsRunning;
+import org.jboss.reddeer.eclipse.condition.ConsoleHasNoChange;
+import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
+import org.jboss.reddeer.eclipse.ui.views.properties.PropertiesView;
+import org.jboss.reddeer.jface.preference.PreferenceDialog;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.swt.impl.button.OkButton;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
+import org.jboss.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
+import org.jboss.tools.docker.reddeer.condition.ContainerIsDeployedCondition;
+import org.jboss.tools.docker.reddeer.preferences.RegistryAccountsPreferencePage;
+import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
+import org.jboss.tools.docker.reddeer.ui.resources.DockerImage;
+import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
+import org.junit.After;
+
+/**
+ * A base class tests that build docker images
+ * 
+ * @author adietish@redhat.com
+ */
+public class AbstractImageBotTest extends AbstractDockerBotTest {
+
+	protected static final String NAME_TAG_SEPARATOR = ":";
+	protected static final String IMAGE_TAG_LATEST = "latest";
+
+	protected static final String IMAGE_TEST_BUILD = "test_build";
+	protected static final String IMAGE_BUSYBOX = "busybox";
+	protected static final String IMAGE_BUSYBOX_LATEST = IMAGE_BUSYBOX + NAME_TAG_SEPARATOR + IMAGE_TAG_LATEST;
+	protected static final String IMAGE_ALPINE = "alpine";
+	protected static final String IMAGE_ALPINE_33 = IMAGE_ALPINE + NAME_TAG_SEPARATOR + "3.3";
+
+	protected static final String REGISTRY_URL = "https://index.docker.io";
+	
+	private static final String CONSOLE_SUCCESS_MSG = "Successfully built";
+
+
+	@After
+	public void after() {
+		cleanUpWorkspace();
+	}
+
+	protected DockerImagesTab openDockerImagesTab() {
+		DockerImagesTab imageTab = new DockerImagesTab();
+		imageTab.activate();
+		imageTab.refresh();
+
+		new WaitWhile(new JobIsRunning(), TimePeriod.NORMAL);
+
+		return imageTab;
+	}
+
+	protected void buildImage(String imageName, String dockerFileFolder, DockerImagesTab imageTab) {
+		try {
+			String dockerFilePath = new File(dockerFileFolder).getCanonicalPath();
+			imageTab.buildImage(imageName, dockerFilePath);
+			new WaitWhile(new JobIsRunning(), TimePeriod.VERY_LONG);
+		} catch (IOException ex) {
+			fail("Resource file not found!");
+		}
+	}
+
+	protected void assertConsoleSuccess() {
+		assertConsoleContains(CONSOLE_SUCCESS_MSG);
+	}
+	
+	protected void assertConsoleContains(String text) {
+		new WaitWhile(new ConsoleHasNoChange());
+		ConsoleView consoleView = new ConsoleView();
+		consoleView.open();
+		assertFalse("Console has no output!", consoleView.getConsoleText().isEmpty());
+		assertTrue("Build has not been successful", consoleView.getConsoleText().contains(text));
+	}
+
+	protected void setUpRegister(String serverAddress, String email, String userName, String password) {
+		PreferenceDialog dialog = new WorkbenchPreferenceDialog();
+		RegistryAccountsPreferencePage page = new RegistryAccountsPreferencePage();
+		dialog.open();
+		dialog.select(page);
+		page.removeRegistry(serverAddress);
+		page.addRegistry(serverAddress, email, userName, password);
+		try {
+			new DefaultShell("New Registry Account").setFocus();
+		} catch (SWTLayerException e) {
+			new DefaultShell("Preferences").setFocus();
+		}
+		new OkButton().click();
+	}
+
+	protected void deleteRegister(String serverAddress) {
+		PreferenceDialog dialog = new WorkbenchPreferenceDialog();
+		RegistryAccountsPreferencePage page = new RegistryAccountsPreferencePage();
+		dialog.open();
+		dialog.select(page);
+		page.removeRegistry(serverAddress);
+		new WaitWhile(new JobIsRunning());
+		new OkButton().click();
+	}
+
+	protected void deleteRegisterIfExists(String serverAddress) {
+		try {
+			deleteRegister(serverAddress);
+		} catch(RedDeerException e) {
+			// swallow intentionally
+		}
+	}
+
+	protected void pullImage(String imageName) {
+		pullImage(imageName, null, null);
+	}
+
+	protected void pullImage(String imageName, String imageTag) {
+		pullImage(imageName, imageTag, null);
+	}
+
+	protected void pullImage(String imageName, String imageTag, String dockerRegister) {
+		try {
+			getConnection().pullImage(imageName, imageTag, dockerRegister);
+		} catch (WaitTimeoutExpiredException ex) {
+			killRunningImageJobs();
+			fail("Timeout expired when pulling image:" + imageName + (imageTag == null ? "" : ":" + imageTag) + "!");
+		}
+	}
+	
+	protected String getCompleteImageName(String imageName) {
+		for (String image : getConnection().getImagesNames()) {
+			if (image.contains(imageName)) {
+				imageName = image.replace(":", "");
+			}
+		}
+		return imageName;
+	}
+
+	protected void deleteImageIfExists(String imageName) {
+		deleteImageIfExists(imageName, IMAGE_TAG_LATEST);
+	}
+
+	protected void deleteImageIfExists(String imageName, String tag) {
+		String name = getCompleteImageName(imageName);
+		if (imageIsDeployed(name + NAME_TAG_SEPARATOR + tag)) {
+			getConnection().getImage(name, tag).remove();
+		}
+	}
+
+	protected void deleteImage(String imageName) {
+		deleteImage(imageName, IMAGE_TAG_LATEST);
+	}
+
+	protected void deleteImage(String imageName, String imageTag) {
+		String completeImageName = getCompleteImageName(imageName);
+		DockerImage image = getConnection().getImage(completeImageName, imageTag);
+		if (image == null) {
+			fail("Image " + imageName + ":" + imageTag + "(" + completeImageName + ":" + imageTag + ")" + " does not exists!");
+		}
+		image.remove();
+	}
+
+	protected void deleteImages(List<String> images) {
+		for (String image : images) {
+			deleteImage(image);
+		}
+	}
+
+	protected boolean imageIsDeployed(String imageName) {
+		return getConnection().imageIsDeployed(imageName);
+	}
+
+	protected int deployedImagesCount(String imageName) {
+		return getConnection().deployedImagesCount(imageName);
+	}
+
+	protected boolean containerIsDeployed(String containerName) {
+		return getConnection().containerIsDeployed(containerName);
+	}
+
+	protected void deleteContainerIfExists(String containerName) {
+		if (containerIsDeployed(containerName)) {
+			getConnection().getContainer(containerName).remove();
+			new WaitWhile(new ContainerIsDeployedCondition(containerName, getConnection()));
+		} 
+	}
+
+	protected void deleteContainer(String containerName) {
+		if (!containerIsDeployed(containerName)) {
+			fail("Container " + containerName + " does not exists!");
+		} 
+		getConnection().getContainer(containerName).remove();
+		new WaitWhile(new ContainerIsDeployedCondition(containerName, getConnection()));
+	}
+
+	/**
+	 * Deletes the given images. Image names may be provided with tag (ex. "alpine:3.3"). 
+	 * Also kills all jobs that are still running.
+	 * @param the names of the image that will be deleted
+	 */
+	protected void deleteImageContainerAfter(String... imageContainerNames) {
+		killRunningImageJobs();
+		deleteImageContainer(imageContainerNames);
+	}
+
+	/**
+	 * Deletes the given images. Image names may be provided with tag (ex. "alpine:3.3").
+	 * @param the names of the image that will be deleted
+	 */
+	protected void deleteImageContainer(String... imageContainerNames) {
+		for (String imageContainerName : imageContainerNames) {
+			String[] nameAndTag = imageContainerName.split(":");
+			if (imageIsDeployed(imageContainerName)) {
+				if (nameAndTag.length == 1) {
+					deleteImage(imageContainerName);
+				} else {
+					deleteImage(nameAndTag[0], nameAndTag[1]);
+				}
+			}
+			if (containerIsDeployed(imageContainerName)) {
+				deleteContainer(imageContainerName);
+			}
+		}
+	}
+
+	protected String getContainerIP(String containerName) {
+		getConnection().getContainer(containerName).select();
+		PropertiesView propertiesView = openPropertiesTab("Inspect");
+		return propertiesView.getProperty("NetworkSettings", "IPAddress").getPropertyValue();
+	}
+}

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/BuildImageTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/BuildImageTest.java
@@ -8,22 +8,9 @@
  * Contributor:
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-
 package org.jboss.tools.docker.ui.bot.test.image;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.File;
-import java.io.IOException;
-
-import org.jboss.reddeer.common.wait.TimePeriod;
-import org.jboss.reddeer.common.wait.WaitWhile;
-import org.jboss.reddeer.core.condition.JobIsRunning;
-import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
-import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
 import org.junit.Test;
 
@@ -33,32 +20,22 @@ import org.junit.Test;
  *
  */
 
-public class BuildImageTest extends AbstractDockerBotTest {
-	private static String imageName = "test_build";
+public class BuildImageTest extends AbstractImageBotTest {
+
+	private static final String DOCKERFILE_FOLDER = "resources/test-build";
 
 	@Test
 	public void testBuildImage() {
-		DockerImagesTab imageTab = new DockerImagesTab();
-		imageTab.activate();
-		imageTab.refresh();
-		new WaitWhile(new JobIsRunning(), TimePeriod.NORMAL);
-		String dockerFilePath = "";
-		try {
-			dockerFilePath = (new File("resources/test-wildfly")).getCanonicalPath();
-		} catch (IOException ex) {
-			fail("Resource file not found!");
-		}
-		imageTab.buildImage(imageName, dockerFilePath);
-		new WaitWhile(new JobIsRunning(), TimePeriod.VERY_LONG);
-		ConsoleView consoleView = new ConsoleView();
-		consoleView.open();
-		assertFalse("Console has no output!", consoleView.getConsoleText().isEmpty());
-		assertTrue("Build has not been successful", consoleView.getConsoleText().contains("Successfully built"));
+		DockerImagesTab imageTab = openDockerImagesTab();
+
+		buildImage(IMAGE_TEST_BUILD, DOCKERFILE_FOLDER, imageTab);
+
+		assertConsoleSuccess();
 	}
 
 	@After
 	public void after() {
-		deleteImageContainerAfter(imageName, "jboss/base-jdk:8");
+		deleteImageContainer(IMAGE_TEST_BUILD);
 		cleanUpWorkspace();
 	}
 

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/HierarchyViewTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/HierarchyViewTest.java
@@ -11,59 +11,35 @@
 
 package org.jboss.tools.docker.ui.bot.test.image;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
-import org.jboss.reddeer.common.wait.TimePeriod;
 import org.jboss.reddeer.common.wait.WaitWhile;
-import org.jboss.reddeer.core.condition.JobIsRunning;
 import org.jboss.reddeer.core.condition.ShellWithTextIsAvailable;
-import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
 import org.jboss.reddeer.swt.api.TreeItem;
 import org.jboss.tools.docker.reddeer.ui.DockerImageHierarchyTab;
-import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
-import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
-import org.junit.After;
 import org.junit.Test;
 
 /**
  * 
  * @author jkopriva@redhat.com
+ * @cotributor adietish@redhat.com
  *
  */
 
-public class HierarchyViewTest extends AbstractDockerBotTest {
-	private static String imageName = "test_build";
+public class HierarchyViewTest extends AbstractImageBotTest {
 
+	private static final String IMAGE_CIRROS_VERSION = "0.3.4";
+	private static final String IMAGE_CIRROS = "docker.io/cirros";
+	
 	@Test
 	public void testHierarchyView() {
-		DockerImagesTab imageTab = new DockerImagesTab();
-		imageTab.activate();
-		imageTab.refresh();
-		new WaitWhile(new JobIsRunning(), TimePeriod.NORMAL);
-		String dockerFilePath = "";
-		try {
-			dockerFilePath = (new File("resources/test-wildfly")).getCanonicalPath();
-		} catch (IOException ex) {
-			fail("Resource file not found!");
-		}
-		imageTab.buildImage(imageName, dockerFilePath);
-		new WaitWhile(new JobIsRunning(), TimePeriod.VERY_LONG);
-		ConsoleView consoleView = new ConsoleView();
-		consoleView.open();
-		assertFalse("Console has no output!", consoleView.getConsoleText().isEmpty());
-		assertTrue("Build has not been successful", consoleView.getConsoleText().contains("Successfully built"));
-		getConnection().getImage(imageName).openImageHierarchy();
-		new WaitWhile(new ShellWithTextIsAvailable("Docker Image Hierarchy"));
-		DockerImageHierarchyTab hierarchyTab = new DockerImageHierarchyTab();
-		hierarchyTab.open();
+		pullImage(IMAGE_CIRROS, IMAGE_CIRROS_VERSION, null);
+		
+		DockerImageHierarchyTab hierarchyTab = openDockerImageHierarchyTab();
 		List<TreeItem> treeItems = hierarchyTab.getTreeItems();
-		compareTextInFirstNode(treeItems, "jboss/base-jdk:8");
+		compareTextInFirstNode(treeItems, "<none>:<none>");
 		List<TreeItem> treeItems2 = treeItems.get(0).getItems();
 		compareTextInFirstNode(treeItems2, "<none>:<none>");
 		List<TreeItem> treeItems3 = treeItems2.get(0).getItems();
@@ -71,21 +47,20 @@ public class HierarchyViewTest extends AbstractDockerBotTest {
 		List<TreeItem> treeItems4 = treeItems3.get(0).getItems();
 		compareTextInFirstNode(treeItems4, "<none>:<none>");
 		List<TreeItem> treeItems5 = treeItems4.get(0).getItems();
-		compareTextInFirstNode(treeItems5, "<none>:<none>");
-		List<TreeItem> treeItems6 = treeItems5.get(0).getItems();
-		compareTextInFirstNode(treeItems6, "test_build:latest");
-	}
-
-	@After
-	public void after() {
-		deleteImageContainerAfter(imageName, "jboss/base-jdk:8");
-		cleanUpWorkspace();
+		compareTextInFirstNode(treeItems5, IMAGE_CIRROS + NAME_TAG_SEPARATOR + IMAGE_CIRROS_VERSION);
 	}
 
 	public void compareTextInFirstNode(List<TreeItem> treeItems, String expectedValue) {
-		String nodeText = treeItems.get(0).getText().replaceAll("\\(.*\\)", "").trim().replaceAll("docker.io/", "");
-		assertTrue("Hierarchy view contains string:" + nodeText + ", but it is expected:" + expectedValue,
+		String nodeText = treeItems.get(0).getText().replaceAll("\\(.*\\)", "").trim();
+		assertTrue("Hierarchy view contains string: " + nodeText + ", but it is expected: " + expectedValue,
 				nodeText.startsWith(expectedValue));
 	}
 
+	private DockerImageHierarchyTab openDockerImageHierarchyTab() {
+		getConnection().getImage(IMAGE_CIRROS, IMAGE_CIRROS_VERSION).openImageHierarchy();
+		new WaitWhile(new ShellWithTextIsAvailable("Docker Image Hierarchy"));
+		DockerImageHierarchyTab hierarchyTab = new DockerImageHierarchyTab();
+		hierarchyTab.open();
+		return hierarchyTab;
+	}
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/ImageTagTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/ImageTagTest.java
@@ -87,14 +87,15 @@ public class ImageTagTest extends AbstractDockerBotTest {
 			new OkButton().click();
 			assertFalse("Image tag has been added!", imageTab.getImageTags(IMAGE_NAME).contains(IMAGE_TAG));
 		} else {
-			assertTrue("Image tag has not been added!", imageTab.getImageTags(IMAGE_NAME).contains(IMAGE_TAG_UPPERCASE));
+			assertTrue("Image tag has not been added!",
+					imageTab.getImageTags(IMAGE_NAME).contains(IMAGE_TAG_UPPERCASE));
 		}
 	}
 
 	/**
 	 * Returns {@code true} if the running docker daemon matches at least the
 	 * given major and minor version. Returns {@code false} otherwise.
-	 * 
+	 *
 	 * @param majorVersion
 	 * @param minorVersion
 	 * @return
@@ -105,9 +106,9 @@ public class ImageTagTest extends AbstractDockerBotTest {
 		String daemonVersion = infoTab.getProperty("Version").getPropertyValue();
 		assertTrue("Could not retrieve docker daemon version.", !StringUtils.isBlank(daemonVersion));
 		String[] versionComponents = daemonVersion.split("\\.");
-		assertTrue("Could not evaluate docker daemon version " + daemonVersion, 
-				versionComponents == null || versionComponents.length >= 2); 
-		int actualMajorVersion = Integer.parseInt(versionComponents[0]); 			
+		assertTrue("Could not evaluate docker daemon version " + daemonVersion,
+				versionComponents == null || versionComponents.length >= 2);
+		int actualMajorVersion = Integer.parseInt(versionComponents[0]);
 		if (actualMajorVersion > majorVersion) {
 			return true;
 		}

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/ImageTagTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/ImageTagTest.java
@@ -14,53 +14,51 @@ package org.jboss.tools.docker.ui.bot.test.image;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import org.apache.commons.lang.StringUtils;
-import org.jboss.reddeer.common.wait.TimePeriod;
 import org.jboss.reddeer.common.wait.WaitWhile;
 import org.jboss.reddeer.core.condition.JobIsRunning;
-import org.jboss.reddeer.eclipse.ui.views.properties.PropertiesView;
 import org.jboss.reddeer.swt.impl.button.OkButton;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
-import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
  * 
  * @author jkopriva
+ * @contributor adietish@redhat.com
  *
  */
 
-public class ImageTagTest extends AbstractDockerBotTest {
-	private static final String IMAGE_NAME = "busybox";
-	private static final String IMAGE_NAME_TO_PULL = "busybox:latest";
-	private static final String IMAGE_TAG = "testtag";
-	private static String IMAGE_TAG_UPPERCASE = "UPPERCASETAG";
+public class ImageTagTest extends AbstractImageBotTest {
 
+	private static final String IMAGE_NAME = IMAGE_BUSYBOX;
+	private static final String IMAGE_NAME_TO_PULL = IMAGE_BUSYBOX_LATEST;
+	private static final String IMAGE_TAG = "testtag";
+	private static final String IMAGE_TAG_UPPERCASE = "UPPERCASETAG";
 	// docker daemon 1.11 errors with uppercase tags, priors dont
 	private static final int DAEMON_MAJOR_VERSION = 1; 
 	private static final int DAEMON_MINOR_VERSION = 11;
 
-	@Test
-	public void testAddRemoveTagToImage() {
-		DockerImagesTab imageTab = new DockerImagesTab();
-		imageTab.activate();
-		imageTab.refresh();
-		new WaitWhile(new JobIsRunning(), TimePeriod.NORMAL);
+	@Before
+	public void before() {
+		deleteImageIfExists(IMAGE_NAME);
 		pullImage(IMAGE_NAME_TO_PULL);
 		new WaitWhile(new JobIsRunning());
 		assertTrue("Image has not been deployed!", imageIsDeployed(IMAGE_NAME));
-
-		imageTab.activate();
-		imageTab.addTagToImage(IMAGE_NAME, IMAGE_TAG);
+	}
+	
+	@Test
+	public void testAddRemoveTagToImage() {
+		DockerImagesTab imagesTab = openDockerImagesTab();
+		imagesTab.addTagToImage(IMAGE_NAME, IMAGE_TAG);
 		new WaitWhile(new JobIsRunning());
-		assertTrue("Image tag has not been added", imageTab.getImageTags(IMAGE_NAME).contains(IMAGE_TAG));
+		assertTrue("Image tag has not been added", imagesTab.getImageTags(IMAGE_NAME).contains(IMAGE_TAG));
 
-		imageTab.activate();
-		imageTab.removeTagFromImage(IMAGE_NAME, IMAGE_TAG);
+		imagesTab.activate();
+		imagesTab.removeTagFromImage(IMAGE_NAME, IMAGE_TAG);
 		new WaitWhile(new JobIsRunning());
-		assertTrue("ImageTaghasNotBeenRemoved", !imageTab.getImageTags(IMAGE_NAME).contains(IMAGE_TAG));
+		assertTrue("ImageTaghasNotBeenRemoved", !imagesTab.getImageTags(IMAGE_NAME).contains(IMAGE_TAG));
 	}
 	
 	/**
@@ -70,50 +68,18 @@ public class ImageTagTest extends AbstractDockerBotTest {
 	 */
 	@Test
 	public void testAddUpperCaseTagToImage() {
-		DockerImagesTab imageTab = new DockerImagesTab();
-		imageTab.activate();
-		imageTab.refresh();
-		new WaitWhile(new JobIsRunning(), TimePeriod.NORMAL);
-		pullImage(IMAGE_NAME_TO_PULL);
-		new WaitWhile(new JobIsRunning());
-		assertTrue("Image has not been deployed!", imageIsDeployed(IMAGE_NAME));
+		DockerImagesTab imagesTab = openDockerImagesTab();
+		imagesTab.addTagToImage(IMAGE_NAME, IMAGE_TAG_UPPERCASE);
 
-		imageTab.activate();
-		imageTab.addTagToImage(IMAGE_NAME, IMAGE_TAG_UPPERCASE);
-		
 		if (isDockerDaemon(DAEMON_MAJOR_VERSION, DAEMON_MINOR_VERSION)) {
 			// docker daemon >= 1.11
 			new DefaultShell("Error tagging image to <" + IMAGE_TAG_UPPERCASE + ">");
 			new OkButton().click();
-			assertFalse("Image tag has been added!", imageTab.getImageTags(IMAGE_NAME).contains(IMAGE_TAG));
+			assertFalse("Image tag has been added!", imagesTab.getImageTags(IMAGE_NAME).contains(IMAGE_TAG));
 		} else {
 			assertTrue("Image tag has not been added!",
-					imageTab.getImageTags(IMAGE_NAME).contains(IMAGE_TAG_UPPERCASE));
+					imagesTab.getImageTags(IMAGE_NAME).contains(IMAGE_TAG_UPPERCASE));
 		}
-	}
-
-	/**
-	 * Returns {@code true} if the running docker daemon matches at least the
-	 * given major and minor version. Returns {@code false} otherwise.
-	 *
-	 * @param majorVersion
-	 * @param minorVersion
-	 * @return
-	 */
-	private boolean isDockerDaemon(int majorVersion, int minorVersion) {
-		getConnection().select();
-		PropertiesView infoTab = openPropertiesTab("Info");
-		String daemonVersion = infoTab.getProperty("Version").getPropertyValue();
-		assertTrue("Could not retrieve docker daemon version.", !StringUtils.isBlank(daemonVersion));
-		String[] versionComponents = daemonVersion.split("\\.");
-		assertTrue("Could not evaluate docker daemon version " + daemonVersion,
-				versionComponents == null || versionComponents.length >= 2);
-		int actualMajorVersion = Integer.parseInt(versionComponents[0]);
-		if (actualMajorVersion > majorVersion) {
-			return true;
-		}
-		int actualMinorVersion = Integer.parseInt(versionComponents[1]);
-		return actualMinorVersion >= minorVersion;
 	}
 
 	@After
@@ -121,13 +87,4 @@ public class ImageTagTest extends AbstractDockerBotTest {
 		deleteImageContainerAfter(IMAGE_NAME);
 		cleanUpWorkspace();
 	}
-	
-	protected PropertiesView openPropertiesTab(String tabName) {
-		PropertiesView propertiesView = new PropertiesView();
-		propertiesView.open();
-		propertiesView.selectTab(tabName);
-		return propertiesView;
-	}
-
-
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/PullImageTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/image/PullImageTest.java
@@ -15,54 +15,37 @@ import static org.junit.Assert.assertTrue;
 
 import org.jboss.reddeer.common.wait.WaitWhile;
 import org.jboss.reddeer.core.condition.JobIsRunning;
-import org.jboss.reddeer.core.exception.CoreLayerException;
-import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
-import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
-import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
  * 
  * @author jkopriva
+ * @contributor adietish@redhat.com
  *
  */
 
-public class PullImageTest extends AbstractDockerBotTest {
-	private String imageName = "busybox";
-	private String imageNameNoTag = "jboss/wildfly";
+public class PullImageTest extends AbstractImageBotTest {
 
+	@Before
+	public void before() {
+		deleteImageIfExists(IMAGE_ALPINE_33);
+		deleteImageIfExists(IMAGE_BUSYBOX_LATEST);
+	}
+	
 	@Test
-	public void testPullImage() {
-		ConsoleView cview = new ConsoleView();
-		cview.open();
-		try {
-			cview.clearConsole();
-		} catch (CoreLayerException ex) {
-			// there's not clear console button, since nothing run before
-		}
-		pullImage(this.imageName);
+	public void testPullImageWithTag() {
+		clearConsole();
+		pullImage(IMAGE_ALPINE, "3.3", null);
 		new WaitWhile(new JobIsRunning());
-		assertTrue("Image has not been deployed!", imageIsDeployed(this.imageName));
+		assertTrue("Image has not been deployed!", imageIsDeployed(IMAGE_ALPINE_33));
 	}
 
 	@Test
 	public void testPullImageWithoutTag() {
-		ConsoleView cview = new ConsoleView();
-		cview.open();
-		try {
-			cview.clearConsole();
-		} catch (CoreLayerException ex) {
-			// there's not clear console button, since nothing run before
-		}
-		pullImage(this.imageNameNoTag);
+		clearConsole();
+		pullImage(IMAGE_BUSYBOX);
 		new WaitWhile(new JobIsRunning());
-		assertTrue("Image has not been deployed!", imageIsDeployed(this.imageNameNoTag));
-		assertTrue("Multiple images has been deployed!", deployedImagesCount(this.imageNameNoTag) == 1);
+		assertTrue("Image has not been deployed!", imageIsDeployed(IMAGE_BUSYBOX_LATEST));
 	}
-
-	@After
-	public void after() {
-		deleteImageContainerAfter(imageName,imageNameNoTag);
-	}
-
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/ComposeTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/ComposeTest.java
@@ -11,13 +11,10 @@
 
 package org.jboss.tools.docker.ui.bot.test.ui;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.File;
-import java.io.IOException;
-
+import org.apache.commons.lang.StringUtils;
 import org.jboss.ide.eclipse.as.reddeer.server.deploy.DeployOnServer;
 import org.jboss.reddeer.common.wait.TimePeriod;
 import org.jboss.reddeer.common.wait.WaitWhile;
@@ -25,7 +22,6 @@ import org.jboss.reddeer.core.condition.JobIsRunning;
 import org.jboss.reddeer.eclipse.condition.ConsoleHasNoChange;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
 import org.jboss.reddeer.eclipse.ui.browser.BrowserView;
-import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
 import org.jboss.reddeer.jface.preference.PreferenceDialog;
 import org.jboss.reddeer.swt.api.Menu;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
@@ -38,7 +34,7 @@ import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
 import org.jboss.tools.docker.reddeer.preferences.DockerComposePreferencePage;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
-import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
+import org.jboss.tools.docker.ui.bot.test.image.AbstractImageBotTest;
 import org.junit.After;
 import org.junit.Test;
 
@@ -48,17 +44,20 @@ import org.junit.Test;
  *
  */
 
-public class ComposeTest extends AbstractDockerBotTest {
-	private static String imageName = "test_compose";
+public class ComposeTest extends AbstractImageBotTest {
+
+	private static final String FILE_DOCKER_COMPOSE = "docker-compose.yml";
+	private static final String SYSPROP_DOCKER_COMPOSE_PATH = "dockerComposePath";
+	private static final String PATH_TEST_COMPOSE = "resources/test-compose";	
+	private static final String PROJECT_TEST_COMPOSE = "test-compose";
+	private static final String IMAGE_NAME = "test_compose";
 	private static final String URL = "http://0.0.0.0:5000/";
-	private static final String DOCKER_COMPOSE_PATH = "/usr/local/bin";
 
 	@Test
 	public void testCompose() {
-		// If patch to Docker compose is empty, try default path.
-		String dockerComposePath = System.getProperty("dockerComposePath") == null
-				|| System.getProperty("dockerComposePath").isEmpty() ? DOCKER_COMPOSE_PATH
-						: System.getProperty("dockerComposePath");
+		String dockerComposePath = System.getProperty(SYSPROP_DOCKER_COMPOSE_PATH);
+		assertTrue("Please provide -D" + SYSPROP_DOCKER_COMPOSE_PATH + "=<path to docker-compose binary> in your launch parameters.", 
+				!StringUtils.isBlank(dockerComposePath));
 
 		// Set up Docker Compose location
 		PreferenceDialog dialog = new WorkbenchPreferenceDialog();
@@ -70,33 +69,27 @@ public class ComposeTest extends AbstractDockerBotTest {
 		new OkButton().click();
 
 		// Build Image
-		DockerImagesTab imageTab = new DockerImagesTab();
-		imageTab.activate();
-		imageTab.refresh();
-		new WaitWhile(new JobIsRunning(), TimePeriod.NORMAL);
-		String dockerFilePath = "";
-		try {
-			dockerFilePath = (new File("resources/test-compose")).getCanonicalPath();
-		} catch (IOException ex) {
-			fail("Resource file not found!");
-		}
-		imageTab.buildImage(imageName, dockerFilePath);
-		new WaitWhile(new JobIsRunning(), TimePeriod.VERY_LONG);
-		ConsoleView consoleView = new ConsoleView();
-		consoleView.open();
-		assertFalse("Console has no output!", consoleView.getConsoleText().isEmpty());
-		assertTrue("Build has not been successful", consoleView.getConsoleText().contains("Successfully built"));
+		DockerImagesTab imagesTab = openDockerImagesTab();
+		buildImage(IMAGE_NAME, PATH_TEST_COMPOSE, imagesTab);
+		assertConsoleSuccess();
 
 		// Import resource folder
-		new ShellMenu("File", "Open Projects from File System...").select();
-		new LabeledCombo("Import source:").setText("resources/test-compose");
-		new FinishButton().click();
-		new WaitWhile(new JobIsRunning());
+		importProject(PATH_TEST_COMPOSE);
 
 		// Run Docker Compose
+		runDockerCompose(PROJECT_TEST_COMPOSE, FILE_DOCKER_COMPOSE);
+
+		// Check if application is running
+		BrowserView browserView = new BrowserView();
+		browserView.open();
+		browserView.openPageURL(URL);
+		DeployOnServer.checkBrowserForErrorPage(browserView, URL);
+	}
+
+	private void runDockerCompose(String project, String projectFile) {
 		PackageExplorer pe = new PackageExplorer();
 		pe.open();
-		pe.getProject("test-compose").getProjectItem("docker-compose.yml").select();
+		pe.getProject(project).getProjectItem(projectFile).select();
 		Menu contextMenu = new ContextMenu("Run As", "2 Docker Compose");
 		contextMenu.select();
 		new OkButton().click();
@@ -105,16 +98,16 @@ public class ComposeTest extends AbstractDockerBotTest {
 			new OkButton().click();
 			fail("Docker Compose has not been found! Is it installed and the path is correct?");
 		} catch (SWTLayerException ex) {
-			// Docker Compose command has been found
 		}
 		new WaitWhile(new JobIsRunning(), TimePeriod.VERY_LONG);
 		new WaitWhile(new ConsoleHasNoChange());
+	}
 
-		// Check if application is running
-		BrowserView browserView = new BrowserView();
-		browserView.open();
-		browserView.openPageURL(URL);
-		DeployOnServer.checkBrowserForErrorPage(browserView, URL);
+	private void importProject(String path) {
+		new ShellMenu("File", "Open Projects from File System...").select();
+		new LabeledCombo("Import source:").setText(path);
+		new FinishButton().click();
+		new WaitWhile(new JobIsRunning());
 	}
 
 	@After

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/DifferentRegistryTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/DifferentRegistryTest.java
@@ -13,44 +13,35 @@ package org.jboss.tools.docker.ui.bot.test.ui;
 
 import static org.junit.Assert.assertTrue;
 
-import org.jboss.reddeer.core.exception.CoreLayerException;
-import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
-import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
-import org.junit.After;
+import org.jboss.tools.docker.ui.bot.test.image.AbstractImageBotTest;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
- * 
  * @author jkopriva
- *
+ * @contributor adietish@redhat.com
  */
+public class DifferentRegistryTest extends AbstractImageBotTest {
 
-public class DifferentRegistryTest extends AbstractDockerBotTest {
-	private String serverAddress = "registry.access.redhat.com";
-	private String email = "test@test.com";
-	private String userName = "test";
-	private String password = "password";
-	private String imageName = "devstudio/atomicapp:latest";
+	private static final String REGISTRY_SERVER_ADDRESS = "registry.access.redhat.com";
+	private static final String EMAIL = "test@test.com";
+	private static final String USERNAME = "test";
+	private static final String PASSWORD = "password";
+	private static final String IMAGE_NAME = "rhel7.2";
+
+	@Before
+	public void before() {
+		deleteImageIfExists(REGISTRY_SERVER_ADDRESS + "/" + IMAGE_NAME);
+		deleteRegisterIfExists(REGISTRY_SERVER_ADDRESS);
+	}
 
 	@Test
 	public void testDifferentRegistry() {
-		ConsoleView cview = new ConsoleView();
-		cview.open();
-		try {
-			cview.clearConsole();
-		} catch (CoreLayerException ex) {
-			// there's not clear console button, since nothing run before
-		}
-		setUpRegister(serverAddress, email, userName, password);
-		setSecureStorage(this.password);
-		pullImage(imageName, null, this.userName + "@" + serverAddress);
-		assertTrue("Image is not deployed!", imageIsDeployed("devstudio/atomicapp"));
-	}
-
-	@After
-	public void after() {
-		deleteImageContainerAfter(serverAddress + "/devstudio/atomicapp");
-		deleteRegister(serverAddress);
+		clearConsole();
+		setUpRegister(REGISTRY_SERVER_ADDRESS, EMAIL, USERNAME, PASSWORD);
+		setSecureStorage(PASSWORD);
+		pullImage(IMAGE_NAME, null, USERNAME + "@" + REGISTRY_SERVER_ADDRESS);
+		assertTrue("Image is not deployed!", imageIsDeployed(IMAGE_NAME));
 	}
 
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/ImageTabTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/ImageTabTest.java
@@ -19,7 +19,7 @@ import org.jboss.reddeer.core.condition.JobIsRunning;
 import org.jboss.reddeer.eclipse.ui.views.properties.PropertiesView;
 import org.jboss.reddeer.swt.api.TableItem;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
-import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
+import org.jboss.tools.docker.ui.bot.test.image.AbstractImageBotTest;
 import org.junit.After;
 import org.junit.Test;
 
@@ -29,13 +29,13 @@ import org.junit.Test;
  *
  */
 
-public class ImageTabTest extends AbstractDockerBotTest {
+public class ImageTabTest extends AbstractImageBotTest {
 
-	private String imageName = "hello-world";
+	private static final String IMAGE_NAME = "hello-world";
 
 	@Test
 	public void testImageTab() {
-		pullImage(this.imageName);
+		pullImage(IMAGE_NAME);
 		DockerImagesTab imageTab = new DockerImagesTab();
 		imageTab.activate();
 		imageTab.refresh();
@@ -47,7 +47,7 @@ public class ImageTabTest extends AbstractDockerBotTest {
 		String sizeFromTable = "";
 
 		for (TableItem item : imageTab.getTableItems()) {
-			if (item.getText(1).contains(imageName)) {
+			if (item.getText(1).contains(IMAGE_NAME)) {
 				idFromTable = item.getText();
 				repoTagsFromTable = item.getText(1);
 				createdFromTable = item.getText(2);
@@ -57,7 +57,7 @@ public class ImageTabTest extends AbstractDockerBotTest {
 		}
 		idFromTable = idFromTable.replace("sha256:", "");
 
-		getConnection().getImage(getCompleteImageName(imageName)).select();
+		getConnection().getImage(getCompleteImageName(IMAGE_NAME)).select();
 
 		PropertiesView propertiesView = new PropertiesView();
 		propertiesView.open();
@@ -74,7 +74,7 @@ public class ImageTabTest extends AbstractDockerBotTest {
 	}
 
 	public void testImageTabSearch() {
-		pullImage(this.imageName);
+		pullImage(IMAGE_NAME);
 		DockerImagesTab imageTab = new DockerImagesTab();
 		imageTab.activate();
 		imageTab.refresh();
@@ -87,7 +87,7 @@ public class ImageTabTest extends AbstractDockerBotTest {
 
 	@After
 	public void after() {
-		deleteImageContainerAfter(imageName);
+		deleteImageContainerAfter(IMAGE_NAME);
 	}
 
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/LaunchDockerImageTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/LaunchDockerImageTest.java
@@ -13,48 +13,69 @@ package org.jboss.tools.docker.ui.bot.test.ui;
 
 import static org.junit.Assert.assertTrue;
 
+import org.jboss.reddeer.common.exception.RedDeerException;
+import org.jboss.reddeer.common.wait.TimePeriod;
+import org.jboss.reddeer.common.wait.WaitWhile;
+import org.jboss.reddeer.core.condition.JobIsRunning;
 import org.jboss.tools.docker.reddeer.ui.RunDockerImageLaunchConfiguration;
-import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
+import org.jboss.tools.docker.ui.bot.test.image.AbstractImageBotTest;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
  * 
  * @author jkopriva
- *
+ * @contributor adietish@redhat.com
  */
 
-public class LaunchDockerImageTest extends AbstractDockerBotTest {
-	private String imageName = "hello-world";
-	private String containerName = "test_variables";
-	private String configurationName = "test_configuration";
+public class LaunchDockerImageTest extends AbstractImageBotTest {
+
+	private static final String IMAGE_NAME = "hello-world";
+	private static final String CONTAINER_NAME = "test_variables";
+	private static final String CONFIGURATION_NAME = "test_configuration";
+
+	@Before
+	public void before() {
+		pullImage(IMAGE_NAME);
+	}
 
 	@Test
 	public void testLaunchConfiguration() {
+		String imageName = getCompleteImageName(IMAGE_NAME);
 
-		pullImage(imageName);
-		String completeImageName = getCompleteImageName(imageName);
-		
-		getConnection().enableConnection();
-		
 		RunDockerImageLaunchConfiguration runImageConf = new RunDockerImageLaunchConfiguration();
+		runDockerImageLaunchConfiguration(
+				imageName + NAME_TAG_SEPARATOR + IMAGE_TAG_LATEST, CONTAINER_NAME, CONFIGURATION_NAME, runImageConf);
+		assertTrue("Container is not deployed!", containerIsDeployed(CONTAINER_NAME));
+	}
+
+	private void runDockerImageLaunchConfiguration(String imageName, String containerName, String configurationName, RunDockerImageLaunchConfiguration runImageConf) {
 		runImageConf.open();
 		runImageConf.createNewConfiguration(configurationName);
 		runImageConf.setContainerName(containerName);
-		runImageConf.selectImage(completeImageName + ":latest");
+		runImageConf.selectImage(imageName);
 		runImageConf.setPrivilegedMode(true);
 		runImageConf.apply();
 		runImageConf.runConfiguration(configurationName);
+		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
+	}
 
-		assertTrue("Container is not deployed!", containerIsDeployed(containerName));
-		runImageConf.open();
-		runImageConf.deleteRunConfiguration(configurationName);
-		runImageConf.close();
+	private void deleteIfExists(String configurationName) {
+		RunDockerImageLaunchConfiguration runImageConf = new RunDockerImageLaunchConfiguration();
+		try {
+			runImageConf.open();
+			runImageConf.deleteRunConfiguration(configurationName);
+			runImageConf.close();
+		} catch (RedDeerException e) {
+			// catched intentionally
+		}
 	}
 
 	@After
 	public void after() {
-		deleteImageContainerAfter(containerName,imageName);
+		deleteIfExists(CONFIGURATION_NAME);
+		deleteImageContainerAfter(CONTAINER_NAME);
 	}
 
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/PropertiesViewTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/PropertiesViewTest.java
@@ -21,43 +21,39 @@ import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageRunSelectionPage;
 import org.jboss.tools.docker.reddeer.ui.DockerContainersTab;
 import org.jboss.tools.docker.reddeer.ui.DockerImagesTab;
-import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
+import org.jboss.tools.docker.ui.bot.test.image.AbstractImageBotTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 /**
- * 
  * @author jkopriva
+ * @contributor adietish@redhat.com
  *
  */
+public class PropertiesViewTest extends AbstractImageBotTest {
 
-public class PropertiesViewTest extends AbstractDockerBotTest {
-
-	private String imageName = "docker/whalesay";
-	private String containerName = "test_run_docker_whalesay";
+	private static final String IMAGE_NAME = IMAGE_BUSYBOX;
+	private static final String CONTAINER_NAME = "test_run_docker_busybox";
 
 	@Before
 	public void before() {
-		pullImage(this.imageName);
+		pullImage(IMAGE_NAME);
 	}
 
 	@Test
 	public void testContainerPropertiesTab() {
-		DockerImagesTab imageTab = new DockerImagesTab();
-		imageTab.activate();
-		imageTab.refresh();
-		new WaitWhile(new JobIsRunning());
-		imageTab.runImage(this.imageName);
+		DockerImagesTab imagesTab = openDockerImagesTab();
+		imagesTab.runImage(IMAGE_NAME);
 		ImageRunSelectionPage firstPage = new ImageRunSelectionPage();
-		firstPage.setName(this.containerName);
+		firstPage.setName(CONTAINER_NAME);
 		firstPage.finish();
 		new WaitWhile(new JobIsRunning());
 		DockerContainersTab containerTab = new DockerContainersTab();
 		containerTab.activate();
 		containerTab.refresh();
 		new WaitWhile(new JobIsRunning(), TimePeriod.NORMAL);
-		containerTab.select(containerName);
+		containerTab.select(CONTAINER_NAME);
 
 		// get values from Properties view
 		PropertiesView propertiesView = new PropertiesView();
@@ -71,10 +67,8 @@ public class PropertiesViewTest extends AbstractDockerBotTest {
 
 	@Test
 	public void testImagePropertiesTab() {
-		DockerImagesTab imageTab = new DockerImagesTab();
-		imageTab.activate();
-		imageTab.refresh();
-		imageTab.selectImage(imageName);
+		DockerImagesTab imagesTab = openDockerImagesTab();
+		imagesTab.selectImage(IMAGE_NAME);
 		PropertiesView propertiesView = new PropertiesView();
 		propertiesView.open();
 		try {
@@ -86,7 +80,6 @@ public class PropertiesViewTest extends AbstractDockerBotTest {
 
 	@After
 	public void after() {
-		deleteImageContainerAfter(containerName,imageName);
+		deleteContainerIfExists(CONTAINER_NAME);
 	}
-
 }

--- a/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/SearchDialogTest.java
+++ b/tests/org.jboss.tools.docker.ui.bot.test/src/org/jboss/tools/docker/ui/bot/test/ui/SearchDialogTest.java
@@ -25,53 +25,55 @@ import org.jboss.reddeer.swt.impl.button.PushButton;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageSearchPage;
 import org.jboss.tools.docker.reddeer.core.ui.wizards.ImageTagSelectionPage;
-import org.jboss.tools.docker.ui.bot.test.AbstractDockerBotTest;
-import org.junit.After;
+import org.jboss.tools.docker.ui.bot.test.image.AbstractImageBotTest;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
  * 
  * @author jkopriva
+ * @contributor adietish@redhat.com
  *
  */
 
-public class SearchDialogTest extends AbstractDockerBotTest {
-	private String imageName = "busybox";
-	private String imageTag = "1.24";
-	private String expectedImageName = "busybox";
-	private String registryAddress = "https://index.docker.io";
+public class SearchDialogTest extends AbstractImageBotTest {
+	
+	private static final String IMAGE_NAME = IMAGE_BUSYBOX;
+	private static final String IMAGE_TAG = "1.24";
+	private static final String EXPECTED_IMAGE_NAME = "busybox";
 
+	@Before
+	public void before() {
+		deleteImageIfExists(IMAGE_NAME, IMAGE_TAG);
+	}
+	
 	@Test
 	public void testSearchDialog() {
 		getConnection()
-			.openImageSearchDialog(this.imageName, null, this.registryAddress);
+			.openImageSearchDialog(IMAGE_NAME, null, REGISTRY_URL);
 		ImageSearchPage pageOne = new ImageSearchPage();
 		pageOne.searchImage();
 		assertFalse("Search result is empty!", pageOne.getSearchResults().isEmpty());
-		assertTrue("Search result do not contains image:" + expectedImageName + "!",
-				pageOne.searchResultsContains(expectedImageName));
+		assertTrue("Search result do not contains image:" + EXPECTED_IMAGE_NAME + "!",
+				pageOne.searchResultsContains(EXPECTED_IMAGE_NAME));
 		pageOne.next();
 
 		new WaitWhile(new ProgressInformationShellIsActive(), TimePeriod.NORMAL);
 		AbstractWait.sleep(TimePeriod.getCustom(5));
 		ImageTagSelectionPage pageTwo = new ImageTagSelectionPage();
 		assertFalse("Search tags are empty!", pageTwo.getTags().isEmpty());
-		new WaitWhile(new JobIsRunning(), TimePeriod.NORMAL);
-		if (!pageTwo.tagsContains(imageTag)) {
+		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
+		if (!pageTwo.tagsContains(IMAGE_TAG)) {
 			pageTwo.cancel();
 			new CancelButton().click();
-			fail("Search results do not contains tag:" + imageTag + "!");
+			fail("Search results do not contain tag: " + IMAGE_TAG + "!");
 		}
-		pageTwo.selectTag(imageTag);
+		pageTwo.selectTag(IMAGE_TAG);
 		pageTwo.finish();
 		new DefaultShell("Pull Image");
 		new PushButton("Finish").click();
 		new WaitWhile(new JobIsRunning(), TimePeriod.VERY_LONG);
 	}
-
-	@After
-	public void after() {
-		deleteImageContainerAfter(imageName+":"+imageTag);
-	}
-
+	
+	
 }


### PR DESCRIPTION
the following changes lead to a very much shorter runtime of the whole suite:

* used smaller docker images to speed up the suite (BuildImageTest,
PullImageTest, ExposedPortTest, ContainerTabTest, PropertiesViewTest,
LaunchDockerImageTest, DockerContainerTest, DifferentRegistryTest,
VolumeMountTest)
* pulling instead of building in HierarchyViewTest
* fixed DockerConnectio#getImageNames and #deployedImagesCount so that
specific image versions can be asserted
* introduced AbstractImageBotTest as base class for all tests that deal
with images (build, push, pull, etc.)
* added AbstractImageBotTest#deleteContainerIfExists to delete
containers from previous test runs
* corrected static fields in test to be consistently static & final