### PR TITLE
JBIDE-25520

### DIFF
--- a/tests/org.jboss.tools.examples.ui.bot.test/README.md
+++ b/tests/org.jboss.tools.examples.ui.bot.test/README.md
@@ -3,27 +3,60 @@ Executing tests:
 mvn clean install -P{profile} -Dswtbot.test.skip=true -Dusage_reporting_enable=false -DdeployOnServer=true
 
 Where
-	${profile} select maven profile: WildFly10, EAP7, JavaEE7, SmokeTestsEAP7, SmokeTestsWildFly10, SmokeTestsJavaEE7 (WildFly10 profile is selected, if you don't specify profile)
+	${profile} select maven profile: WildFly11, EAP7, JavaEE7, SmokeTestsEAP7, SmokeTestsWildFly10, SmokeTestsJavaEE7 (WildFly10 profile is selected, if you don't specify profile)
 	
 You can specify other parameters as well(depending on profile you have selected):
 WildFly profile:
+-PWildFly11
 -DquickstartsURLWildFly=${quickstartsURLWildFly}		-	URL for WildFly Quickstarts
 -DexamplesFolderWildFly=${examplesFolderWildFly}		-	examples folder of WildFly Quickstarts
 
+G.e.
+
+```
+mvn clean verify -DexamplesFolderWildFly=wildfly-11.0.0.Final-quickstarts -DquickstartsURLWildFly=https://github.com/wildfly/quickstart/releases/download/11.0.0.Final/wildfly-11.0.0.Final-quickstarts.zip -PWildFly -DspecificQuickstarts=helloworld-jms
+```
+
 EAP profile:
+-PEAP7
 -DquickstartsURLEAP=${quickstartsURLEAP}				-	URL for EAP Quickstarts
 -DexamplesFolderEAP=${examplesFolderEAP}				-	examples folder of EAP Quickstarts
 -Djbosstools.test.jboss-eap-7.x.url=${EAP7_URL_OF_ZIP}	-	URL of zip file with EAP server
 
+G.e.
+
+```
+mvn clean verify -DquickstartsURLEAP=http://download.eng.brq.redhat.com/released/JBEAP-7/7.1.0/jboss-eap-7.1.0-quickstarts.zip -DexamplesFolderEAP=jboss-eap-7.1.0.GA-quickstarts -Djbosstools.test.jboss-eap-7.x.url=http://download.eng.brq.redhat.com/released/JBEAP-7/7.1.0/jboss-eap-7.1.0.zip -PEAP7 -DspecificQuickstarts=helloworld-jms
+```
+
 JavaEE profile:
+-PJavaEE7
 -DquickstartsURLJavaEE=${quickstartsURLJavaEE}			-	URL for JavaEE7 Quickstarts
 -DexamplesFolderJavaEE=${examplesFolderJavaEE}			-	examples folder of JavaEE7 Quickstarts
 
+G.e.
+
+```
+mvn clean verify -PJavaEE7 -DquickstartsURLJavaEE=https://github.com/javaee-samples/javaee7-samples/archive/master.zip -DexamplesFolderJavaEE=javaee7-samples-master
+```
+
 All:
+
 -DdeployOnServer=true									-	if false, only import is performed, if true, project is imported (Default value true)
 
+Some Launch configuration can be found in dir [./launchers](./launchers)
 
-  
+Notes: 
+- if you execute tests from devstudio make sure you have executed ```mvn install -P<profile> ...``` first because mvn is responsible for downloading WildFly/EAP7 servers and quickstarts from given URLs (look into pom.xml for more)
+- if you use -Dmaven.settings.path=~/.m2/settings.xml for local testing make sure to make backup so in case that test run is killed changes (satisfied by @DefineMavenRepository annotation requirement) in settings.xml can be reverted
+- if there is a missing property look for it and its default value in pom.xml or parents projects
+- for local testing it might be convenient to use  -Dreddeer.close.welcome.screen=true 
+- you can run test for single or several quickstarts by using -DspecificQuickstarts=temperature-converter,xml-dom4j,helloworld-ws,websocket-hello,helloworld
+- you can also use -DexamplesLocation=<pathToQuickstartsDir> that overrides -DexamplesFolder<JavaEE|EAP|WildFly> you may use something like -DexamplesLocation=./target/<quickstartsDir>
+- you can also force maven to download devstudio using -Pdownload-devstudio
+- in files resources/servers/*-blacklist-test-errors-regexes.json there are for specific quickstarts regular expressions describing errors that are known and documented and can be ignore/skipped in tests ( [JBDS-4638](https://issues.jboss.org/browse/JBDS-4638), [JBDS-4636](https://issues.jboss.org/browse/JBDS-4636) )
+- in files resources/servers/*-blacklist there are blacklisted quickstarts such as templates and deprecated ones ( [JBDS-4637](https://issues.jboss.org/browse/JBDS-4637) )
+
   
 Errors and Warnings will be written to standard output after executing tests.
 Also All errors will be written to files inside target/reports/<exampleName>.txt

--- a/tests/org.jboss.tools.examples.ui.bot.test/launchers/Examples - EAP7 - helloworld-jms.launch
+++ b/tests/org.jboss.tools.examples.ui.bot.test/launchers/Examples - EAP7 - helloworld-jms.launch
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.reddeer.eclipse.ui.launcher.JunitLaunchConfig">
+<booleanAttribute key="append.args" value="true"/>
+<booleanAttribute key="askclear" value="false"/>
+<booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticValidate" value="true"/>
+<stringAttribute key="bootstrap" value=""/>
+<stringAttribute key="checked" value="[NONE]"/>
+<booleanAttribute key="clearConfig" value="true"/>
+<booleanAttribute key="clearws" value="true"/>
+<booleanAttribute key="clearwslog" value="false"/>
+<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+<booleanAttribute key="default" value="true"/>
+<booleanAttribute key="includeOptional" value="true"/>
+<stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/EAPImportQuickstartsTest.java"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="false"/>
+<mapAttribute key="org.eclipse.debug.core.environmentVariables">
+<mapEntry key="DISPLAY" value=":5"/>
+<mapEntry key="WAYLAND_DISPLAY" value=":5"/>
+</mapAttribute>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.jboss.tools.examples.ui.bot.test.integration.EAPImportQuickstartsTest"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.jboss.tools.examples.ui.bot.test"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea -Dusage_reporting_enabled=false -Drd.config=./target/classes/servers/wildfly-11.json -DquickstartsURLEAP=http://download.eng.brq.redhat.com/released/JBEAP-7/7.1.0/jboss-eap-7.1.0-quickstarts.zip -DexamplesLocation=./target/jboss-eap-7.1.0.GA-quickstarts -Djbosstools.test.jboss-eap-7.x.url=http://download.eng.brq.redhat.com/released/JBEAP-7/7.1.0/jboss-eap-7.1.0.zip -DspecificQuickstarts=helloworld-jms"/>
+<stringAttribute key="pde.version" value="3.3"/>
+<stringAttribute key="product" value="com.jboss.devstudio.core.product"/>
+<stringAttribute key="rd.launch.property.rd.captureScreenshot" value="true"/>
+<stringAttribute key="rd.launch.property.rd.closeShells" value="true"/>
+<stringAttribute key="rd.launch.property.rd.closeWelcomeScreen" value="true"/>
+<stringAttribute key="rd.launch.property.rd.defaultKey" value="org.eclipse.reddeer.widget.key"/>
+<stringAttribute key="rd.launch.property.rd.disableMavenIndex" value="true"/>
+<stringAttribute key="rd.launch.property.rd.logCollectorEnabled" value="true"/>
+<stringAttribute key="rd.launch.property.rd.logLevel" value="ALL"/>
+<stringAttribute key="rd.launch.property.rd.logMessageFilter" value="ALL"/>
+<stringAttribute key="rd.launch.property.rd.maximizeWorkbench" value="true"/>
+<stringAttribute key="rd.launch.property.rd.openAssociatedPerspective" value="never"/>
+<stringAttribute key="rd.launch.property.rd.pauseFailedTest" value="false"/>
+<stringAttribute key="rd.launch.property.rd.timePeriodFactor" value="1.0"/>
+<booleanAttribute key="show_selected_only" value="false"/>
+<booleanAttribute key="tracing" value="false"/>
+<booleanAttribute key="useCustomFeatures" value="false"/>
+<booleanAttribute key="useDefaultConfig" value="true"/>
+<booleanAttribute key="useDefaultConfigArea" value="false"/>
+<booleanAttribute key="useProduct" value="true"/>
+</launchConfiguration>

--- a/tests/org.jboss.tools.examples.ui.bot.test/launchers/Examples - EAP7.launch
+++ b/tests/org.jboss.tools.examples.ui.bot.test/launchers/Examples - EAP7.launch
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.reddeer.eclipse.ui.launcher.JunitLaunchConfig">
+<booleanAttribute key="append.args" value="true"/>
+<booleanAttribute key="askclear" value="false"/>
+<booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticValidate" value="true"/>
+<stringAttribute key="bootstrap" value=""/>
+<stringAttribute key="checked" value="[NONE]"/>
+<booleanAttribute key="clearConfig" value="true"/>
+<booleanAttribute key="clearws" value="true"/>
+<booleanAttribute key="clearwslog" value="false"/>
+<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+<booleanAttribute key="default" value="true"/>
+<booleanAttribute key="includeOptional" value="true"/>
+<stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/EAPImportQuickstartsTest.java"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="false"/>
+<mapAttribute key="org.eclipse.debug.core.environmentVariables">
+<mapEntry key="DISPLAY" value=":5"/>
+<mapEntry key="WAYLAND_DISPLAY" value=":5"/>
+</mapAttribute>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.jboss.tools.examples.ui.bot.test.integration.EAPImportQuickstartsTest"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.jboss.tools.examples.ui.bot.test"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea -Dusage_reporting_enabled=false -Drd.config=./target/classes/servers/wildfly-11.json -DquickstartsURLEAP=http://download.eng.brq.redhat.com/released/JBEAP-7/7.1.0/jboss-eap-7.1.0-quickstarts.zip -DexamplesLocation=./target/jboss-eap-7.1.0.GA-quickstarts -Djbosstools.test.jboss-eap-7.x.url=http://download.eng.brq.redhat.com/released/JBEAP-7/7.1.0/jboss-eap-7.1.0.zip"/>
+<stringAttribute key="pde.version" value="3.3"/>
+<stringAttribute key="product" value="com.jboss.devstudio.core.product"/>
+<stringAttribute key="rd.launch.property.rd.captureScreenshot" value="true"/>
+<stringAttribute key="rd.launch.property.rd.closeShells" value="true"/>
+<stringAttribute key="rd.launch.property.rd.closeWelcomeScreen" value="true"/>
+<stringAttribute key="rd.launch.property.rd.defaultKey" value="org.eclipse.reddeer.widget.key"/>
+<stringAttribute key="rd.launch.property.rd.disableMavenIndex" value="true"/>
+<stringAttribute key="rd.launch.property.rd.logCollectorEnabled" value="true"/>
+<stringAttribute key="rd.launch.property.rd.logLevel" value="ALL"/>
+<stringAttribute key="rd.launch.property.rd.logMessageFilter" value="ALL"/>
+<stringAttribute key="rd.launch.property.rd.maximizeWorkbench" value="true"/>
+<stringAttribute key="rd.launch.property.rd.openAssociatedPerspective" value="never"/>
+<stringAttribute key="rd.launch.property.rd.pauseFailedTest" value="false"/>
+<stringAttribute key="rd.launch.property.rd.timePeriodFactor" value="1.0"/>
+<booleanAttribute key="show_selected_only" value="false"/>
+<booleanAttribute key="tracing" value="false"/>
+<booleanAttribute key="useCustomFeatures" value="false"/>
+<booleanAttribute key="useDefaultConfig" value="true"/>
+<booleanAttribute key="useDefaultConfigArea" value="false"/>
+<booleanAttribute key="useProduct" value="true"/>
+</launchConfiguration>

--- a/tests/org.jboss.tools.examples.ui.bot.test/launchers/Examples - JavaEE7.launch
+++ b/tests/org.jboss.tools.examples.ui.bot.test/launchers/Examples - JavaEE7.launch
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.reddeer.eclipse.ui.launcher.JunitLaunchConfig">
+<booleanAttribute key="append.args" value="true"/>
+<booleanAttribute key="askclear" value="false"/>
+<booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticValidate" value="true"/>
+<stringAttribute key="bootstrap" value=""/>
+<stringAttribute key="checked" value="[NONE]"/>
+<booleanAttribute key="clearConfig" value="true"/>
+<booleanAttribute key="clearws" value="true"/>
+<booleanAttribute key="clearwslog" value="false"/>
+<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+<booleanAttribute key="default" value="true"/>
+<booleanAttribute key="includeOptional" value="true"/>
+<stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/WildFlyImportQuickstartsTest.java"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="false"/>
+<mapAttribute key="org.eclipse.debug.core.environmentVariables">
+<mapEntry key="DISPLAY" value=":5"/>
+<mapEntry key="WAYLAND_DISPLAY" value=":5"/>
+</mapAttribute>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.jboss.tools.examples.ui.bot.test.integration.WildFlyImportQuickstartsTest"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.jboss.tools.examples.ui.bot.test"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea -Dusage_reporting_enabled=false -DdeployOnServer=false -DquickstartsURLJavaEE=https://github.com/javaee-samples/javaee7-samples/archive/master.zip -DexamplesLocation=javaee7-samples-master -Drd.config=./target/classes/servers/wildfly-11.json"/>
+<stringAttribute key="pde.version" value="3.3"/>
+<stringAttribute key="product" value="com.jboss.devstudio.core.product"/>
+<stringAttribute key="rd.launch.property.rd.captureScreenshot" value="true"/>
+<stringAttribute key="rd.launch.property.rd.closeShells" value="true"/>
+<stringAttribute key="rd.launch.property.rd.closeWelcomeScreen" value="true"/>
+<stringAttribute key="rd.launch.property.rd.defaultKey" value="org.eclipse.reddeer.widget.key"/>
+<stringAttribute key="rd.launch.property.rd.disableMavenIndex" value="true"/>
+<stringAttribute key="rd.launch.property.rd.logCollectorEnabled" value="true"/>
+<stringAttribute key="rd.launch.property.rd.logLevel" value="ALL"/>
+<stringAttribute key="rd.launch.property.rd.logMessageFilter" value="ALL"/>
+<stringAttribute key="rd.launch.property.rd.maximizeWorkbench" value="true"/>
+<stringAttribute key="rd.launch.property.rd.openAssociatedPerspective" value="never"/>
+<stringAttribute key="rd.launch.property.rd.pauseFailedTest" value="false"/>
+<stringAttribute key="rd.launch.property.rd.timePeriodFactor" value="1.0"/>
+<booleanAttribute key="show_selected_only" value="false"/>
+<booleanAttribute key="tracing" value="false"/>
+<booleanAttribute key="useCustomFeatures" value="false"/>
+<booleanAttribute key="useDefaultConfig" value="true"/>
+<booleanAttribute key="useDefaultConfigArea" value="false"/>
+<booleanAttribute key="useProduct" value="true"/>
+</launchConfiguration>

--- a/tests/org.jboss.tools.examples.ui.bot.test/launchers/Examples - WildFly11  - helloworld-jms.launch
+++ b/tests/org.jboss.tools.examples.ui.bot.test/launchers/Examples - WildFly11  - helloworld-jms.launch
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.reddeer.eclipse.ui.launcher.JunitLaunchConfig">
+<booleanAttribute key="append.args" value="true"/>
+<booleanAttribute key="askclear" value="false"/>
+<booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticValidate" value="true"/>
+<stringAttribute key="bootstrap" value=""/>
+<stringAttribute key="checked" value="[NONE]"/>
+<booleanAttribute key="clearConfig" value="true"/>
+<booleanAttribute key="clearws" value="true"/>
+<booleanAttribute key="clearwslog" value="false"/>
+<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+<booleanAttribute key="default" value="true"/>
+<booleanAttribute key="includeOptional" value="true"/>
+<stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/WildFlyImportQuickstartsTest.java"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="false"/>
+<mapAttribute key="org.eclipse.debug.core.environmentVariables">
+<mapEntry key="DISPLAY" value=":5"/>
+<mapEntry key="WAYLAND_DISPLAY" value=":5"/>
+</mapAttribute>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.jboss.tools.examples.ui.bot.test.integration.WildFlyImportQuickstartsTest"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.jboss.tools.examples.ui.bot.test"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea -Dusage_reporting_enabled=false -Drd.config=./target/classes/servers/wildfly-11.json -DdeployOnServer=false -DexamplesLocation=target/wildfly-11.0.0.Final-quickstarts -DquickstartsURLWildFly=https://github.com/wildfly/quickstart/releases/download/11.0.0.Final/wildfly-11.0.0.Final-quickstarts.zip -DspecificQuickstarts=helloworld-jms"/>
+<stringAttribute key="pde.version" value="3.3"/>
+<stringAttribute key="product" value="com.jboss.devstudio.core.product"/>
+<stringAttribute key="rd.launch.property.rd.captureScreenshot" value="true"/>
+<stringAttribute key="rd.launch.property.rd.closeShells" value="true"/>
+<stringAttribute key="rd.launch.property.rd.closeWelcomeScreen" value="true"/>
+<stringAttribute key="rd.launch.property.rd.defaultKey" value="org.eclipse.reddeer.widget.key"/>
+<stringAttribute key="rd.launch.property.rd.disableMavenIndex" value="true"/>
+<stringAttribute key="rd.launch.property.rd.logCollectorEnabled" value="true"/>
+<stringAttribute key="rd.launch.property.rd.logLevel" value="ALL"/>
+<stringAttribute key="rd.launch.property.rd.logMessageFilter" value="ALL"/>
+<stringAttribute key="rd.launch.property.rd.maximizeWorkbench" value="true"/>
+<stringAttribute key="rd.launch.property.rd.openAssociatedPerspective" value="never"/>
+<stringAttribute key="rd.launch.property.rd.pauseFailedTest" value="false"/>
+<stringAttribute key="rd.launch.property.rd.timePeriodFactor" value="1.0"/>
+<booleanAttribute key="show_selected_only" value="false"/>
+<booleanAttribute key="tracing" value="false"/>
+<booleanAttribute key="useCustomFeatures" value="false"/>
+<booleanAttribute key="useDefaultConfig" value="true"/>
+<booleanAttribute key="useDefaultConfigArea" value="false"/>
+<booleanAttribute key="useProduct" value="true"/>
+</launchConfiguration>

--- a/tests/org.jboss.tools.examples.ui.bot.test/launchers/Examples - WildFly11.launch
+++ b/tests/org.jboss.tools.examples.ui.bot.test/launchers/Examples - WildFly11.launch
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.reddeer.eclipse.ui.launcher.JunitLaunchConfig">
+<booleanAttribute key="append.args" value="true"/>
+<booleanAttribute key="askclear" value="false"/>
+<booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticValidate" value="true"/>
+<stringAttribute key="bootstrap" value=""/>
+<stringAttribute key="checked" value="[NONE]"/>
+<booleanAttribute key="clearConfig" value="true"/>
+<booleanAttribute key="clearws" value="true"/>
+<booleanAttribute key="clearwslog" value="false"/>
+<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+<booleanAttribute key="default" value="true"/>
+<booleanAttribute key="includeOptional" value="true"/>
+<stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/WildFlyImportQuickstartsTest.java"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="false"/>
+<mapAttribute key="org.eclipse.debug.core.environmentVariables">
+<mapEntry key="DISPLAY" value=":5"/>
+<mapEntry key="WAYLAND_DISPLAY" value=":5"/>
+</mapAttribute>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.jboss.tools.examples.ui.bot.test.integration.WildFlyImportQuickstartsTest"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.jboss.tools.examples.ui.bot.test"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea -Dusage_reporting_enabled=false -Drd.config=./target/classes/servers/wildfly-11.json -DdeployOnServer=false -DexamplesLocation=wildfly-11.0.0.Final-quickstarts -DquickstartsURLWildFly=https://github.com/wildfly/quickstart/releases/download/11.0.0.Final/wildfly-11.0.0.Final-quickstarts.zip"/>
+<stringAttribute key="pde.version" value="3.3"/>
+<stringAttribute key="product" value="com.jboss.devstudio.core.product"/>
+<stringAttribute key="rd.launch.property.rd.captureScreenshot" value="true"/>
+<stringAttribute key="rd.launch.property.rd.closeShells" value="true"/>
+<stringAttribute key="rd.launch.property.rd.closeWelcomeScreen" value="true"/>
+<stringAttribute key="rd.launch.property.rd.defaultKey" value="org.eclipse.reddeer.widget.key"/>
+<stringAttribute key="rd.launch.property.rd.disableMavenIndex" value="true"/>
+<stringAttribute key="rd.launch.property.rd.logCollectorEnabled" value="true"/>
+<stringAttribute key="rd.launch.property.rd.logLevel" value="ALL"/>
+<stringAttribute key="rd.launch.property.rd.logMessageFilter" value="ALL"/>
+<stringAttribute key="rd.launch.property.rd.maximizeWorkbench" value="true"/>
+<stringAttribute key="rd.launch.property.rd.openAssociatedPerspective" value="never"/>
+<stringAttribute key="rd.launch.property.rd.pauseFailedTest" value="false"/>
+<stringAttribute key="rd.launch.property.rd.timePeriodFactor" value="1.0"/>
+<booleanAttribute key="show_selected_only" value="false"/>
+<booleanAttribute key="tracing" value="false"/>
+<booleanAttribute key="useCustomFeatures" value="false"/>
+<booleanAttribute key="useDefaultConfig" value="true"/>
+<booleanAttribute key="useDefaultConfigArea" value="false"/>
+<booleanAttribute key="useProduct" value="true"/>
+</launchConfiguration>

--- a/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
@@ -17,17 +17,17 @@
 		<!-- -DimportTestDefinition=${importTestDefinition}</systemProperties> -->
 		<systemProperties>${integrationTestsSystemProperties} -DexamplesLocation=${project.build.directory}/${examplesFolder} -Dmaven.settings.path=${maven.settings.path} -Drd.config=${reddeer.config} -DspecificQuickstarts=${specificQuickstarts} -DdeployOnServer=${deployOnServer}</systemProperties>
 		<quickstartsURLWildFly>https://github.com/wildfly/quickstart/archive/11.0.0.Final.zip</quickstartsURLWildFly>
-		<quickstartsURLEAP>http://download.eng.brq.redhat.com/released/JBEAP-7/7.0.0/jboss-eap-7.0.0-quickstarts.zip</quickstartsURLEAP>
+		<quickstartsURLEAP>http://download.eng.brq.redhat.com/released/JBEAP-7/7.1.0/jboss-eap-7.1.0-quickstarts.zip</quickstartsURLEAP>
 		<quickstartsURLJavaEE>https://github.com/javaee-samples/javaee7-samples/archive/master.zip</quickstartsURLJavaEE>
 		<maven.settings.path>${project.build.directory}/classes/settings.xml</maven.settings.path>
 		<reddeer.config.wildfly11>${project.build.directory}/classes/servers/wildfly-11.json</reddeer.config.wildfly11>
 		<reddeer.config.eap7>${project.build.directory}/classes/servers/eap-7.json</reddeer.config.eap7>
 		<examplesFolderWildFly>quickstart-11.0.0.Final</examplesFolderWildFly>
-		<examplesFolderEAP>jboss-eap-7.0.0.GA-quickstarts</examplesFolderEAP>
+		<examplesFolderEAP>jboss-eap-7.1.0.GA-quickstarts</examplesFolderEAP>
 		<examplesFolderJavaEE>javaee7-samples-master</examplesFolderJavaEE>
 		<jbosstools.test.wildfly11.home>${requirementsDirectory}/wildfly-11.0.0.Final</jbosstools.test.wildfly11.home>
-		<jbosstools.test.eap7.home>${requirementsDirectory}/jboss-eap-7.0</jbosstools.test.eap7.home>
-		<jbosstools.test.jboss-eap-7.x.url>http://download.eng.brq.redhat.com/released/JBEAP-7/7.0.0/jboss-eap-7.0.0.zip</jbosstools.test.jboss-eap-7.x.url>
+		<jbosstools.test.eap7.home>${requirementsDirectory}/jboss-eap-7.1</jbosstools.test.eap7.home>
+		<jbosstools.test.jboss-eap-7.x.url>http://download.eng.brq.redhat.com/released/JBEAP-7/7.1.0/jboss-eap-7.1.0.zip</jbosstools.test.jboss-eap-7.x.url>
 		<surefire.timeout>18000</surefire.timeout>
 		<skipTests>false</skipTests>
 		<deployOnServer>false</deployOnServer>
@@ -81,6 +81,28 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<configuration>
+					<dependency-resolution>
+						<extraRequirements>
+							<requirement>
+								<type>p2-installable-unit</type>
+								<id>net.sf.eclipsecs.feature.group</id>
+								<versionRange>8.0.0</versionRange>
+							</requirement>
+							<requirement>
+								<type>p2-installable-unit</type>
+								<id>com.basistech.m2e.code.quality.checkstyle.feature.feature.group</id>
+								<versionRange>1.0.0</versionRange>
+							</requirement>
+						</extraRequirements>
+					</dependency-resolution>
+				</configuration>
+			</plugin>
+		</plugins>
 	</build>
 
 	<profiles>
@@ -97,26 +119,6 @@
 			</properties>
 			<build>
 				<plugins>
-					<plugin>
-						<groupId>org.eclipse.tycho</groupId>
-						<artifactId>target-platform-configuration</artifactId>
-						<configuration>
-							<dependency-resolution>
-								<extraRequirements>
-									<requirement>
-										<type>p2-installable-unit</type>
-										<id>net.sf.eclipsecs.feature.group</id>
-										<versionRange>8.0.0</versionRange>
-									</requirement>
-									<requirement>
-										<type>p2-installable-unit</type>
-										<id>com.basistech.m2e.code.quality.checkstyle.feature.feature.group</id>
-										<versionRange>1.0.0</versionRange>
-									</requirement>
-								</extraRequirements>
-							</dependency-resolution>
-						</configuration>
-					</plugin>
 					<plugin>
 						<groupId>com.googlecode.maven-download-plugin</groupId>
 						<artifactId>download-maven-plugin</artifactId>
@@ -196,13 +198,13 @@
 								</configuration>
 							</execution>
 							<execution>
-								<id>install-eap-7.0</id>
+								<id>install-eap-7.x</id>
 								<phase>pre-integration-test</phase>
 								<goals>
 									<goal>wget</goal>
 								</goals>
 								<configuration>
-									<url>${jbosstools.test.jboss-eap-7.0.url}</url>
+									<url>${jbosstools.test.jboss-eap-7.x.url}</url>
 									<unpack>true</unpack>
 								</configuration>
 							</execution>

--- a/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/eap-7.json
+++ b/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/eap-7.json
@@ -2,7 +2,7 @@
 	"org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer": [
 		{
 			"runtime": "${jbosstools.test.eap7.home}",
-			"version": "7.0",
+			"version": "7.1",
 			"family": "EAP"
 		}
 	]

--- a/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/eap-blacklist-test-errors-regexes.json
+++ b/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/eap-blacklist-test-errors-regexes.json
@@ -1,0 +1,35 @@
+{
+	"jts": [
+		".*Invalid content was found starting with element.*iiop:.*-name.*",
+		".*Referenced file contains errors.*jboss-ejb3-spec-2_0\\.xsd.*"
+	],
+	"ejb-security-interceptors": [
+		".*Invalid content was found starting with element.*jee:interceptor-binding.*",
+		".*Referenced file contains errors.*jboss-ejb3-spec-2_0\\.xsd.*"
+	],
+	"messaging-clustering-singleton": [
+		".*Referenced file contains errors.*jboss-ejb-delivery-active_1_1\\.xsd.*",
+		".*Referenced file contains errors.*jboss-ejb3-2_0\\.xsd.*",
+		".*Referenced file contains errors.*jboss-ejb3-spec-2_0\\.xsd.*"
+	],
+	"jaxws-retail": [
+		".*Customer cannot be resolved to a type.*",
+		".*DiscountRequest cannot be resolved to a type.*",
+		".*DiscountResponse cannot be resolved to a type.*",
+		".*ProfileMgmt cannot be resolved to a type.*",
+		".*The import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.Customer cannot be resolved.*",
+		".*The import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.DiscountRequest cannot be resolved.*",
+		".*The import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.DiscountResponse cannot be resolved.*",
+		".*The import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.ProfileMgmt cannot be resolved.*",
+		".*Type mismatch: cannot convert from ProfileMgmt to ProfileMgmt.*"
+	],
+	"spring-petclinic": [
+		".*\\).*expected.*",
+		".*}.*expected.*",
+		".*primary expression expected.*",
+		".*Semi-colon expected.*"
+	],
+	"*": [
+		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
+	]
+}

--- a/tests/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/AbstractImportQuickstartsTest.java
+++ b/tests/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/AbstractImportQuickstartsTest.java
@@ -230,7 +230,7 @@ public abstract class AbstractImportQuickstartsTest {
 				}
 			}
 		} catch (NullPointerException ex) {
-			fail("Please check path to quickstarts. Folder does not exist!");
+			fail("Please check path to quickstarts. Folder does not exist! " + file.getAbsolutePath());
 		}
 		return resultList;
 	}
@@ -275,12 +275,28 @@ public abstract class AbstractImportQuickstartsTest {
 				// there was no project in this directory. Pass the test.
 				return;
 			}
+			log.info("Check for warnings and errors");
 			checkForWarnings(qstart);
-			if (blacklistErrorsFileContents == null || (!blacklistErrorsFileContents.containsKey(qstart.getName()))) {
+			if (blacklistErrorsFileContents == null || (!blacklistErrorsFileContents.containsKey(qstart.getName())
+					&& !blacklistErrorsFileContents.containsKey("*"))) {
+				
 				checkForErrors(qstart);
 				checkErrorLog(qstart);
 			} else {
-				JSONArray errorsToIgnore = (JSONArray) blacklistErrorsFileContents.get(qstart.getName());
+				log.info("Lets ignore known errors:");
+
+				JSONArray errorsToIgnore = new JSONArray();
+				if (blacklistErrorsFileContents.containsKey(qstart.getName())) {
+					errorsToIgnore = (JSONArray) blacklistErrorsFileContents.get(qstart.getName());
+				}
+				if (blacklistErrorsFileContents.containsKey("*")) {
+					JSONArray errorsToIgnoreForAll = (JSONArray) blacklistErrorsFileContents.get("*");
+					for (Object o : errorsToIgnoreForAll) {
+						errorsToIgnore.add(o);
+					}
+				}
+				log.info(errorsToIgnore.toJSONString());
+
 				List<String> errorsToIgnoreList = (List<String>) (List<?>) Arrays.asList(errorsToIgnore.toArray());
 				checkForErrors(qstart, errorsToIgnoreList);
 				checkErrorLog(qstart, errorsToIgnoreList);

--- a/tests/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/EAPImportQuickstartsTest.java
+++ b/tests/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/EAPImportQuickstartsTest.java
@@ -39,6 +39,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 public class EAPImportQuickstartsTest extends AbstractImportQuickstartsTest {
 	public static final String SERVER_NAME ="Enterprise Application Platform";
 	public static final String BLACKLIST_FILE = "resources/servers/eap-blacklist";
+	public static final String BLACKLIST_ERRORS_REGEXES_FILE = "resources/servers/eap-blacklist-test-errors-regexes.json";
 
 	@Parameters(name = "{0}")
 	public static Collection<Quickstart> data() {
@@ -54,7 +55,7 @@ public class EAPImportQuickstartsTest extends AbstractImportQuickstartsTest {
 	 */
 	@Test
 	public void quickstartTest() {
-		runQuickstarts(qstart, SERVER_NAME, BLACKLIST_FILE);
+		runQuickstarts(qstart, SERVER_NAME, BLACKLIST_FILE, BLACKLIST_ERRORS_REGEXES_FILE);
 	}
 
 


### PR DESCRIPTION
- Updated to eap71
- Moved checkstyle plugin req to global build
- Ignore more documented errors
- Updated readme

Documented errors:
Checkstyle execution... - is automatically resolved, but sometimes it hangs.
spring-petclinic - relates to JS support and split JS files
jaxws-retail - missing files needs to be generated from wsdl first. 
Referenced file contains errors.. & nvalid content was found - relates to duplicate entries for xml definition files, [bz & duplicates](https://bugzilla.redhat.com/show_bug.cgi?id=1193543)
 
Related job [run](https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/examples.eap.it.weekly/158/)

Signed-off-by: vprusa <vprusa@redhat.com>