### PR TITLE
JBDS-4730: Use "Red Hat CodeReady Studio" instead of "Red Hat Develop…

### DIFF
--- a/tests/org.jboss.tools.central.ui.bot.test/src/org/jboss/tools/central/test/ui/reddeer/InstallationDetailsTest.java
+++ b/tests/org.jboss.tools.central.ui.bot.test/src/org/jboss/tools/central/test/ui/reddeer/InstallationDetailsTest.java
@@ -55,9 +55,9 @@ public class InstallationDetailsTest {
 
 	private static String HELP_BUTTON = "Help";
 
-	private static String ABOUT_MENU_BUTTON = ".*About Red Hat.*Developer Studio.*";
+	private static String ABOUT_MENU_BUTTON = ".*About Red Hat.*(Developer|CodeReady) Studio.*";
 	private static String MODAL_DIALOG_ABOUT_DEVSTUDIO_INSTALLATION_DETAILS_BUTTON = ".*Installation Details.*";
-	private static String MODAL_DIALOG_ABOUT_DEVSTUDIO_INSTALLATION_DETAILS_TITLE = ".*Red Hat.*Developer Studio Installation Details.*";
+	private static String MODAL_DIALOG_ABOUT_DEVSTUDIO_INSTALLATION_DETAILS_TITLE = ".*Red Hat.*(Developer|CodeReady) Studio Installation Details.*";
 	private static String MODAL_DIALOG_CONFIG_MENU_BUTTON = "Configuration";
 
 	private Logger log = new Logger(this.getClass());

--- a/tests/org.jboss.tools.maven.ui.bot.test/src/org/jboss/tools/maven/ui/bot/test/ui/SeamPluginsTest.java
+++ b/tests/org.jboss.tools.maven.ui.bot.test/src/org/jboss/tools/maven/ui/bot/test/ui/SeamPluginsTest.java
@@ -22,7 +22,7 @@ public class SeamPluginsTest extends AbstractMavenSWTBotTest{
 	
 	@Test
 	public void testSeamIsNotPresent(){
-		new ShellMenuItem("Help","About Red Hat Developer Studio").select();
+		new ShellMenuItem("Help","About Red Hat CodeReady Studio").select();
 		new PushButton("Installation Details").click();
 		new DefaultShell(new WithTextMatcher(new RegexMatcher(".*Installation Details")));
 		new DefaultTabItem("Plug-ins").activate();


### PR DESCRIPTION
…er Studio" in graphics & text

Signed-off-by: Jeff MAURY <jmaury@redhat.com>