### PR TITLE
Update runtime servers for deltaspike to wildfly-16

### DIFF
--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/template/NullValuesInjectionTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/template/NullValuesInjectionTemplate.java
@@ -46,11 +46,11 @@ public class NullValuesInjectionTemplate extends CDITestBase {
 		
 		te = new TextEditor("Bean2.java");
 		cond = new EditorHasValidationMarkers(te);
+		te.save();
 		
 		if (CDIVersion.equals("1.0")) {
 			new WaitUntil(cond, false);
 			assertTrue("Editor hasn't validation markers.", cond.test());
-			te.save();
 			new WaitWhile(new JobIsRunning());
 			new WaitUntil(new EditorHasValidationMarkers(te), false);
 			assertTrue("Editor hasn't validation markers.", cond.test());
@@ -58,7 +58,6 @@ public class NullValuesInjectionTemplate extends CDITestBase {
 			new WaitUntil(cond, false);
 			new WaitWhile(cond, false);
 			assertFalse("Editor has validation markers: " + cond.getResult(), cond.test());
-			te.save();
 			new WaitWhile(new JobIsRunning());
 			new WaitUntil(cond, false);
 			new WaitWhile(cond, false);

--- a/tests/org.jboss.tools.deltaspike.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.deltaspike.ui.bot.test/pom.xml
@@ -15,8 +15,8 @@
 		<jbosstools.test.jre.8>${NATIVE_TOOLS}${SEP}${OPENJDK18}</jbosstools.test.jre.8>
 		<systemProperties>${integrationTestsSystemProperties} -Drd.config=target/classes/servers/requirements.json -Djbosstools.test.jre.8=${jbosstools.test.jre.8}</systemProperties>
 		<suiteClass>org.jboss.tools.deltaspike.ui.bot.test.DeltaspikeAllBotTests</suiteClass>
-		<jbosstools.test.wildfly.10x.home>${requirementsDirectory}/wildfly-10.0.0.Final</jbosstools.test.wildfly.10x.home>
-		<deltaspike_lib_version>1.8.0</deltaspike_lib_version>
+		<jbosstools.test.wildfly.16.home>${requirementsDirectory}/wildfly-16.0.0.Final</jbosstools.test.wildfly.16.home>
+		<deltaspike_lib_version>1.8.2</deltaspike_lib_version>
 	</properties>
 	
 	
@@ -68,7 +68,7 @@
 								<artifactItem>
 									<groupId>org.wildfly</groupId>
 									<artifactId>wildfly-dist</artifactId>
-									<version>10.0.0.Final</version>
+									<version>16.0.0.Final</version>
 									<type>zip</type>
 								</artifactItem>
 							</artifactItems>

--- a/tests/org.jboss.tools.deltaspike.ui.bot.test/resources/prj/configureProblemSeverity/pom.xml
+++ b/tests/org.jboss.tools.deltaspike.ui.bot.test/resources/prj/configureProblemSeverity/pom.xml
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>javax.enterprise</groupId>
 			<artifactId>cdi-api</artifactId>
-			<version>1.2</version>
+			<version>2.0</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/tests/org.jboss.tools.deltaspike.ui.bot.test/resources/servers/requirements.json
+++ b/tests/org.jboss.tools.deltaspike.ui.bot.test/resources/servers/requirements.json
@@ -1,8 +1,8 @@
 {
 	"org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer": [
 		{
-			"runtime": "${jbosstools.test.wildfly.10x.home}",
-			"version": "10.x",
+			"runtime": "${jbosstools.test.wildfly.16.home}",
+			"version": "16",
 			"family": "WILDFLY",
 			"runtimeEnvironment": "JavaSE-1.8"
 		}

--- a/tests/org.jboss.tools.deltaspike.ui.bot.test/src/org/jboss/tools/deltaspike/ui/bot/test/DeltaspikeAllBotTests.java
+++ b/tests/org.jboss.tools.deltaspike.ui.bot.test/src/org/jboss/tools/deltaspike/ui/bot/test/DeltaspikeAllBotTests.java
@@ -1,13 +1,5 @@
 /*******************************************************************************
-
-
- * 
- * 
- * 
- * 
- * 
- * 
- * [45Copyright (c) 2010-2013 Red Hat, Inc.
+ * Copyright (c) 2010-2019 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,

--- a/tests/org.jboss.tools.deltaspike.ui.bot.test/src/org/jboss/tools/deltaspike/ui/bot/test/DeltaspikeTestBase.java
+++ b/tests/org.jboss.tools.deltaspike.ui.bot.test/src/org/jboss/tools/deltaspike/ui/bot/test/DeltaspikeTestBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2013 Red Hat, Inc.
+ * Copyright (c) 2010-2019 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,


### PR DESCRIPTION
   - udpate cdi used in deltaspike tests
   - fix cdi nullvalueInjection test

Signed-off-by: Ondrej Dockal <odockal@redhat.com>