### PR TITLE
JBIDE-24963 - Create CDI 2.0 integration tests - step 1

### DIFF
--- a/tests/org.jboss.tools.cdi.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.bot.test/pom.xml
@@ -15,7 +15,8 @@
 		<systemProperties>${integrationTestsSystemProperties} -Drd.config=target/classes/servers/requirements.json -Djbosstools.test.weld-se.home=${jbosstools.test.weld-se.home} -Djbosstools.test.weld-api.home=${jbosstools.test.weld-api.home} -Djbosstools.test.jre.8=${jbosstools.test.jre.8}</systemProperties>
 		<surefire.timeout>14400</surefire.timeout>
 		<jbosstools.test.jboss-as-7.1.home>${requirementsDirectory}/jboss-as-7.1.1.Final</jbosstools.test.jboss-as-7.1.home>
-		<jbosstools.test.wildfly.10.home>${requirementsDirectory}/wildfly-10.0.0.Final</jbosstools.test.wildfly.10.home>
+		<jbosstools.test.wildfly.13.home>${requirementsDirectory}/wildfly-13.0.0.Final</jbosstools.test.wildfly.13.home>
+		<jbosstools.test.wildfly.16.home>${requirementsDirectory}/wildfly-16.0.0.Final</jbosstools.test.wildfly.16.home>
 		<jbosstools.test.weld-se.home>${requirementsDirectory}/weld/se/</jbosstools.test.weld-se.home>
 		<jbosstools.test.weld-api.home>${requirementsDirectory}/weld/api/</jbosstools.test.weld-api.home>
 	</properties>
@@ -55,6 +56,12 @@
 			<id>cdi11-tests</id>
 			<properties>
 				<suiteClass>org.jboss.tools.cdi.bot.test.CDI11SuiteTest</suiteClass>
+			</properties>
+		</profile>
+		<profile>
+			<id>cdi20-tests</id>
+			<properties>
+				<suiteClass>org.jboss.tools.cdi.bot.test.CDI20SuiteTest</suiteClass>
 			</properties>
 		</profile>
 		<profile>
@@ -117,7 +124,25 @@
 								<artifactItem>
 									<groupId>org.wildfly</groupId>
 									<artifactId>wildfly-dist</artifactId>
-									<version>10.0.0.Final</version>
+									<version>13.0.0.Final</version>
+									<type>zip</type>
+								</artifactItem>
+							</artifactItems>
+						</configuration>
+					</execution>
+					<execution>
+						<id>wildfly16</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>unpack</goal>
+						</goals>
+						<configuration>
+							<skip>${skipTests}</skip>
+							<artifactItems>
+								<artifactItem>
+									<groupId>org.wildfly</groupId>
+									<artifactId>wildfly-dist</artifactId>
+									<version>16.0.0.Final</version>
 									<type>zip</type>
 								</artifactItem>
 							</artifactItems>

--- a/tests/org.jboss.tools.cdi.bot.test/resources/servers/requirements.json
+++ b/tests/org.jboss.tools.cdi.bot.test/resources/servers/requirements.json
@@ -1,8 +1,14 @@
 {
 	"org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer": [
 		{
-			"runtime": "${jbosstools.test.wildfly.10.home}",
-			"version": "10.x",
+			"runtime": "${jbosstools.test.wildfly.16.home}",
+			"version": "16",
+			"family": "WILDFLY",
+			"runtimeEnvironment": "JavaSE-1.8"
+		},
+		{
+			"runtime": "${jbosstools.test.wildfly.13.home}",
+			"version": "13",
 			"family": "WILDFLY",
 			"runtimeEnvironment": "JavaSE-1.8"
 		},

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDI20SuiteTest.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDI20SuiteTest.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.bot.test;
+
+import org.eclipse.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.tools.cdi.bot.test.beans.named.cdi20.NamedComponentsSearchingTestCDI20;
+import org.jboss.tools.cdi.bot.test.beans.openon.cdi20.BeanInjectOpenOnTestCDI20;
+import org.jboss.tools.cdi.bot.test.beans.openon.cdi20.FindObserverEventTestCDI20;
+import org.jboss.tools.cdi.bot.test.wizard.cdi20.CDIWebProjectWizardTestCDI20;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite.SuiteClasses;
+
+/** 
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
+@RunWith(RedDeerSuite.class)
+@SuiteClasses({
+	NamedComponentsSearchingTestCDI20.class,
+	BeanInjectOpenOnTestCDI20.class,
+	FindObserverEventTestCDI20.class,
+	CDIWebProjectWizardTestCDI20.class,
+})
+public class CDI20SuiteTest {
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDITestBase.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDITestBase.java
@@ -53,6 +53,8 @@ import org.junit.BeforeClass;
 
 public class CDITestBase {
 
+	protected String CDIVersion;
+	
 	protected static String PROJECT_NAME = "CDIProject";
 	protected static final String PACKAGE_NAME = "cdi";
 
@@ -67,6 +69,9 @@ public class CDITestBase {
 	private static final String JAVA_VERSION_STR;
 	private static final Double JAVA_VERSION;
  
+	protected static final String VERSION = "version";
+	protected static final String FAMILY = "family";
+	
 	static {
 		JAVA_VERSION_STR = System.getProperty("java.version");
 		JAVA_VERSION = Double.parseDouble(JAVA_VERSION_STR.substring(0, JAVA_VERSION_STR.indexOf(".") + 1));
@@ -93,6 +98,7 @@ public class CDITestBase {
 			fp.setProjectName(PROJECT_NAME);
 			fp.setTargetRuntime(sr.getRuntimeName());
 			fp.activateFacet("1.8", "Java");
+			fp.activateFacet(CDIVersion, "CDI (Contexts and Dependency Injection)");
 			cw.finish();
 			new WaitUntil(new JobIsRunning(), TimePeriod.DEFAULT, false);
 			new WaitWhile(new JobIsRunning(), TimePeriod.LONG);

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi10/AsYouTypeValidationTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi10/AsYouTypeValidationTestCDI10.java
@@ -31,11 +31,11 @@ public class AsYouTypeValidationTestCDI10 extends AsYouTypeValidationTemplate {
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi10/BeanValidationQuickFixTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi10/BeanValidationQuickFixTestCDI10.java
@@ -33,11 +33,11 @@ public class BeanValidationQuickFixTestCDI10 extends BeanValidationQuickFixTempl
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	} 
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi10/NullValuesInjectionTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi10/NullValuesInjectionTestCDI10.java
@@ -31,11 +31,11 @@ public class NullValuesInjectionTestCDI10 extends NullValuesInjectionTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi11/AsYouTypeValidationTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi11/AsYouTypeValidationTestCDI11.java
@@ -32,11 +32,13 @@ public class AsYouTypeValidationTestCDI11 extends AsYouTypeValidationTemplate {
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi11/BeanValidationQuickFixTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi11/BeanValidationQuickFixTestCDI11.java
@@ -33,11 +33,13 @@ public class BeanValidationQuickFixTestCDI11 extends BeanValidationQuickFixTempl
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi11/NullValuesInjectionTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi11/NullValuesInjectionTestCDI11.java
@@ -32,18 +32,23 @@ public class NullValuesInjectionTestCDI11 extends NullValuesInjectionTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
+	}
+	
+	public NullValuesInjectionTestCDI11() {
+		CDIVersion = "1.1";
 	}
 	
 	@Before
 	public void changeDiscoveryMode(){
 		prepareBeanXml("all", true);
-		CDIVersion = "1.1";
 	}
 
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi11/VetoedAnnotationTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi11/VetoedAnnotationTestCDI11.java
@@ -31,11 +31,13 @@ public class VetoedAnnotationTestCDI11 extends VetoedAnnotationTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/template/NullValuesInjectionTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/template/NullValuesInjectionTemplate.java
@@ -25,8 +25,6 @@ import org.junit.Test;
 
 public class NullValuesInjectionTemplate extends CDITestBase {
 
-	protected String CDIVersion;
-
 	// cdi1.1+
 	@Test
 	public void injectNullValue() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi10/DecoratorFromWebBeanTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi10/DecoratorFromWebBeanTestCDI10.java
@@ -31,11 +31,11 @@ public class DecoratorFromWebBeanTestCDI10 extends DecoratorFromWebBeanTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi10/DecoratorValidationQuickFixTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi10/DecoratorValidationQuickFixTestCDI10.java
@@ -33,11 +33,11 @@ public class DecoratorValidationQuickFixTestCDI10 extends DecoratorValidationQui
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi11/DecoratorFromWebBeanTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi11/DecoratorFromWebBeanTestCDI11.java
@@ -32,11 +32,13 @@ public class DecoratorFromWebBeanTestCDI11 extends DecoratorFromWebBeanTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi11/DecoratorValidationQuickFixTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi11/DecoratorValidationQuickFixTestCDI11.java
@@ -33,11 +33,13 @@ public class DecoratorValidationQuickFixTestCDI11 extends DecoratorValidationQui
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi10/AllAssignableDialogTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi10/AllAssignableDialogTestCDI10.java
@@ -31,11 +31,11 @@ public class AllAssignableDialogTestCDI10 extends AllAssignableDialogTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi10/AssignableDialogFilterTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi10/AssignableDialogFilterTestCDI10.java
@@ -31,11 +31,11 @@ public class AssignableDialogFilterTestCDI10 extends AssignableDialogFilterTempl
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi11/AllAssignableDialogTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi11/AllAssignableDialogTestCDI11.java
@@ -32,11 +32,13 @@ public class AllAssignableDialogTestCDI11 extends AllAssignableDialogTemplate {
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi11/AssignableDialogFilterTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi11/AssignableDialogFilterTestCDI11.java
@@ -32,11 +32,13 @@ public class AssignableDialogFilterTestCDI11 extends AssignableDialogFilterTempl
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 		

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/ibinding/cdi10/IBindingValidationQuickFixTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/ibinding/cdi10/IBindingValidationQuickFixTestCDI10.java
@@ -33,11 +33,11 @@ public class IBindingValidationQuickFixTestCDI10 extends IBindingValidationQuick
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/ibinding/cdi11/IBindingValidationQuickFixTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/ibinding/cdi11/IBindingValidationQuickFixTestCDI11.java
@@ -33,11 +33,13 @@ public class IBindingValidationQuickFixTestCDI11 extends IBindingValidationQuick
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 		

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/interceptor/cdi10/InterceptorValidationQuickFixTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/interceptor/cdi10/InterceptorValidationQuickFixTestCDI10.java
@@ -33,11 +33,11 @@ public class InterceptorValidationQuickFixTestCDI10 extends InterceptorValidatio
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/interceptor/cdi11/InterceptorValidationQuickFixTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/interceptor/cdi11/InterceptorValidationQuickFixTestCDI11.java
@@ -33,11 +33,13 @@ public class InterceptorValidationQuickFixTestCDI11 extends InterceptorValidatio
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi10/NamedComponentsSearchingTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi10/NamedComponentsSearchingTestCDI10.java
@@ -38,11 +38,11 @@ public class NamedComponentsSearchingTestCDI10 extends NamedComponentsSearchingT
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi10/NamedRefactoringTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi10/NamedRefactoringTestCDI10.java
@@ -38,11 +38,11 @@ public class NamedRefactoringTestCDI10 extends NamedRefactoringTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi11/NamedComponentsSearchingTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi11/NamedComponentsSearchingTestCDI11.java
@@ -39,11 +39,13 @@ public class NamedComponentsSearchingTestCDI11 extends NamedComponentsSearchingT
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 		

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi11/NamedRefactoringTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi11/NamedRefactoringTestCDI11.java
@@ -39,11 +39,13 @@ public class NamedRefactoringTestCDI11 extends NamedRefactoringTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi20/NamedComponentsSearchingTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi20/NamedComponentsSearchingTestCDI20.java
@@ -1,14 +1,15 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
  * and is available at http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributor:
- *     Red Hat, Inc. - initial API and implementation
+ * 
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package org.jboss.tools.cdi.bot.test.weld.cdi10;
+
+package org.jboss.tools.cdi.bot.test.beans.named.cdi20;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -21,29 +22,39 @@ import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequireme
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
 import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.weld.template.WeldExcludeTemplate;
-import org.jboss.tools.cdi.reddeer.validators.BeanValidationProviderCDI10;
+import org.jboss.tools.cdi.bot.test.beans.named.teplate.NamedComponentsSearchingTemplate;
 import org.junit.Before;
 
+/** 
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
 @JRE(cleanup=true)
 @JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
 @OpenPerspective(JavaEEPerspective.class)
-public class WeldExcludeTestCDI10 extends WeldExcludeTemplate{
+public class NamedComponentsSearchingTestCDI20 extends NamedComponentsSearchingTemplate {
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
 					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	
+	public NamedComponentsSearchingTestCDI20() {
+		CDIVersion = "2.0";
+	}
+		
 	@Before
-	public void setValidationProvider(){
-		validationProvider = new BeanValidationProviderCDI10();
+	public void changeDiscoveryMode(){
+		prepareBeanXml("all", true);
 	}
 
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cd10/BeanInjectOpenOnTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cd10/BeanInjectOpenOnTestCDI10.java
@@ -31,11 +31,11 @@ public class BeanInjectOpenOnTestCDI10 extends BeanInjectOpenOnTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cd10/FindObserverEventTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cd10/FindObserverEventTestCDI10.java
@@ -31,11 +31,11 @@ public class FindObserverEventTestCDI10 extends FindObserverEventTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cdi11/BeanInjectOpenOnTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cdi11/BeanInjectOpenOnTestCDI11.java
@@ -32,11 +32,13 @@ public class BeanInjectOpenOnTestCDI11 extends BeanInjectOpenOnTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 		

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cdi11/FindObserverEventTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cdi11/FindObserverEventTestCDI11.java
@@ -32,11 +32,13 @@ public class FindObserverEventTestCDI11 extends FindObserverEventTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 		

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cdi20/BeanInjectOpenOnTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cdi20/BeanInjectOpenOnTestCDI20.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -8,7 +8,7 @@
  * Contributor:
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package org.jboss.tools.cdi.bot.test.weld.cdi10;
+package org.jboss.tools.cdi.bot.test.beans.openon.cdi20;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -21,29 +21,39 @@ import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequireme
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
 import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.weld.template.WeldExcludeTemplate;
-import org.jboss.tools.cdi.reddeer.validators.BeanValidationProviderCDI10;
+import org.jboss.tools.cdi.bot.test.beans.openon.template.BeanInjectOpenOnTemplate;
 import org.junit.Before;
 
+/**
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
 @JRE(cleanup=true)
 @JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
 @OpenPerspective(JavaEEPerspective.class)
-public class WeldExcludeTestCDI10 extends WeldExcludeTemplate{
+public class BeanInjectOpenOnTestCDI20 extends BeanInjectOpenOnTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
 					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	
+	public BeanInjectOpenOnTestCDI20() {
+		CDIVersion = "2.0";
+	}
+		
 	@Before
-	public void setValidationProvider(){
-		validationProvider = new BeanValidationProviderCDI10();
+	public void changeDiscoveryMode(){
+		prepareBeanXml("all", true);
 	}
 
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cdi20/FindObserverEventTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cdi20/FindObserverEventTestCDI20.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -8,7 +8,7 @@
  * Contributor:
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package org.jboss.tools.cdi.bot.test.weld.cdi10;
+package org.jboss.tools.cdi.bot.test.beans.openon.cdi20;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -21,29 +21,39 @@ import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequireme
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
 import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.weld.template.WeldExcludeTemplate;
-import org.jboss.tools.cdi.reddeer.validators.BeanValidationProviderCDI10;
+import org.jboss.tools.cdi.bot.test.beans.openon.template.FindObserverEventTemplate;
 import org.junit.Before;
 
+/**
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
 @JRE(cleanup=true)
 @JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
 @OpenPerspective(JavaEEPerspective.class)
-public class WeldExcludeTestCDI10 extends WeldExcludeTemplate{
+public class FindObserverEventTestCDI20 extends FindObserverEventTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
 					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	
+	public FindObserverEventTestCDI20() {
+		CDIVersion = "2.0";
+	}
+		
 	@Before
-	public void setValidationProvider(){
-		validationProvider = new BeanValidationProviderCDI10();
+	public void changeDiscoveryMode(){
+		prepareBeanXml("all", true);
 	}
 
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/qualifier/cdi10/QualifierValidationQuickFixTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/qualifier/cdi10/QualifierValidationQuickFixTestCDI10.java
@@ -33,11 +33,11 @@ public class QualifierValidationQuickFixTestCDI10 extends QualifierValidationQui
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/qualifier/cdi11/QualifierValidationQuickFixTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/qualifier/cdi11/QualifierValidationQuickFixTestCDI11.java
@@ -33,11 +33,13 @@ public class QualifierValidationQuickFixTestCDI11 extends QualifierValidationQui
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/scope/cdi10/ScopeValidationQuickFixTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/scope/cdi10/ScopeValidationQuickFixTestCDI10.java
@@ -33,11 +33,11 @@ public class ScopeValidationQuickFixTestCDI10 extends ScopeValidationQuickFixTem
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/scope/cdi11/ScopeValidationQuickFixTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/scope/cdi11/ScopeValidationQuickFixTestCDI11.java
@@ -33,11 +33,13 @@ public class ScopeValidationQuickFixTestCDI11 extends ScopeValidationQuickFixTem
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/stereotype/cdi10/StereotypeValidationQuickFixTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/stereotype/cdi10/StereotypeValidationQuickFixTestCDI10.java
@@ -33,11 +33,11 @@ public class StereotypeValidationQuickFixTestCDI10 extends StereotypeValidationQ
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/stereotype/cdi11/StereotypeValidationQuickFixTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/stereotype/cdi11/StereotypeValidationQuickFixTestCDI11.java
@@ -33,11 +33,13 @@ public class StereotypeValidationQuickFixTestCDI11 extends StereotypeValidationQ
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/annotation/cdi11/BeanParametersAnnotationTest.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/annotation/cdi11/BeanParametersAnnotationTest.java
@@ -54,11 +54,13 @@ public class BeanParametersAnnotationTest extends CDITestBase {
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/bean/cdi11/ExcludeBeanTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/bean/cdi11/ExcludeBeanTestCDI11.java
@@ -34,11 +34,13 @@ public class ExcludeBeanTestCDI11 extends ExcludeBeanTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi10/BeansXMLBeansEditorTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi10/BeansXMLBeansEditorTestCDI10.java
@@ -31,11 +31,11 @@ public class BeansXMLBeansEditorTestCDI10 extends BeansXMLBeansEditorTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi10/BeansXMLValidationTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi10/BeansXMLValidationTestCDI10.java
@@ -42,11 +42,11 @@ public class BeansXMLValidationTestCDI10 extends BeansXMLValidationTemplate {
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi11/BeansXMLBeansEditorTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi11/BeansXMLBeansEditorTestCDI11.java
@@ -32,11 +32,13 @@ public class BeansXMLBeansEditorTestCDI11 extends BeansXMLBeansEditorTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi11/BeansXMLDiscoveryModesTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi11/BeansXMLDiscoveryModesTestCDI11.java
@@ -31,11 +31,13 @@ public class BeansXMLDiscoveryModesTestCDI11 extends BeansXMLDiscoveryModesTempl
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi11/BeansXMLUITestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi11/BeansXMLUITestCDI11.java
@@ -33,11 +33,13 @@ public class BeansXMLUITestCDI11 extends BeansXMLUITemplate {
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi11/BeansXMLValidationTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi11/BeansXMLValidationTestCDI11.java
@@ -40,11 +40,13 @@ public class BeansXMLValidationTestCDI11 extends BeansXMLValidationTemplate {
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/completion/cdi10/BeansXMLCompletionTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/completion/cdi10/BeansXMLCompletionTestCDI10.java
@@ -40,11 +40,11 @@ public class BeansXMLCompletionTestCDI10 extends BeansXMLCompletionTemplate {
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/completion/cdi11/BeansXMLCompletionTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/completion/cdi11/BeansXMLCompletionTestCDI11.java
@@ -39,11 +39,13 @@ public class BeansXMLCompletionTestCDI11 extends BeansXMLCompletionTemplate {
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/discovery/cdi11/BeanDiscoveryInExplicitArchivesTest.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/discovery/cdi11/BeanDiscoveryInExplicitArchivesTest.java
@@ -48,11 +48,12 @@ public class BeanDiscoveryInExplicitArchivesTest extends BeanDiscoveryInArchives
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/discovery/cdi11/BeanDiscoveryInImplicitArchivesTest.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/discovery/cdi11/BeanDiscoveryInImplicitArchivesTest.java
@@ -48,11 +48,13 @@ public class BeanDiscoveryInImplicitArchivesTest extends BeanDiscoveryInArchives
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/openon/cdi10/BeansXMLOpenOnTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/openon/cdi10/BeansXMLOpenOnTestCDI10.java
@@ -31,11 +31,11 @@ public class BeansXMLOpenOnTestCDI10 extends BeansXMLOpenOnTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/openon/cdi11/BeansXMLOpenOnTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/openon/cdi11/BeansXMLOpenOnTestCDI11.java
@@ -31,11 +31,13 @@ public class BeansXMLOpenOnTestCDI11 extends BeansXMLOpenOnTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi10/BeansXMLAsYouTypeValidationTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi10/BeansXMLAsYouTypeValidationTestCDI10.java
@@ -31,11 +31,11 @@ public class BeansXMLAsYouTypeValidationTestCDI10 extends BeansXMLAsYouTypeValid
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi10/BeansXMLValidationQuickFixTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi10/BeansXMLValidationQuickFixTestCDI10.java
@@ -33,11 +33,11 @@ public class BeansXMLValidationQuickFixTestCDI10 extends BeansXMLValidationQuick
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi11/BeansXMLAsYouTypeValidationTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi11/BeansXMLAsYouTypeValidationTestCDI11.java
@@ -32,11 +32,13 @@ public class BeansXMLAsYouTypeValidationTestCDI11 extends BeansXMLAsYouTypeValid
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi11/BeansXMLValidationQuickFixTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi11/BeansXMLValidationQuickFixTestCDI11.java
@@ -35,11 +35,13 @@ public class BeansXMLValidationQuickFixTestCDI11 extends BeansXMLValidationQuick
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/validation/cdi10/CDIValidatorTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/validation/cdi10/CDIValidatorTestCDI10.java
@@ -31,11 +31,11 @@ public class CDIValidatorTestCDI10 extends CDIValidatorTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/validation/cdi11/CDIValidatorTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/validation/cdi11/CDIValidatorTestCDI11.java
@@ -32,11 +32,13 @@ public class CDIValidatorTestCDI11 extends CDIValidatorTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi10/WeldBuiltInContextsTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi10/WeldBuiltInContextsTestCDI10.java
@@ -31,11 +31,11 @@ public class WeldBuiltInContextsTestCDI10 extends WeldBuiltInContextsTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi10/WeldParametersAnnotationTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi10/WeldParametersAnnotationTestCDI10.java
@@ -31,11 +31,11 @@ public class WeldParametersAnnotationTestCDI10 extends WeldParametersAnnotationT
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi10/WeldScanTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi10/WeldScanTestCDI10.java
@@ -31,11 +31,11 @@ public class WeldScanTestCDI10 extends WeldScanTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi11/WeldBuiltInContextsTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi11/WeldBuiltInContextsTestCDI11.java
@@ -31,11 +31,13 @@ public class WeldBuiltInContextsTestCDI11 extends WeldBuiltInContextsTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi11/WeldExcludeTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi11/WeldExcludeTestCDI11.java
@@ -33,11 +33,13 @@ public class WeldExcludeTestCDI11 extends WeldExcludeTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi11/WeldParametersAnnotationTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi11/WeldParametersAnnotationTestCDI11.java
@@ -32,11 +32,13 @@ public class WeldParametersAnnotationTestCDI11 extends WeldParametersAnnotationT
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi11/WeldScanTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi11/WeldScanTestCDI11.java
@@ -31,11 +31,13 @@ public class WeldScanTestCDI11 extends WeldScanTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi10/CDIWebProjectWizardTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi10/CDIWebProjectWizardTestCDI10.java
@@ -23,6 +23,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.wizard.template.CDIWebProjectWizardTemplate;
+import org.junit.Test;
 
 @JRE(cleanup=true)
 @JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
@@ -32,16 +33,20 @@ public class CDIWebProjectWizardTestCDI10 extends CDIWebProjectWizardTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	
 	public CDIWebProjectWizardTestCDI10(){
 		CDIVersion = "1.0";
 	}
-
+	
+	@Test
+	public void createCDIProjectWithoutBeansXmlCDI10() {
+		createCDIProjectWithoutBeansXml();
+	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi10/DynamicWebProjectWithCDITestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi10/DynamicWebProjectWithCDITestCDI10.java
@@ -35,11 +35,11 @@ public class DynamicWebProjectWithCDITestCDI10 extends ProjectWithCDITemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi10/EjbProjectWithCDITestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi10/EjbProjectWithCDITestCDI10.java
@@ -35,11 +35,11 @@ public class EjbProjectWithCDITestCDI10 extends ProjectWithCDITemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi10/UtilityProjectWithCDITestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi10/UtilityProjectWithCDITestCDI10.java
@@ -35,11 +35,11 @@ public class UtilityProjectWithCDITestCDI10 extends ProjectWithCDITemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/AllWizardsTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/AllWizardsTestCDI11.java
@@ -25,6 +25,6 @@ public class AllWizardsTestCDI11 extends WizardTemplate {
 
 	@RequirementRestriction
 	public static RequirementMatcher getRestrictionMatcher() {
-	  return new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly());
+	  return new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly());
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/CDIWebProjectWizardTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/CDIWebProjectWizardTestCDI11.java
@@ -23,6 +23,7 @@ import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.wizard.template.CDIWebProjectWizardTemplate;
+import org.junit.Test;
 
 @JRE(cleanup=true)
 @OpenPerspective(JavaEEPerspective.class)
@@ -32,15 +33,22 @@ public class CDIWebProjectWizardTestCDI11 extends CDIWebProjectWizardTemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	
 	public CDIWebProjectWizardTestCDI11(){
 		CDIVersion = "1.2";
+	}
+	
+	@Test
+	public void createCDIProjectWithoutBeansXmlCDI11() {
+		createCDIProjectWithoutBeansXml();
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/DynamicWebProjectWithCDITestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/DynamicWebProjectWithCDITestCDI11.java
@@ -35,11 +35,13 @@ public class DynamicWebProjectWithCDITestCDI11 extends ProjectWithCDITemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/EjbProjectWithCDITestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/EjbProjectWithCDITestCDI11.java
@@ -35,11 +35,13 @@ public class EjbProjectWithCDITestCDI11 extends ProjectWithCDITemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/UtilityProjectWithCDITestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/UtilityProjectWithCDITestCDI11.java
@@ -35,11 +35,13 @@ public class UtilityProjectWithCDITestCDI11 extends ProjectWithCDITemplate{
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
 		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()));
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, "family", ServerMatcher.WildFly()),
-					new RequirementMatcher(JRE.class, "version", "1.8"));
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi20/CDIWebProjectWizardTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi20/CDIWebProjectWizardTestCDI20.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.bot.test.wizard.cdi20;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.reddeer.common.wait.TimePeriod;
+import org.eclipse.reddeer.common.wait.WaitUntil;
+import org.eclipse.reddeer.common.wait.WaitWhile;
+import org.eclipse.reddeer.core.exception.CoreLayerException;
+import org.eclipse.reddeer.eclipse.condition.ProblemExists;
+import org.eclipse.reddeer.eclipse.jst.servlet.ui.project.facet.WebProjectFirstPage;
+import org.eclipse.reddeer.eclipse.ui.navigator.resources.ProjectExplorer;
+import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
+import org.eclipse.reddeer.eclipse.ui.views.markers.ProblemsView.ProblemType;
+import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
+import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
+import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
+import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
+import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.eclipse.reddeer.swt.impl.combo.DefaultCombo;
+import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
+import org.jboss.tools.cdi.bot.test.CDITestBase;
+import org.jboss.tools.cdi.bot.test.wizard.template.CDIWebProjectWizardTemplate;
+import org.jboss.tools.cdi.reddeer.cdi.ui.CDIProjectWizard;
+import org.jboss.tools.cdi.reddeer.cdi.ui.wizard.facet.CDIInstallWizardPage;
+import org.junit.Test;
+
+/**
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
+@JRE(cleanup=true)
+@OpenPerspective(JavaEEPerspective.class)
+@JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
+public class CDIWebProjectWizardTestCDI20 extends CDIWebProjectWizardTemplate{
+
+	@RequirementRestriction
+	public static Collection<RequirementMatcher> getRestrictionMatcher() {
+		if (CDITestBase.isJavaLE8()) { 
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
+		} else {
+			return Arrays.asList(
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
+		}
+	}
+	
+	public CDIWebProjectWizardTestCDI20(){
+		CDIVersion = "2.0";
+	}
+	
+	//JBIDE-26643 | cdi2.0 does not contain the page for unchecking the "create beans.xml" option
+	@Test(expected = JBIDE26643Exception.class)
+	public void createCDIProjectWithoutBeansXmlCDI20() throws JBIDE26643Exception{
+		CDIProjectWizard cw = new CDIProjectWizard();
+		cw.open();
+		WebProjectFirstPage fp = new WebProjectFirstPage(cw);
+		fp.setProjectName(PROJECT_NAME);
+		if (CDIVersion.equals("2.0")) {
+			new DefaultCombo(2).setSelection("Dynamic Web Project with CDI 2.0 (Contexts and Dependency Injection)");
+		}
+		assertEquals(sr.getRuntimeName(),fp.getTargetRuntime());
+		assertEquals("Dynamic Web Project with CDI "+CDIVersion+" (Contexts and Dependency Injection)",fp.getConfiguration());
+		fp.activateFacet("1.8", "Java");
+		cw.next();
+		cw.next();
+		cw.next();
+		try {
+			CDIInstallWizardPage ip = new CDIInstallWizardPage(cw);
+			ip.toggleCreateBeansXml(false);
+		} catch (CoreLayerException e) {
+			cw.cancel();
+			throw new JBIDE26643Exception("'Create beans.xml' checkbox not found while using CDI 2.0.");
+		}
+		cw.finish();
+		isCDISupportEnabled(PROJECT_NAME);
+		isCDIFacetEnabled(PROJECT_NAME, CDIVersion);
+		ProjectExplorer pe = new ProjectExplorer();
+		pe.open();
+		assertTrue(pe.containsProject(PROJECT_NAME));
+		assertFalse(pe.getProject(PROJECT_NAME).containsResource("WebContent","WEB-INF","beans.xml"));
+		new WaitUntil(new ProblemExists(ProblemType.ALL), TimePeriod.LONG, false);
+		if (CDIVersion.equals("1.0")) {
+			assertTrue(new ProblemExists(ProblemType.ALL).test());	
+		} else {	
+			new WaitWhile(new ProblemExists(ProblemType.ALL));	
+		}
+	}
+	
+	class JBIDE26643Exception extends Exception {
+		
+		public JBIDE26643Exception(String message) {
+			super(message);
+		}
+	}
+}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/template/CDIWebProjectWizardTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/template/CDIWebProjectWizardTemplate.java
@@ -28,6 +28,7 @@ import org.eclipse.reddeer.junit.requirement.inject.InjectRequirement;
 import org.eclipse.reddeer.swt.condition.ShellIsAvailable;
 import org.eclipse.reddeer.swt.impl.button.LabeledCheckBox;
 import org.eclipse.reddeer.swt.impl.button.PushButton;
+import org.eclipse.reddeer.swt.impl.combo.DefaultCombo;
 import org.eclipse.reddeer.swt.impl.menu.ContextMenu;
 import org.eclipse.reddeer.swt.impl.shell.DefaultShell;
 import org.eclipse.reddeer.swt.impl.tree.DefaultTree;
@@ -42,9 +43,11 @@ import org.junit.Test;
 
 public class CDIWebProjectWizardTemplate{
 	
-	
-	private static final String PROJECT_NAME = "CDIProject";
 	protected String CDIVersion;
+	
+	protected static final String PROJECT_NAME = "CDIProject";
+	protected static final String VERSION = "version";
+	protected static final String FAMILY = "family";
 	
 	@InjectRequirement
 	protected ServerRequirement sr;
@@ -72,6 +75,10 @@ public class CDIWebProjectWizardTemplate{
 		cw.open();
 		WebProjectFirstPage fp = new WebProjectFirstPage(cw);
 		fp.setProjectName(PROJECT_NAME);
+		// set the right configuration for CDI 2.0
+		if (CDIVersion.equals("2.0")) {
+			new DefaultCombo(2).setSelection("Dynamic Web Project with CDI 2.0 (Contexts and Dependency Injection)");
+		}
 		assertEquals(sr.getRuntimeName(),fp.getTargetRuntime());
 		assertEquals("Dynamic Web Project with CDI "+CDIVersion+" (Contexts and Dependency Injection)",fp.getConfiguration());
 		fp.activateFacet("1.8", "Java");
@@ -92,7 +99,6 @@ public class CDIWebProjectWizardTemplate{
 	
 	//cdi1.1+
 	//cd1.0 should show warning
-	@Test
 	public void createCDIProjectWithoutBeansXml(){
 		CDIProjectWizard cw = new CDIProjectWizard();
 		cw.open();
@@ -123,7 +129,7 @@ public class CDIWebProjectWizardTemplate{
 	
 	//dynamic web..and other JEE7 project-enabled
 	
-	private boolean isCDISupportEnabled(String projectName){
+	protected boolean isCDISupportEnabled(String projectName){
 		openProjectProperties(projectName);
 		new DefaultTreeItem("CDI (Contexts and Dependency Injection) Settings").select();
 		boolean toReturn = new LabeledCheckBox("CDI support:").isChecked();
@@ -132,7 +138,7 @@ public class CDIWebProjectWizardTemplate{
 		return toReturn;
 	}
 	
-	private boolean isCDIFacetEnabled(String projectName, String cdiVersion){
+	protected boolean isCDIFacetEnabled(String projectName, String cdiVersion){
 		openProjectProperties(projectName);
 		new DefaultTreeItem("Project Facets").select();
 		boolean result = new DefaultTreeItem(new DefaultTree(1),"CDI (Contexts and Dependency Injection)").isChecked();
@@ -151,3 +157,4 @@ public class CDIWebProjectWizardTemplate{
 	}
 	
 }
+

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/template/ProjectWithCDITemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/template/ProjectWithCDITemplate.java
@@ -44,11 +44,15 @@ import org.junit.Test;
 
 public class ProjectWithCDITemplate{
 	
+	protected String CDIVersion;
+	
 	protected String PROJECT_NAME = "CDIProject";
 	protected boolean enabledByDefault = true;
 	protected String ignoredProblem;
 	protected String expectedProblemAdded;
 	
+	protected static final String VERSION = "version";
+	protected static final String FAMILY = "family";
 
 	@After
 	public void cleanUp() {


### PR DESCRIPTION
JBIDE-24963 - Create CDI 2.0 integration tests - step 1
	NamedComponentsSearchingTestCDI20.class
	BeanInjectOpenOnTestCDI20.class
	FindObserverEventTestCDI20.class
	CDIWebProjectWizardTestCDI20.class

Jenkins: https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cdi20.itests/4/
Jira: https://issues.jboss.org/browse/JBIDE-24963

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>