### PR TITLE
JBIDE-26291

### DIFF
--- a/tests/org.jboss.tools.examples.ui.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.examples.ui.bot.test/META-INF/MANIFEST.MF
@@ -6,10 +6,10 @@ Bundle-Version: 4.4.200.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.eclipse.reddeer.go;bundle-version="2.1.0",
+Require-Bundle: org.eclipse.reddeer.go,
  org.junit;bundle-version="4.8.2",
  org.jboss.tools.maven.reddeer,
- org.jboss.tools.central.reddeer,
+ org.jboss.tools.central.reddeer;bundle-version="[2.1.100,2.2.0)",
  org.jboss.ide.eclipse.as.reddeer
 Import-Package: org.json.simple,
  org.json.simple.parser

--- a/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
@@ -301,16 +301,14 @@
 					</plugin>
 				</plugins>
 			</build>
-			<!-- because JBIDE-25742 -->
-			<!-- <repositories>
+			<repositories>
 				<repository>
 					<id>jaxws-repo</id>
 					<name>jaxws-repo</name>
 					<layout>p2</layout>
-					<url>http://coderplus.com/m2e-update-sites/jaxws-maven-plugin/</url>
+					<url>https://coderplus.github.io/m2e-connector-for-jaxws-maven-plugin/</url>
 				</repository>
 			</repositories>
-			-->
 		</profile>
 		<profile>
 			<id>SmokeTestsWildFly11</id>

--- a/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/eap-7.json
+++ b/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/eap-7.json
@@ -2,7 +2,7 @@
 	"org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer": [
 		{
 			"runtime": "${jbosstools.test.eap7.home}",
-			"version": "7.1",
+			"version": "7.x",
 			"family": "EAP"
 		}
 	]

--- a/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/wildfly-blacklist-test-errors-regexes.json
+++ b/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/wildfly-blacklist-test-errors-regexes.json
@@ -22,5 +22,10 @@
 		".*The import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.DiscountResponse cannot be resolved.*",
 		".*The import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.ProfileMgmt cannot be resolved.*",
 		".*Type mismatch: cannot convert from ProfileMgmt to ProfileMgmt.*"
+	],
+	"jsf":[
+		".*Element 'value' must have no element.*",
+		".*Value 'param1 flow1 value' is not facet-valid with respect to pattern.*",
+		".*Invalid content was found starting with elemen 'flow-call'.*"
 	]
 }


### PR DESCRIPTION
Fixed some errors with Maven update call,
added as repository https://coderplus.github.io/m2e-connector-for-jaxws-maven-plugin/ because the old one had broken one of the underlying xml files,
updated versions - bundles, eap-7.x,
ignore known warning.

In progress, will add test run soon.