### PR TITLE
JSF itests stabilization

### DIFF
--- a/tests/org.jboss.tools.jsf.ui.test/build.properties
+++ b/tests/org.jboss.tools.jsf.ui.test/build.properties
@@ -1,3 +1,5 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
+               resources/,\
+               .

--- a/tests/org.jboss.tools.jsf.ui.test/launchers/AllTestsSuite.launch
+++ b/tests/org.jboss.tools.jsf.ui.test/launchers/AllTestsSuite.launch
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.reddeer.eclipse.ui.launcher.JunitLaunchConfig">
+<booleanAttribute key="append.args" value="true"/>
+<booleanAttribute key="askclear" value="false"/>
+<booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticValidate" value="true"/>
+<stringAttribute key="bootstrap" value=""/>
+<stringAttribute key="checked" value="[NONE]"/>
+<booleanAttribute key="clearConfig" value="true"/>
+<booleanAttribute key="clearws" value="true"/>
+<booleanAttribute key="clearwslog" value="false"/>
+<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+<booleanAttribute key="default" value="true"/>
+<booleanAttribute key="includeOptional" value="true"/>
+<stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/AllTestsSuite.java"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<mapAttribute key="org.eclipse.debug.core.environmentVariables">
+<mapEntry key="DISPLAY" value=":1"/>
+</mapAttribute>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.jboss.tools.jsf.ui.test.AllTestsSuite"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -pluginCustomization ${project_loc:org.jboss.tools.jsf.ui.test}/../pluginCustomization.ini"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.jboss.tools.jsf.ui.test"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dusage_reporting_enabled=false -Djbosstools.test.jboss-eap-7.1.home=${string_prompt:&quot;Server runtime location&quot;}"/>
+<stringAttribute key="pde.version" value="3.3"/>
+<stringAttribute key="product" value="com.jboss.devstudio.core.product"/>
+<stringAttribute key="rd.launch.property.rd.captureScreenshot" value="true"/>
+<stringAttribute key="rd.launch.property.rd.closeShells" value="true"/>
+<stringAttribute key="rd.launch.property.rd.closeWelcomeScreen" value="true"/>
+<stringAttribute key="rd.launch.property.rd.config" value="resources/requirements.json"/>
+<stringAttribute key="rd.launch.property.rd.disableMavenIndex" value="true"/>
+<stringAttribute key="rd.launch.property.rd.logCollectorEnabled" value="true"/>
+<stringAttribute key="rd.launch.property.rd.logLevel" value="ALL"/>
+<stringAttribute key="rd.launch.property.rd.logMessageFilter" value="ALL"/>
+<stringAttribute key="rd.launch.property.rd.maximizeWorkbench" value="true"/>
+<stringAttribute key="rd.launch.property.rd.openAssociatedPerspective" value="never"/>
+<stringAttribute key="rd.launch.property.rd.pauseFailedTest" value="false"/>
+<stringAttribute key="rd.launch.property.rd.timePeriodFactor" value="1.0"/>
+<booleanAttribute key="show_selected_only" value="false"/>
+<stringAttribute key="templateConfig" value="${target_home}/configuration/config.ini"/>
+<booleanAttribute key="tracing" value="false"/>
+<booleanAttribute key="useCustomFeatures" value="false"/>
+<booleanAttribute key="useDefaultConfig" value="true"/>
+<booleanAttribute key="useDefaultConfigArea" value="false"/>
+<booleanAttribute key="useProduct" value="true"/>
+</launchConfiguration>

--- a/tests/org.jboss.tools.jsf.ui.test/launchers/JSFAllTestsSuite.launch
+++ b/tests/org.jboss.tools.jsf.ui.test/launchers/JSFAllTestsSuite.launch
@@ -34,7 +34,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -pluginCustomization ${project_loc:org.jboss.tools.jsf.ui.test}/../pluginCustomization.ini"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.jboss.tools.jsf.ui.test"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dusage_reporting_enabled=false -Djbosstools.test.jboss-eap-7.0.home=${string_prompt:&quot;Server runtime location&quot;}"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dusage_reporting_enabled=false -Djbosstools.test.jboss-eap-7.1.home=${string_prompt:&quot;Server runtime location&quot;}"/>
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value="com.jboss.devstudio.core.product"/>
 <stringAttribute key="rd.launch.property.rd.captureScreenshot" value="true"/>

--- a/tests/org.jboss.tools.jsf.ui.test/pom.xml
+++ b/tests/org.jboss.tools.jsf.ui.test/pom.xml
@@ -13,10 +13,13 @@
 	
 	<properties>
 		<jbosstools.test.jboss-eap-7.0.home>${requirementsDirectory}/jboss-eap-7.0</jbosstools.test.jboss-eap-7.0.home>
+		<jbosstools.test.jboss-eap-7.1.home>${requirementsDirectory}/jboss-eap-7.1</jbosstools.test.jboss-eap-7.1.home>
 		<rd.config>${project.build.directory}/classes/requirements.json</rd.config>
-		<systemProperties>${integrationTestsSystemProperties} -Dusage_reporting_enabled=false -Drd.config=${rd.config}</systemProperties>
+		<systemProperties>${integrationTestsSystemProperties} -Dusage_reporting_enabled=false -Drd.config=${rd.config} -Djbosstools.test.jboss-eap-7.1.home=${jbosstools.test.jboss-eap-7.1.home}</systemProperties>
 		<surefire.timeout>10800</surefire.timeout>
 		<test.class>org.jboss.tools.jsf.ui.test.AllTestsSuite</test.class>
+		<jbosstools.test.jboss-eap-7.0.url>http://download.eng.brq.redhat.com/released/JBEAP-7/7.0.0/jboss-eap-7.0.0.zip</jbosstools.test.jboss-eap-7.0.url>
+		<jbosstools.test.jboss-eap-7.1.url>http://download.eng.brq.redhat.com/released/JBEAP-7/7.1.0/jboss-eap-7.1.0.zip</jbosstools.test.jboss-eap-7.1.url>
 	</properties>
 
 	<profiles>
@@ -30,57 +33,7 @@
 			<id>smoke-tests</id>
 			<properties>
 				<test.class>org.jboss.tools.jsf.ui.test.SmokeTestsSuite</test.class>
-			</properties>			
-		</profile>
-	
-		<profile>
-			<id>product</id>
-			<activation>
-				<property>
-					<name>product-download-properties-file</name>
-				</property>
-			</activation>
-			
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>properties-maven-plugin</artifactId>
-						<version>1.0.0</version>
-						<executions>
-							<execution>
-								<phase>initialize</phase>
-								<goals>
-									<goal>read-project-properties</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<quiet>true</quiet>
-							<files>
-								<file>${product-download-properties-file}</file>
-							</files>
-						</configuration>
-					</plugin>
-					<plugin>
-						<groupId>com.googlecode.maven-download-plugin</groupId>
-						<artifactId>download-maven-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>install-eap-70</id>
-								<phase>pre-integration-test</phase>
-								<goals>
-									<goal>wget</goal>
-								</goals>
-								<configuration>
-									<url>${jbosstools.test.eap70.url}</url>
-									<unpack>true</unpack>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
+			</properties>
 		</profile>
 	</profiles>
 
@@ -93,7 +46,24 @@
 					<testClass>${test.class}</testClass>
 				</configuration>
 			</plugin>
-
+			
+			<plugin>
+				<groupId>com.googlecode.maven-download-plugin</groupId>
+				<artifactId>download-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>install-eap-7.1</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>wget</goal>
+						</goals>
+						<configuration>
+							<url>${jbosstools.test.jboss-eap-7.1.url}</url>
+							<unpack>true</unpack>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 		
 		<resources>

--- a/tests/org.jboss.tools.jsf.ui.test/resources/requirements.json
+++ b/tests/org.jboss.tools.jsf.ui.test/resources/requirements.json
@@ -1,8 +1,8 @@
 {
 	"org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer": [
 		{
-			"runtime": "${jbosstools.test.jboss-eap-7.0.home}",
-			"version": "7.0",
+			"runtime": "${jbosstools.test.jboss-eap-7.1.home}",
+			"version": "7.1",
 			"family": "EAP"
 		}
 	]

--- a/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/AllTestsSuite.java
+++ b/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/AllTestsSuite.java
@@ -21,7 +21,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({
     CreateJSFProjectTest.class,
     RunJSFProjectTest.class,
-    ExportImportWARTest.class
+    ExportImportWARTest.class,
     })
 public class AllTestsSuite {
 

--- a/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/project/CreateJSFProjectTest.java
+++ b/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/project/CreateJSFProjectTest.java
@@ -15,12 +15,12 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.eclipse.reddeer.eclipse.core.resources.Project;
 import org.eclipse.reddeer.eclipse.ui.navigator.resources.ProjectExplorer;
 import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
 import org.eclipse.reddeer.junit.internal.runner.ParameterizedRequirementsRunnerFactory;
 import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
+import org.eclipse.reddeer.requirements.closeeditors.CloseAllEditorsRequirement.CloseAllEditors;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
 import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
@@ -37,6 +37,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 @DoNotUseVPE
 @UseParametersRunnerFactory(ParameterizedRequirementsRunnerFactory.class)
 @JBossServer(state = ServerRequirementState.PRESENT)
+@CloseAllEditors
 public class CreateJSFProjectTest {
 
 	protected static final String PROJECT_NAME_BASE = "JSFTestProject";
@@ -48,8 +49,13 @@ public class CreateJSFProjectTest {
 	@Parameters(name = "{0} {1}")
 	public static Collection<String[]> data() {
 		return Arrays.asList(
-				new String[][] {{"JSF 1.2", "JSFKickStartWithoutLibs"}, {"JSF 2.2", "JSFKickStartWithoutLibs"},
-						{"JSF 1.2 with Facelets", "FaceletsKickStartWithoutLibs"}});
+				new String[][] {
+					{"JSF 1.2", "JSFKickStartWithoutLibs"},
+					{"JSF 1.2 with Facelets", "FaceletsKickStartWithoutLibs"},
+					{"JSF 2.0", "JSFBlankWithLibs"}, 
+					{"JSF 2.1", "JSFBlankWithoutLibs"}, 
+					{"JSF 2.2", "JSFKickStartWithoutLibs"}
+				});
 	}
 
 	@RequirementRestriction
@@ -74,7 +80,10 @@ public class CreateJSFProjectTest {
 
 		JSFTestUtils.checkProblemsView();
 
-		JSFTestUtils.checkErrorLog();
+		//JSFTestUtils.checkErrorLog();
+		assertTrue(projectExplorer.getProject(projectName).containsResource("WebContent", "WEB-INF"));
+		assertTrue(projectExplorer.getProject(projectName).containsResource("WebContent", "WEB-INF", "web.xml"));
+		assertTrue(projectExplorer.getProject(projectName).containsResource("WebContent", "WEB-INF", "faces-config.xml"));
 	}
 	
 	@Before
@@ -84,10 +93,7 @@ public class CreateJSFProjectTest {
 
 	@After
 	public void teardown() {
-		// delete test project
-		ProjectExplorer projectExplorer = new ProjectExplorer();
-		Project project = projectExplorer.getProject(projectName);
-		project.delete(true);
+		JSFTestUtils.deleteProject(projectName);
 	}
 
 }

--- a/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/project/RunJSFProjectTest.java
+++ b/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/project/RunJSFProjectTest.java
@@ -10,16 +10,20 @@ O * Copyright (c) 2016 Red Hat, Inc.
  ******************************************************************************/
 package org.jboss.tools.jsf.ui.test.project;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.common.exception.WaitTimeoutExpiredException;
+import org.eclipse.reddeer.common.matcher.RegexMatcher;
 import org.eclipse.reddeer.common.wait.TimePeriod;
 import org.eclipse.reddeer.common.wait.WaitUntil;
-import org.eclipse.reddeer.eclipse.core.resources.Project;
-import org.eclipse.reddeer.eclipse.ui.navigator.resources.ProjectExplorer;
+import org.eclipse.reddeer.common.wait.WaitWhile;
+import org.eclipse.reddeer.core.exception.CoreLayerException;
+import org.eclipse.reddeer.eclipse.ui.browser.BrowserEditor;
 import org.eclipse.reddeer.eclipse.wst.server.ui.cnf.Server;
 import org.eclipse.reddeer.eclipse.wst.server.ui.cnf.ServerModule;
 import org.eclipse.reddeer.eclipse.wst.server.ui.cnf.ServersView2;
@@ -32,7 +36,10 @@ import org.eclipse.reddeer.junit.internal.runner.ParameterizedRequirementsRunner
 import org.eclipse.reddeer.junit.requirement.inject.InjectRequirement;
 import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
+import org.eclipse.reddeer.requirements.closeeditors.CloseAllEditorsRequirement.CloseAllEditors;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.eclipse.reddeer.swt.impl.menu.ContextMenuItem;
+import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
 import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
@@ -50,10 +57,11 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 @DoNotUseVPE
 @UseParametersRunnerFactory(ParameterizedRequirementsRunnerFactory.class)
 @JBossServer(state = ServerRequirementState.RUNNING)
+@CloseAllEditors
 public class RunJSFProjectTest {
 
 	protected static final String PROJECT_NAME_BASE = "JSFTestProject";
-
+	
 	private String jsfEnvironment;
 	private String template;
 	private String projectName;
@@ -64,8 +72,13 @@ public class RunJSFProjectTest {
 	@Parameters(name = "{0} {1}")
 	public static Collection<String[]> data() {
 		return Arrays.asList(
-				new String[][] {{"JSF 1.2", "JSFKickStartWithoutLibs"}, {"JSF 2.2", "JSFKickStartWithoutLibs"},
-						{"JSF 1.2 with Facelets", "FaceletsKickStartWithoutLibs"}});
+				new String[][] {
+					{"JSF 1.2", "JSFKickStartWithoutLibs"},
+					{"JSF 1.2 with Facelets", "FaceletsKickStartWithoutLibs"},
+					{"JSF 2.0", "JSFBlankWithLibs"}, 
+					{"JSF 2.1", "JSFBlankWithoutLibs"}, 
+					{"JSF 2.2", "JSFKickStartWithoutLibs"}
+					});
 	}
 
 	@RequirementRestriction
@@ -87,23 +100,57 @@ public class RunJSFProjectTest {
 
 	@After
 	public void teardown() {
-		ProjectExplorer projectExplorer = new ProjectExplorer();
-		projectExplorer.open();
-		Project project = projectExplorer.getProject(projectName);
-		project.delete(true);
-		JSFTestUtils.checkErrorLog();
+		// workaround for https://github.com/eclipse/reddeer/issues/1843
+		deleteModule();
+		JSFTestUtils.deleteProject(projectName);
 	}
-
+	
+	
 	@Test
 	public void deployProjectTest() {
 		deployProject();
 
 		checkDeployedProject();
+		checkDeployedAppInWebBrowser();
+	}
+	
+	private void showInWebBrowser() {
+		Server server = getServer();
+		ServerModule module = server.getModule(projectName);
+		module.select();
+		new ContextMenuItem("Show In", "Web Browser").select();
+		new WaitUntil(new JobIsRunning(), TimePeriod.MEDIUM, false);
+		new WaitWhile(new JobIsRunning(), TimePeriod.MEDIUM, false);
+	}
+	
+	private void checkDeployedAppInWebBrowser() {
+		showInWebBrowser();
+		new WaitUntil(new JobIsRunning(), TimePeriod.MEDIUM, false);
+		String browserName = getBrowserEditorTitle(projectName);
+		if (browserName.isEmpty()) {
+			return;
+		}
+		BrowserEditor browser = new BrowserEditor(new RegexMatcher(browserName + ".*"));
+		assertTrue(browser.getPageURL().contains(projectName));
+		assertFalse(browser.getText().contains("Not Found"));
+	}
+	
+	private String getBrowserEditorTitle(String projectName) {
+		switch (projectName) {
+		case "JSFTestProjectJSF1.2": 
+			return "Input User Name";
+		case "JSFTestProjectJSF1.2withFacelets":
+		case "JSFTestProjectJSF2.2":
+			return "Input User Name";
+		default:
+			return "";
+		}
 	}
 
 	private void checkDeployedProject() {
 		Server server = getServer();
 		ServerModule module = server.getModule(projectName);
+
 		ModuleIsInState moduleIsInStateCondition = new ModuleIsInState(ServerState.STARTED,
 				ServerPublishState.SYNCHRONIZED, module);
 		try {
@@ -118,11 +165,23 @@ public class RunJSFProjectTest {
 		ModifyModulesDialog addAndRemoveModulesDialog = server.addAndRemoveModules();
 		ModifyModulesPage modifyModulesPage = new ModifyModulesPage(addAndRemoveModulesDialog);
 		modifyModulesPage.add(projectName);
-		addAndRemoveModulesDialog.finish();
+		// https://github.com/eclipse/reddeer/issues/1894
+		try {
+			addAndRemoveModulesDialog.finish();
+		} catch (CoreLayerException exc) {
+			// shell Server was closed already
+		}
+		new WaitUntil(new JobIsRunning(), TimePeriod.MEDIUM, false);
 	}
 
 	private Server getServer() {
 		ServersView2 serversView = new ServersView2();
+		serversView.open();
 		return serversView.getServer(serverReq.getServerName());
+	}
+	
+	private void deleteModule() {
+		Server server = getServer();
+		server.getModule(projectName).remove();
 	}
 }

--- a/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/requirement/DoNotUseVPERequirement.java
+++ b/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/requirement/DoNotUseVPERequirement.java
@@ -43,9 +43,10 @@ public class DoNotUseVPERequirement implements Requirement<DoNotUseVPE> {
 	}
 
 	private ExtendedFileEditorsPreferencePage openPreferencePage() {
-		ExtendedFileEditorsPreferencePage prefPage = new ExtendedFileEditorsPreferencePage(this.prefDialog);
 		prefDialog = new WorkbenchPreferenceDialog();
 		prefDialog.open();
+
+		ExtendedFileEditorsPreferencePage prefPage = new ExtendedFileEditorsPreferencePage(this.prefDialog);
 		prefDialog.select(prefPage);
 		return prefPage;
 	}

--- a/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/utils/JSFTestUtils.java
+++ b/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/utils/JSFTestUtils.java
@@ -15,6 +15,8 @@ import static org.junit.Assert.assertEquals;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.eclipse.reddeer.common.logging.Logger;
+import org.eclipse.reddeer.common.wait.WaitWhile;
 import org.eclipse.reddeer.core.lookup.WidgetLookup;
 import org.eclipse.reddeer.core.matcher.WithStyleMatcher;
 import org.eclipse.reddeer.eclipse.ui.problems.Problem;
@@ -24,6 +26,7 @@ import org.eclipse.reddeer.eclipse.ui.views.markers.ProblemsView;
 import org.eclipse.reddeer.eclipse.ui.views.markers.ProblemsView.ProblemType;
 import org.eclipse.reddeer.swt.impl.button.CheckBox;
 import org.eclipse.reddeer.swt.impl.shell.DefaultShell;
+import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.jboss.tools.jsf.reddeer.ui.JSFNewProjectFirstPage;
@@ -32,6 +35,8 @@ import org.jboss.tools.jsf.reddeer.ui.JSFNewProjectWizard;
 
 public class JSFTestUtils {
 
+	private static final Logger log = Logger.getLogger(JSFTestUtils.class);
+	
 	public static void checkProblemsView() {
 		// problems view should be empty
 		ProblemsView problemsView = new ProblemsView();
@@ -85,6 +90,25 @@ public class JSFTestUtils {
 
 		jsfNewProjectWizard.finish();
 	}
+	
+	/**
+	 * Removes project from Project Explorer
+	 * @param log class logger from which method was called
+	 */
+	public static void deleteProject(String project) {
+		log.info("Removing " + project);
+		// temporary workaround until upstream patch is applied (eclipse bug 478634)
+		try {
+			org.eclipse.reddeer.direct.project.Project.delete(project, true, true);
+		} catch (RuntimeException exc) {
+			log.error("RuntimeException occured during deleting project");
+			exc.printStackTrace();
+			log.info("Deleting project second time ...");
+			org.eclipse.reddeer.direct.project.Project.delete(project, true, true);
+		} 
+		new WaitWhile(new JobIsRunning());
+	}
+
 
 	private static String errorsToString(List<LogMessage> errorMessages) {
 		StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
   - Workaround for infinite building workspace loop
   - New way of downloading jboss-eap 7.0 server, via download-maven-plugin
   - Itests are green on jenkins rhel and win slaves

Signed-off-by: Ondrej Dockal <odockal@redhat.com>