### PR TITLE
JBIDE-24963-2 - Create CDI 2.0 integration tests - step 2

### DIFF
--- a/plugins/org.jboss.tools.cdi.reddeer/src/org/jboss/tools/cdi/reddeer/validators/BeansXmlValidationProviderCDI20.java
+++ b/plugins/org.jboss.tools.cdi.reddeer/src/org/jboss/tools/cdi/reddeer/validators/BeansXmlValidationProviderCDI20.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.reddeer.validators;
+
+import java.util.Arrays;
+
+import org.eclipse.reddeer.eclipse.ui.views.markers.ProblemsView.ProblemType;
+import org.jboss.tools.cdi.reddeer.annotation.ValidationType;
+
+public class BeansXmlValidationProviderCDI20 extends AbstractValidationProvider {
+	
+	private final String jsr = "JSR-365";
+	
+	public BeansXmlValidationProviderCDI20() {
+		super();
+	}
+
+	@Override
+	void init() {
+		problems.add(new ValidationProblem(ProblemType.ERROR, ValidationType.NO_CLASS, 
+				"There is no class", jsr, Arrays.asList("Create CDI Bean")));
+		
+		problems.add(new ValidationProblem(ProblemType.ERROR, ValidationType.NO_ANNOTATION,
+				"There is no annotation",jsr, Arrays.asList("Create CDI")));
+		
+		problems.add(new ValidationProblem(ProblemType.ERROR, ValidationType.ISNT_ALTERNATIVE_STEREOTYPE,
+				"is not @Alternative stereotype annotation",jsr, Arrays.asList("Add annotation @Alternative")));
+		
+		problems.add(new ValidationProblem(ProblemType.ERROR, ValidationType.ISNT_ALTERNATIVE,
+				"is not an alternative bean class",jsr, Arrays.asList("Add annotation @Alternative")));
+		
+		problems.add(new ValidationProblem(ProblemType.ERROR, ValidationType.NO_DECORATOR,
+				"There is no class" ,jsr, Arrays.asList("Create CDI Decorator")));
+		
+		problems.add(new ValidationProblem(ProblemType.ERROR, ValidationType.NO_INTERCEPTOR,
+				"There is no class" ,jsr, Arrays.asList("Create CDI Interceptor")));
+		
+		problems.add(new ValidationProblem(ProblemType.ERROR, ValidationType.ISNT_INTERCEPTOR,
+				"is not an interceptor class" ,jsr, null));
+		
+		problems.add(new ValidationProblem(ProblemType.ERROR, ValidationType.ISNT_DECORATOR,
+				"is not a decorator bean class" ,jsr, null));
+	}
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDI20SuiteTest.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDI20SuiteTest.java
@@ -14,6 +14,9 @@ import org.eclipse.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.tools.cdi.bot.test.beans.named.cdi20.NamedComponentsSearchingTestCDI20;
 import org.jboss.tools.cdi.bot.test.beans.openon.cdi20.BeanInjectOpenOnTestCDI20;
 import org.jboss.tools.cdi.bot.test.beans.openon.cdi20.FindObserverEventTestCDI20;
+import org.jboss.tools.cdi.bot.test.beansxml.cdi20.BeansXMLBeansEditorTestCDI20;
+import org.jboss.tools.cdi.bot.test.beansxml.cdi20.BeansXMLValidationTestCDI20;
+import org.jboss.tools.cdi.bot.test.beansxml.validation.cdi20.BeansXMLValidationQuickFixTestCDI20;
 import org.jboss.tools.cdi.bot.test.wizard.cdi20.CDIWebProjectWizardTestCDI20;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite.SuiteClasses;
@@ -29,6 +32,9 @@ import org.junit.runners.Suite.SuiteClasses;
 	BeanInjectOpenOnTestCDI20.class,
 	FindObserverEventTestCDI20.class,
 	CDIWebProjectWizardTestCDI20.class,
+	BeansXMLBeansEditorTestCDI20.class,
+	BeansXMLValidationTestCDI20.class,
+	BeansXMLValidationQuickFixTestCDI20.class,
 })
 public class CDI20SuiteTest {
 

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi20/BeansXMLBeansEditorTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi20/BeansXMLBeansEditorTestCDI20.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -8,7 +8,7 @@
  * Contributor:
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package org.jboss.tools.cdi.bot.test.wizard.cdi10;
+package org.jboss.tools.cdi.bot.test.beansxml.cdi20;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -21,26 +21,39 @@ import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequireme
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
 import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
-import org.jboss.tools.cdi.bot.test.wizard.template.CDIWebProjectWizardTemplate;
+import org.jboss.tools.cdi.bot.test.beansxml.template.BeansXMLBeansEditorTemplate;
+import org.junit.Before;
 
+/** 
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
 @JRE(cleanup=true)
 @JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
 @OpenPerspective(JavaEEPerspective.class)
-public class CDIWebProjectWizardTestCDI10 extends CDIWebProjectWizardTemplate{
+public class BeansXMLBeansEditorTestCDI20 extends BeansXMLBeansEditorTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
+		if (isJavaLE8()) { 
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
 					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
-	
-	public CDIWebProjectWizardTestCDI10(){
-		CDIVersion = "1.0";
+
+	public BeansXMLBeansEditorTestCDI20() {
+		CDIVersion = "2.0";
 	}
+
+	@Before
+	public void changeDiscoveryMode(){
+		prepareBeanXml("all", true);
+	}
+
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi20/BeansXMLValidationTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi20/BeansXMLValidationTestCDI20.java
@@ -1,14 +1,15 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
  * and is available at http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributor:
- *     Red Hat, Inc. - initial API and implementation
+ * 
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package org.jboss.tools.cdi.bot.test.wizard.cdi10;
+
+package org.jboss.tools.cdi.bot.test.beansxml.cdi20;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -21,26 +22,41 @@ import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequireme
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
 import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
-import org.jboss.tools.cdi.bot.test.wizard.template.CDIWebProjectWizardTemplate;
+import org.jboss.tools.cdi.bot.test.beansxml.template.BeansXMLValidationTemplate;
+import org.jboss.tools.cdi.reddeer.validators.BeansXmlValidationProviderCDI20;
+import org.junit.Before;
 
+/** 
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
 @JRE(cleanup=true)
 @JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
 @OpenPerspective(JavaEEPerspective.class)
-public class CDIWebProjectWizardTestCDI10 extends CDIWebProjectWizardTemplate{
+public class BeansXMLValidationTestCDI20 extends BeansXMLValidationTemplate {
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
+		if (isJavaLE8()) { 
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
 					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
-	
-	public CDIWebProjectWizardTestCDI10(){
-		CDIVersion = "1.0";
+
+	public BeansXMLValidationTestCDI20() {
+		CDIVersion = "2.0";
 	}
+
+	@Before
+	public void changeDiscoveryMode(){
+		validationProvider = new BeansXmlValidationProviderCDI20();
+		prepareBeanXml("all", true);
+	}
+	
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi20/BeansXMLValidationQuickFixTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi20/BeansXMLValidationQuickFixTestCDI20.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -8,39 +8,58 @@
  * Contributor:
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package org.jboss.tools.cdi.bot.test.wizard.cdi10;
+package org.jboss.tools.cdi.bot.test.beansxml.validation.cdi20;
 
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.eclipse.reddeer.common.wait.WaitWhile;
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
 import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
 import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
 import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
-import org.jboss.tools.cdi.bot.test.wizard.template.CDIWebProjectWizardTemplate;
+import org.jboss.tools.cdi.bot.test.beansxml.validation.template.BeansXMLValidationQuickFixTemplate;
+import org.jboss.tools.cdi.reddeer.validators.BeansXmlValidationProviderCDI20;
+import org.junit.Before;
 
+/** 
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
 @JRE(cleanup=true)
 @JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
 @OpenPerspective(JavaEEPerspective.class)
-public class CDIWebProjectWizardTestCDI10 extends CDIWebProjectWizardTemplate{
+public class BeansXMLValidationQuickFixTestCDI20 extends BeansXMLValidationQuickFixTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
+		if (isJavaLE8()) { 
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
 		} else {
 			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
 					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
-	
-	public CDIWebProjectWizardTestCDI10(){
-		CDIVersion = "1.0";
+
+	public BeansXMLValidationQuickFixTestCDI20() {
+		CDIVersion = "2.0";
 	}
+
+	@Before
+	public void setValidationProvider(){
+		validationProvider = new BeansXmlValidationProviderCDI20();
+		requireBeansXML = false;
+		prepareBeanXml("all", true);
+		new WaitWhile(new JobIsRunning());
+	}
+
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/CDIWebProjectWizardTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/CDIWebProjectWizardTestCDI11.java
@@ -23,7 +23,6 @@ import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.wizard.template.CDIWebProjectWizardTemplate;
-import org.junit.Test;
 
 @JRE(cleanup=true)
 @OpenPerspective(JavaEEPerspective.class)
@@ -45,10 +44,5 @@ public class CDIWebProjectWizardTestCDI11 extends CDIWebProjectWizardTemplate{
 	
 	public CDIWebProjectWizardTestCDI11(){
 		CDIVersion = "1.2";
-	}
-	
-	@Test
-	public void createCDIProjectWithoutBeansXmlCDI11() {
-		createCDIProjectWithoutBeansXml();
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi20/CDIWebProjectWizardTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi20/CDIWebProjectWizardTestCDI20.java
@@ -10,35 +10,19 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.wizard.cdi20;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.eclipse.reddeer.common.wait.TimePeriod;
-import org.eclipse.reddeer.common.wait.WaitUntil;
-import org.eclipse.reddeer.common.wait.WaitWhile;
-import org.eclipse.reddeer.core.exception.CoreLayerException;
-import org.eclipse.reddeer.eclipse.condition.ProblemExists;
-import org.eclipse.reddeer.eclipse.jst.servlet.ui.project.facet.WebProjectFirstPage;
-import org.eclipse.reddeer.eclipse.ui.navigator.resources.ProjectExplorer;
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
-import org.eclipse.reddeer.eclipse.ui.views.markers.ProblemsView.ProblemType;
 import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
 import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.eclipse.reddeer.swt.impl.combo.DefaultCombo;
 import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.wizard.template.CDIWebProjectWizardTemplate;
-import org.jboss.tools.cdi.reddeer.cdi.ui.CDIProjectWizard;
-import org.jboss.tools.cdi.reddeer.cdi.ui.wizard.facet.CDIInstallWizardPage;
-import org.junit.Test;
 
 /**
  * 
@@ -65,50 +49,5 @@ public class CDIWebProjectWizardTestCDI20 extends CDIWebProjectWizardTemplate{
 	
 	public CDIWebProjectWizardTestCDI20(){
 		CDIVersion = "2.0";
-	}
-	
-	//JBIDE-26643 | cdi2.0 does not contain the page for unchecking the "create beans.xml" option
-	@Test(expected = JBIDE26643Exception.class)
-	public void createCDIProjectWithoutBeansXmlCDI20() throws JBIDE26643Exception{
-		CDIProjectWizard cw = new CDIProjectWizard();
-		cw.open();
-		WebProjectFirstPage fp = new WebProjectFirstPage(cw);
-		fp.setProjectName(PROJECT_NAME);
-		if (CDIVersion.equals("2.0")) {
-			new DefaultCombo(2).setSelection("Dynamic Web Project with CDI 2.0 (Contexts and Dependency Injection)");
-		}
-		assertEquals(sr.getRuntimeName(),fp.getTargetRuntime());
-		assertEquals("Dynamic Web Project with CDI "+CDIVersion+" (Contexts and Dependency Injection)",fp.getConfiguration());
-		fp.activateFacet("1.8", "Java");
-		cw.next();
-		cw.next();
-		cw.next();
-		try {
-			CDIInstallWizardPage ip = new CDIInstallWizardPage(cw);
-			ip.toggleCreateBeansXml(false);
-		} catch (CoreLayerException e) {
-			cw.cancel();
-			throw new JBIDE26643Exception("'Create beans.xml' checkbox not found while using CDI 2.0.");
-		}
-		cw.finish();
-		isCDISupportEnabled(PROJECT_NAME);
-		isCDIFacetEnabled(PROJECT_NAME, CDIVersion);
-		ProjectExplorer pe = new ProjectExplorer();
-		pe.open();
-		assertTrue(pe.containsProject(PROJECT_NAME));
-		assertFalse(pe.getProject(PROJECT_NAME).containsResource("WebContent","WEB-INF","beans.xml"));
-		new WaitUntil(new ProblemExists(ProblemType.ALL), TimePeriod.LONG, false);
-		if (CDIVersion.equals("1.0")) {
-			assertTrue(new ProblemExists(ProblemType.ALL).test());	
-		} else {	
-			new WaitWhile(new ProblemExists(ProblemType.ALL));	
-		}
-	}
-	
-	class JBIDE26643Exception extends Exception {
-		
-		public JBIDE26643Exception(String message) {
-			super(message);
-		}
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/template/CDIWebProjectWizardTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/template/CDIWebProjectWizardTemplate.java
@@ -99,11 +99,15 @@ public class CDIWebProjectWizardTemplate{
 	
 	//cdi1.1+
 	//cd1.0 should show warning
+	@Test
 	public void createCDIProjectWithoutBeansXml(){
 		CDIProjectWizard cw = new CDIProjectWizard();
 		cw.open();
 		WebProjectFirstPage fp = new WebProjectFirstPage(cw);
 		fp.setProjectName(PROJECT_NAME);
+		if (CDIVersion.equals("2.0")) {
+			new DefaultCombo(2).setSelection("Dynamic Web Project with CDI 2.0 (Contexts and Dependency Injection)");
+		}
 		assertEquals(sr.getRuntimeName(),fp.getTargetRuntime());
 		assertEquals("Dynamic Web Project with CDI "+CDIVersion+" (Contexts and Dependency Injection)",fp.getConfiguration());
 		fp.activateFacet("1.8", "Java");


### PR DESCRIPTION
JBIDE-24963-2 - Create CDI 2.0 integration tests - step 2; following testclasses are added:
	- BeansXMLBeansEditorTestCDI20.class
	- BeansXMLValidationTestCDI20.class
	- BeansXMLValidationQuickFixTestCDI20.class

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>

@odockal  please review

Jira: https://issues.jboss.org/browse/JBIDE-24963
Jenkins: https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cdi20.itests/16/
<img width="334" alt="Snímek obrazovky 2019-06-03 v 20 24 04" src="https://user-images.githubusercontent.com/43820055/58824925-91473200-863d-11e9-809b-9f60996c183f.png">


