### PR TITLE
JBIDE-24978 Stabilize SmartImport tests.

### DIFF
--- a/tests/org.jboss.tools.easymport.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.easymport.ui.bot.test/pom.xml
@@ -16,6 +16,7 @@
 		<skipTests>false</skipTests>
 		<usage_reporting_enabled>false</usage_reporting_enabled>
 		<maven.test.failure.ignore>true</maven.test.failure.ignore>
+		<systemProperties>-Dignored.errors.regexp=${ignored.errors.regexp}</systemProperties>
 	</properties>
 
 	<build>


### PR DESCRIPTION
Add possibility to ignore some errors in Error View. Test can be started with parameter like this: 
-Dignored.errors.regexp="Some error \.\*|Another error".

Also added Abstract wait before cleaning of Error View at start up because some of irelevant errors can appear after a while.

Signed-off-by: Lukáš Valach <lvalach@redhat.com>