### PR TITLE
Removed jaxws-repo repository

### DIFF
--- a/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
@@ -301,7 +301,8 @@
 					</plugin>
 				</plugins>
 			</build>
-			<repositories>
+			<!-- because JBIDE-25742 -->
+			<!-- <repositories>
 				<repository>
 					<id>jaxws-repo</id>
 					<name>jaxws-repo</name>
@@ -309,6 +310,7 @@
 					<url>http://coderplus.com/m2e-update-sites/jaxws-maven-plugin/</url>
 				</repository>
 			</repositories>
+			-->
 		</profile>
 		<profile>
 			<id>SmokeTestsWildFly11</id>


### PR DESCRIPTION
Because of [https://issues.jboss.org/browse/JBIDE-25742](https://issues.jboss.org/browse/JBIDE-25742)