### PR TITLE
Examples - Added blacklist file for non supported quickstarts in DevStudio

### DIFF
--- a/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
@@ -30,7 +30,7 @@
 		<jbosstools.test.jboss-eap-7.x.url>http://download.eng.brq.redhat.com/released/JBEAP-7/7.0.0/jboss-eap-7.0.0.zip</jbosstools.test.jboss-eap-7.x.url>
 		<surefire.timeout>18000</surefire.timeout>
 		<skipTests>false</skipTests>
-		<deployOnServer>true</deployOnServer>
+		<deployOnServer>false</deployOnServer>
 	</properties>
 	<build>
 	<resources>

--- a/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/eap-blacklist
+++ b/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/eap-blacklist
@@ -1,0 +1,1 @@
+ejb-multi-server

--- a/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/wildfly-blacklist
+++ b/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/wildfly-blacklist
@@ -1,0 +1,1 @@
+ejb-multi-server

--- a/tests/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/EAPImportQuickstartsTest.java
+++ b/tests/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/EAPImportQuickstartsTest.java
@@ -39,6 +39,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 @JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP7x)
 public class EAPImportQuickstartsTest extends AbstractImportQuickstartsTest {
 	public static final String SERVER_NAME ="Enterprise Application Platform";
+	public static final String BLACKLIST_FILE = "resources/servers/eap-blacklist";
 
 	@Parameters(name = "{0}")
 	public static Collection<Quickstart> data() {
@@ -54,7 +55,7 @@ public class EAPImportQuickstartsTest extends AbstractImportQuickstartsTest {
 	 */
 	@Test
 	public void quickstartTest() {
-		runQuickstarts(qstart, SERVER_NAME);
+		runQuickstarts(qstart, SERVER_NAME, BLACKLIST_FILE);
 	}
 
 

--- a/tests/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/WildFlyImportQuickstartsTest.java
+++ b/tests/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/WildFlyImportQuickstartsTest.java
@@ -43,6 +43,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 public class WildFlyImportQuickstartsTest extends AbstractImportQuickstartsTest {
 	public static final String SERVER_NAME = "WildFly";
+	public static final String BLACKLIST_FILE = "resources/servers/wildfly-blacklist";
 
 	@Parameters(name = "{0}")
 	public static Collection<Quickstart> data() {
@@ -58,7 +59,7 @@ public class WildFlyImportQuickstartsTest extends AbstractImportQuickstartsTest 
 	 */
 	@Test
 	public void quickstartTest() {
-		runQuickstarts(qstart, SERVER_NAME);
+		runQuickstarts(qstart, SERVER_NAME,BLACKLIST_FILE);
 	}
 
 


### PR DESCRIPTION
Changes:
- Added blacklist file for wildfly and EAP examples, which are not supported in DevStudio
- Deploy on server is not activated by default - now is tested only import in DevStudio, leaving support for deploying on server for future testing purporses