### PR TITLE
Jsf stabilization

### DIFF
--- a/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
@@ -171,13 +171,13 @@
 								</configuration>
 							</execution>
 							<execution>
-								<id>install-eap-7.x</id>
+								<id>install-eap-7.0</id>
 								<phase>pre-integration-test</phase>
 								<goals>
 									<goal>wget</goal>
 								</goals>
 								<configuration>
-									<url>${jbosstools.test.jboss-eap-7.x.url}</url>
+									<url>${jbosstools.test.jboss-eap-7.0.url}</url>
 									<unpack>true</unpack>
 								</configuration>
 							</execution>

--- a/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/eap-7.xml
+++ b/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/eap-7.xml
@@ -7,9 +7,9 @@
 						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/JBossServerRequirements.xsd">
 
 	<requirements>
-		<server:jboss-server-requirement name="EAP-7.x">
+		<server:jboss-server-requirement name="EAP-7.0">
 			<server:type>
-				<server:familyEAP version="7.x"></server:familyEAP>
+				<server:familyEAP version="7.0"></server:familyEAP>
 			</server:type>
 			<server:runtime>${jbosstools.test.eap7.home}</server:runtime>
 		</server:jboss-server-requirement>

--- a/tests/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/EAPImportQuickstartsTest.java
+++ b/tests/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/EAPImportQuickstartsTest.java
@@ -36,7 +36,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 @RunWith(RedDeerSuite.class)
 @UseParametersRunnerFactory(ParameterizedRequirementsRunnerFactory.class)
 @DefineMavenRepository(propDefMavenRepo = @PropertyDefinedMavenRepository(ID = "test", snapshots = true) )
-@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP7x)
+@JBossServer(state=ServerReqState.RUNNING, type=ServerReqType.EAP7_0)
 public class EAPImportQuickstartsTest extends AbstractImportQuickstartsTest {
 	public static final String SERVER_NAME ="Enterprise Application Platform";
 	public static final String BLACKLIST_FILE = "resources/servers/eap-blacklist";

--- a/tests/org.jboss.tools.jsf.ui.test/resources/EAP70.xml
+++ b/tests/org.jboss.tools.jsf.ui.test/resources/EAP70.xml
@@ -3,12 +3,15 @@
 	xmlns="http://www.jboss.org/NS/Req" 
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:server="http://www.jboss.org/NS/ServerReq"
-	xsi:schemaLocation="http://www.jboss.org/NS/Req http://www.jboss.org/schema/reddeer/v1/RedDeerSchema.xsd http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/v1/JBossServerRequirements.xsd">
+	xsi:schemaLocation="http://www.jboss.org/NS/Req 
+						http://www.jboss.org/schema/reddeer/v1/RedDeerSchema.xsd 
+						http://www.jboss.org/NS/ServerReq 
+						file:///home/odockal/JBossServerRequirements.xsd">
 
 	<requirements>
-		<server:jboss-server-requirement name="EAP-7.x">
+		<server:jboss-server-requirement name="EAP-7.0">
 			<server:type>
-				<server:familyEAP version="7.x"></server:familyEAP>
+				<server:familyEAP version="7.0"></server:familyEAP>
 			</server:type>
 			<server:runtime>${jbosstools.test.jboss-eap-7.0.home}</server:runtime>
 		</server:jboss-server-requirement>

--- a/tests/org.jboss.tools.jsf.ui.test/resources/EAP70.xml
+++ b/tests/org.jboss.tools.jsf.ui.test/resources/EAP70.xml
@@ -6,7 +6,7 @@
 	xsi:schemaLocation="http://www.jboss.org/NS/Req 
 						http://www.jboss.org/schema/reddeer/v1/RedDeerSchema.xsd 
 						http://www.jboss.org/NS/ServerReq 
-						file:///home/odockal/JBossServerRequirements.xsd">
+						http://www.jboss.org/schema/reddeer/v1/JBossServerRequirements.xsd">
 
 	<requirements>
 		<server:jboss-server-requirement name="EAP-7.0">

--- a/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/project/CreateJSFProjectTest.java
+++ b/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/project/CreateJSFProjectTest.java
@@ -25,6 +25,7 @@ import org.jboss.reddeer.requirements.server.ServerReqState;
 import org.jboss.tools.jsf.ui.test.requirement.DoNotUseVPERequirement.DoNotUseVPE;
 import org.jboss.tools.jsf.ui.test.utils.JSFTestUtils;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
@@ -33,7 +34,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 @RunWith(RedDeerSuite.class)
 @DoNotUseVPE
 @UseParametersRunnerFactory(ParameterizedRequirementsRunnerFactory.class)
-@JBossServer(type = ServerReqType.EAP7x, state = ServerReqState.PRESENT)
+@JBossServer(type = ServerReqType.EAP7_0, state = ServerReqState.PRESENT)
 public class CreateJSFProjectTest {
 
 	protected static final String PROJECT_NAME_BASE = "JSFTestProject";
@@ -67,6 +68,11 @@ public class CreateJSFProjectTest {
 		JSFTestUtils.checkProblemsView();
 
 		JSFTestUtils.checkErrorLog();
+	}
+	
+	@Before
+	public void setup() {
+		JSFTestUtils.deleteErrorLog();
 	}
 
 	@After

--- a/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/project/ExportImportWARTest.java
+++ b/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/project/ExportImportWARTest.java
@@ -18,6 +18,9 @@ import java.io.File;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerReqType;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
+import org.jboss.reddeer.common.wait.TimePeriod;
+import org.jboss.reddeer.common.wait.WaitWhile;
+import org.jboss.reddeer.core.condition.JobIsRunning;
 import org.jboss.reddeer.eclipse.core.resources.Project;
 import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
 import org.jboss.reddeer.eclipse.jdt.ui.ProjectExplorer;
@@ -99,6 +102,7 @@ public class ExportImportWARTest {
 		ImportWebWarWizardPage importPage = new ImportWebWarWizardPage();
 		importPage.setWarLocation(new File(WAR_FILE_LOCATION).getAbsolutePath());
 		importPage.setName(NEW_PROJECT_NAME);
+		new WaitWhile(new JobIsRunning(), TimePeriod.LONG, false);
 		importDialog.finish();
 	}
 

--- a/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/project/ExportImportWARTest.java
+++ b/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/project/ExportImportWARTest.java
@@ -8,7 +8,6 @@
  * Contributor:
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-
 package org.jboss.tools.jsf.ui.test.project;
 
 import static org.junit.Assert.assertTrue;
@@ -40,7 +39,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(RedDeerSuite.class)
 @DoNotUseVPE
-@JBossServer(type = ServerReqType.EAP7x, state = ServerReqState.RUNNING)
+@JBossServer(type = ServerReqType.EAP7_0, state = ServerReqState.RUNNING)
 public class ExportImportWARTest {
 
 	private static final String PROJECT_NAME = "JSFProject";

--- a/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/project/RunJSFProjectTest.java
+++ b/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/project/RunJSFProjectTest.java
@@ -47,7 +47,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 @RunWith(RedDeerSuite.class)
 @DoNotUseVPE
 @UseParametersRunnerFactory(ParameterizedRequirementsRunnerFactory.class)
-@JBossServer(type = ServerReqType.EAP7x, state = ServerReqState.RUNNING)
+@JBossServer(type = ServerReqType.EAP7_0, state = ServerReqState.RUNNING)
 public class RunJSFProjectTest {
 
 	protected static final String PROJECT_NAME_BASE = "JSFTestProject";
@@ -75,6 +75,7 @@ public class RunJSFProjectTest {
 	@Before
 	public void setup() {
 		JSFTestUtils.createJSFProject(projectName, jsfEnvironment, template, false);
+		JSFTestUtils.deleteErrorLog();
 	}
 
 	@After

--- a/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/utils/JSFTestUtils.java
+++ b/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/utils/JSFTestUtils.java
@@ -51,11 +51,18 @@ public class JSFTestUtils {
 		}
 		assertEquals("Error log contains errors: \n" + errorsToString(logView.getErrorMessages()), 0,
 				errorMessages.size());
-		logView.deleteLog();
 	}
 
 	public static void createJSFProject(String projectName, String jsfEnvironment, String template) {
 		createJSFProject(projectName, jsfEnvironment, template, false);
+	}
+	
+	public static void deleteErrorLog() {
+		LogView errorLog = new LogView();
+		errorLog.open();
+		if(!errorLog.getErrorMessages().isEmpty() || !errorLog.getWarningMessages().isEmpty()) {
+			errorLog.deleteLog();
+		}
 	}
 
 	public static void createJSFProject(String projectName, String jsfEnvironment, String template,


### PR DESCRIPTION
 Updates made to reflect deprecated EAP7x server type requirement. See [PR](https://github.com/jbosstools/jbosstools-server/pull/519). Added some stabilization efforts.