### PR TITLE
JBIDE-24900 Split CDI 10/11 smoke tests to separated suites.

### DIFF
--- a/tests/org.jboss.tools.cdi.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.bot.test/pom.xml
@@ -27,6 +27,18 @@
 			</properties>
 		</profile>
 		<profile>
+			<id>cdi10-smoke-tests</id>
+			<properties>
+				<suiteClass>org.jboss.tools.cdi.bot.test.CDI10SmokeSuite</suiteClass>
+			</properties>
+		</profile>
+		<profile>
+			<id>cdi11-smoke-tests</id>
+			<properties>
+				<suiteClass>org.jboss.tools.cdi.bot.test.CDI11SmokeSuite</suiteClass>
+			</properties>
+		</profile>
+		<profile>
 			<id>all-bot-tests</id>
 			<properties>
 				<suiteClass>org.jboss.tools.cdi.bot.test.CDIAllBotTests</suiteClass>

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDI10SmokeSuite.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDI10SmokeSuite.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2007-2017 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.bot.test;
+
+import org.eclipse.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.tools.cdi.bot.test.beans.bean.cdi10.BeanValidationQuickFixTestCDI10;
+import org.jboss.tools.cdi.bot.test.beans.named.cdi10.NamedComponentsSearchingTestCDI10;
+import org.jboss.tools.cdi.bot.test.beans.openon.cd10.BeanInjectOpenOnTestCDI10;
+import org.jboss.tools.cdi.bot.test.beans.openon.cd10.FindObserverEventTestCDI10;
+import org.jboss.tools.cdi.bot.test.beansxml.cdi10.BeansXMLBeansEditorTestCDI10;
+import org.jboss.tools.cdi.bot.test.beansxml.cdi10.BeansXMLValidationTestCDI10;
+import org.jboss.tools.cdi.bot.test.beansxml.completion.cdi10.BeansXMLCompletionTestCDI10;
+import org.jboss.tools.cdi.bot.test.beansxml.validation.cdi10.BeansXMLValidationQuickFixTestCDI10;
+import org.jboss.tools.cdi.bot.test.validation.cdi10.CDIValidatorTestCDI10;
+import org.jboss.tools.cdi.bot.test.wizard.cdi10.CDIWebProjectWizardTestCDI10;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(RedDeerSuite.class)
+@SuiteClasses({	
+	BeanValidationQuickFixTestCDI10.class,
+	NamedComponentsSearchingTestCDI10.class,
+	BeanInjectOpenOnTestCDI10.class,
+	FindObserverEventTestCDI10.class,
+	BeansXMLCompletionTestCDI10.class,
+	BeansXMLBeansEditorTestCDI10.class,
+	BeansXMLValidationTestCDI10.class,
+	BeansXMLValidationQuickFixTestCDI10.class,
+	CDIValidatorTestCDI10.class,
+	CDIWebProjectWizardTestCDI10.class,
+})
+public class CDI10SmokeSuite {
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDI11SmokeSuite.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDI11SmokeSuite.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2007-2017 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.bot.test;
+
+import org.eclipse.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.tools.cdi.bot.test.beans.bean.cdi11.BeanValidationQuickFixTestCDI11;
+import org.jboss.tools.cdi.bot.test.beans.named.cdi11.NamedComponentsSearchingTestCDI11;
+import org.jboss.tools.cdi.bot.test.beans.openon.cdi11.BeanInjectOpenOnTestCDI11;
+import org.jboss.tools.cdi.bot.test.beans.openon.cdi11.FindObserverEventTestCDI11;
+import org.jboss.tools.cdi.bot.test.beansxml.cdi11.BeansXMLBeansEditorTestCDI11;
+import org.jboss.tools.cdi.bot.test.beansxml.cdi11.BeansXMLDiscoveryModesTestCDI11;
+import org.jboss.tools.cdi.bot.test.beansxml.cdi11.BeansXMLValidationTestCDI11;
+import org.jboss.tools.cdi.bot.test.beansxml.completion.cdi11.BeansXMLCompletionTestCDI11;
+import org.jboss.tools.cdi.bot.test.beansxml.validation.cdi11.BeansXMLValidationQuickFixTestCDI11;
+import org.jboss.tools.cdi.bot.test.validation.cdi11.CDIValidatorTestCDI11;
+import org.jboss.tools.cdi.bot.test.wizard.cdi11.CDIWebProjectWizardTestCDI11;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(RedDeerSuite.class)
+@SuiteClasses({
+	BeanValidationQuickFixTestCDI11.class,
+	NamedComponentsSearchingTestCDI11.class,
+	BeanInjectOpenOnTestCDI11.class,
+	FindObserverEventTestCDI11.class,
+	BeansXMLCompletionTestCDI11.class,
+	BeansXMLBeansEditorTestCDI11.class,
+	BeansXMLValidationTestCDI11.class,
+	BeansXMLValidationQuickFixTestCDI11.class,
+	CDIValidatorTestCDI11.class,
+	CDIWebProjectWizardTestCDI11.class,
+	BeansXMLDiscoveryModesTestCDI11.class
+})
+public class CDI11SmokeSuite {
+
+}


### PR DESCRIPTION
JBIDE-24900 Split CDI 10/11 smoke tests to separated suites.

Signed-off-by: Lukáš Valach <lvalach@redhat.com>