### PR TITLE
JBIDE-24963-3 - add new testclasses for CDI 2.0

### DIFF
--- a/plugins/org.jboss.tools.cdi.reddeer/src/org/jboss/tools/cdi/reddeer/common/model/ui/editor/EditorPartWrapper.java
+++ b/plugins/org.jboss.tools.cdi.reddeer/src/org/jboss/tools/cdi/reddeer/common/model/ui/editor/EditorPartWrapper.java
@@ -323,5 +323,15 @@ public class EditorPartWrapper extends AbstractEditor{
 		selectBeanXmlType("beans.xml");
 		return new DefaultText(new DefaultSection("Cdi Beans"), 0).isEnabled();
 	}
+	
+	public boolean isTrimItemAvailable(){
+		List<TreeItem> items = new DefaultTreeItem("beans.xml").getItems();
+		for (TreeItem item : items) {
+			if (item.getText().equals("trim")) {
+				return true;
+			}
+		}
+		return false;
+	}
 
 }

--- a/tests/org.jboss.tools.cdi.bot.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.cdi.bot.test/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Eclipse-BundleShape: jar
 Bundle-Localization: plugin
 Bundle-Vendor: Red Hat
+Import-Package: org.eclipse.jdt.ui.wizards

--- a/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/ApplicationScoped.java
+++ b/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/ApplicationScoped.java
@@ -1,0 +1,8 @@
+package package1;
+
+import javax.enterprise.context.*;
+
+@ApplicationScoped
+public class TestBean {
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/ConversationScoped.java
+++ b/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/ConversationScoped.java
@@ -1,0 +1,8 @@
+package package1;
+
+import javax.enterprise.context.*;
+
+@ConversationScoped
+public class TestBean {
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/Decorator.java
+++ b/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/Decorator.java
@@ -1,0 +1,8 @@
+package package1;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class TestBean implements TestInterface {
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/DefaultTest.java
+++ b/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/DefaultTest.java
@@ -1,0 +1,8 @@
+package package1;
+
+import javax.inject.Inject;
+
+public class Test {
+@Inject TestBean bean;
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/DefaultTestBean.java
+++ b/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/DefaultTestBean.java
@@ -1,0 +1,5 @@
+package package1;
+
+public class TestBean {
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/Dependent.java
+++ b/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/Dependent.java
@@ -1,0 +1,8 @@
+package package1;
+
+import javax.enterprise.context.Dependent;
+
+@Dependent
+public class TestBean {
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/RequestScoped.java
+++ b/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/RequestScoped.java
@@ -1,0 +1,8 @@
+package package1;
+
+import javax.enterprise.context.*;
+
+@RequestScoped
+public class TestBean {
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/SessionScoped.java
+++ b/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/SessionScoped.java
@@ -1,0 +1,8 @@
+package package1;
+
+import javax.enterprise.context.*;
+
+@SessionScoped
+public class TestBean {
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/Singleton.java
+++ b/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/Singleton.java
@@ -1,0 +1,8 @@
+package package1;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class TestBean {
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/TestDecorator.java
+++ b/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/TestDecorator.java
@@ -1,0 +1,11 @@
+package package1;
+
+import javax.inject.Inject;
+import javax.decorator.Decorator;
+import javax.decorator.Delegate;
+
+@Decorator
+public class Test implements TestInterface {
+@Inject @Delegate TestInterface bean;
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/TestInterceptor.java
+++ b/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/TestInterceptor.java
@@ -1,0 +1,12 @@
+package package1;
+
+import javax.inject.Inject;
+import javax.interceptor.Interceptors;
+
+public class Test {
+@Inject TestBean bean;
+
+@Interceptors(TestInterceptor.class)
+public void testBeanMethod() {}
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/TestStereotype.java
+++ b/tests/org.jboss.tools.cdi.bot.test/resources/trimTestsExampleFiles/TestStereotype.java
@@ -1,0 +1,13 @@
+package package1;
+
+import javax.inject.Inject;
+import javax.decorator.Decorator;
+import javax.decorator.Delegate;
+import javax.inject.Inject;
+import javax.interceptor.Interceptors;
+
+@TestStereotype
+public class Test {
+@Inject TestBean bean;
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDI20SuiteTest.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDI20SuiteTest.java
@@ -12,6 +12,7 @@ package org.jboss.tools.cdi.bot.test;
 
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.tools.cdi.bot.test.beans.bean.cdi20.AsYouTypeValidationTestCDI20;
+import org.jboss.tools.cdi.bot.test.beans.bean.cdi20.BeanValidationQuickFixTestCDI20;
 import org.jboss.tools.cdi.bot.test.beans.bean.cdi20.NullValuesInjectionTestCDI20;
 import org.jboss.tools.cdi.bot.test.beans.bean.cdi20.VetoedAnnotationTestCDI20;
 import org.jboss.tools.cdi.bot.test.beans.decorator.cdi20.DecoratorFromWebBeanTestCDI20;
@@ -30,13 +31,16 @@ import org.jboss.tools.cdi.bot.test.beans.stereotype.cdi20.StereotypeValidationQ
 import org.jboss.tools.cdi.bot.test.beansxml.annotation.cdi20.BeanParametersAnnotationTestCDI20;
 import org.jboss.tools.cdi.bot.test.beansxml.bean.cdi20.ExcludeBeanTestCDI20;
 import org.jboss.tools.cdi.bot.test.beansxml.cdi20.BeansXMLBeansEditorTestCDI20;
+import org.jboss.tools.cdi.bot.test.beansxml.cdi20.BeansXMLDiscoveryModesTestCDI20;
 import org.jboss.tools.cdi.bot.test.beansxml.cdi20.BeansXMLUITestCDI20;
 import org.jboss.tools.cdi.bot.test.beansxml.cdi20.BeansXMLValidationTestCDI20;
+import org.jboss.tools.cdi.bot.test.beansxml.completion.cdi20.BeansXMLCompletionTestCDI20;
 import org.jboss.tools.cdi.bot.test.beansxml.discovery.cdi20.BeanDiscoveryInExplicitArchivesTestCDI20;
 import org.jboss.tools.cdi.bot.test.beansxml.discovery.cdi20.BeanDiscoveryInImplicitArchivesTestCDI20;
 import org.jboss.tools.cdi.bot.test.beansxml.openon.cdi20.BeansXMLOpenOnTestCDI20;
 import org.jboss.tools.cdi.bot.test.beansxml.validation.cdi20.BeansXMLAsYouTypeValidationTestCDI20;
 import org.jboss.tools.cdi.bot.test.beansxml.validation.cdi20.BeansXMLValidationQuickFixTestCDI20;
+import org.jboss.tools.cdi.bot.test.validation.cdi20.CDIValidatorTestCDI20;
 import org.jboss.tools.cdi.bot.test.weld.cdi20.WeldBuiltInContextsTestCDI20;
 import org.jboss.tools.cdi.bot.test.weld.cdi20.WeldExcludeTestCDI20;
 import org.jboss.tools.cdi.bot.test.weld.cdi20.WeldParametersAnnotationTestCDI20;
@@ -89,6 +93,10 @@ import org.junit.runners.Suite.SuiteClasses;
 	WeldExcludeTestCDI20.class,
 	WeldParametersAnnotationTestCDI20.class,
 	WeldScanTestCDI20.class,
+	BeanValidationQuickFixTestCDI20.class,
+	BeansXMLCompletionTestCDI20.class,
+	CDIValidatorTestCDI20.class,
+	BeansXMLDiscoveryModesTestCDI20.class,
 })
 public class CDI20SuiteTest {
 

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDITestBase.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDITestBase.java
@@ -26,9 +26,11 @@ import org.eclipse.reddeer.common.wait.WaitUntil;
 import org.eclipse.reddeer.common.wait.WaitWhile;
 import org.eclipse.reddeer.core.lookup.ShellLookup;
 import org.eclipse.reddeer.eclipse.core.resources.Project;
+import org.eclipse.reddeer.eclipse.jdt.ui.wizards.AbstractJavaWizardPage;
 import org.eclipse.reddeer.eclipse.jdt.ui.wizards.NewClassCreationWizard;
-import org.eclipse.reddeer.eclipse.jdt.ui.wizards.NewClassWizardPage;
+import org.eclipse.reddeer.eclipse.jdt.ui.wizards.NewInterfaceCreationWizard;
 import org.eclipse.reddeer.eclipse.jst.servlet.ui.project.facet.WebProjectFirstPage;
+import org.eclipse.reddeer.eclipse.selectionwizard.NewMenuWizard;
 import org.eclipse.reddeer.eclipse.ui.navigator.resources.ProjectExplorer;
 import org.eclipse.reddeer.junit.requirement.inject.InjectRequirement;
 import org.eclipse.reddeer.swt.condition.ShellIsAvailable;
@@ -42,6 +44,8 @@ import org.eclipse.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement;
 import org.jboss.tools.cdi.reddeer.CDIConstants;
 import org.jboss.tools.cdi.reddeer.cdi.ui.CDIProjectWizard;
+import org.jboss.tools.cdi.reddeer.cdi.ui.NewInterceptorCreationWizard;
+import org.jboss.tools.cdi.reddeer.cdi.ui.NewStereotypeCreationWizard;
 import org.jboss.tools.cdi.reddeer.common.model.ui.editor.EditorPartWrapper;
 import org.jboss.tools.cdi.reddeer.uiutils.BeansHelper;
 import org.jboss.tools.cdi.reddeer.uiutils.BeansXMLHelper;
@@ -153,15 +157,38 @@ public class CDITestBase {
 		}
 	}
 	
-	protected void createClass(String project, String packageName, String className) {
+	protected void createNewClass(String project, String packageName, String className) {
+		NewClassCreationWizard c = new NewClassCreationWizard();
+		AbstractJavaWizardPage page = new AbstractJavaWizardPage(c) {};
+		createNewProjectFile(project, packageName, className, c, page);
+	}
+
+	protected void createNewInterface(String project, String packageName, String interfaceName) {
+		NewInterfaceCreationWizard c = new NewInterfaceCreationWizard();
+		AbstractJavaWizardPage page = new AbstractJavaWizardPage(c) {};
+		createNewProjectFile(project, packageName, interfaceName, c, page);
+	}
+
+	protected void createNewInterceptor(String project, String packageName, String interceptorName) {
+		NewInterceptorCreationWizard c = new NewInterceptorCreationWizard();
+		AbstractJavaWizardPage page = new AbstractJavaWizardPage(c) {};
+		createNewProjectFile(project, packageName, interceptorName, c, page);
+	}
+
+	protected void createNewStereotype(String project, String packageName, String stereotypeName) {
+		NewStereotypeCreationWizard c = new NewStereotypeCreationWizard();
+		AbstractJavaWizardPage page = new AbstractJavaWizardPage(c) {};
+		createNewProjectFile(project, packageName, stereotypeName, c, page);
+	}
+
+	protected void createNewProjectFile(String project, String packageName, String fileName, NewMenuWizard c,
+			AbstractJavaWizardPage page) {
 		ProjectExplorer pe = new ProjectExplorer();
 		pe.open();
 		pe.selectProjects(project);
-		NewClassCreationWizard c = new NewClassCreationWizard();
 		c.open();
-		NewClassWizardPage page = new NewClassWizardPage(c);
 		page.setPackage(packageName);
-		page.setName(className);
+		page.setName(fileName);
 		c.finish();
 	}
 
@@ -244,8 +271,8 @@ public class CDITestBase {
 	}
 	
 	public void setupProject(Map<Integer, String> valuesToInsertIntoTextEditor) {
-		createClass(PROJECT_NAME, "test", CDI_BEAN_1_JAVA_FILE_NAME);
-		createClass(PROJECT_NAME, "test", CDI_BEAN_2_JAVA_FILE_NAME);
+		createNewClass(PROJECT_NAME, "test", CDI_BEAN_1_JAVA_FILE_NAME);
+		createNewClass(PROJECT_NAME, "test", CDI_BEAN_2_JAVA_FILE_NAME);
 		ProjectExplorer pe = new ProjectExplorer();
 		pe.open();
 		pe.getProject(PROJECT_NAME).getProjectItem(CDIConstants.JAVA_RESOURCES, CDIConstants.SRC, "test",

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi20/BeanValidationQuickFixTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi20/BeanValidationQuickFixTestCDI20.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.bot.test.beans.bean.cdi20;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
+import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
+import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
+import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
+import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
+import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
+import org.jboss.tools.cdi.bot.test.beans.bean.template.BeanValidationQuickFixTemplate;
+import org.jboss.tools.cdi.reddeer.validators.BeanValidationProvider;
+import org.junit.Before;
+
+/**
+ *
+ * @author zcervink@redhat.com
+ *
+ */
+@JRE(cleanup=true)
+@JBossServer(state = ServerRequirementState.PRESENT, cleanup = false)
+@OpenPerspective(JavaEEPerspective.class)
+public class BeanValidationQuickFixTestCDI20 extends BeanValidationQuickFixTemplate {
+
+	@RequirementRestriction
+	public static Collection<RequirementMatcher> getRestrictionMatcher() {
+		if (isJavaLE8()) {
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
+		} else {
+			return Arrays.asList(
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
+		}
+	}
+
+	public BeanValidationQuickFixTestCDI20() {
+		CDIVersion = "2.0";
+	}
+
+	@Before
+	public void changeDiscoveryMode() {
+		validationProvider = new BeanValidationProvider("JSR-365");
+		prepareBeanXml("all", true);
+	}
+}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/template/BeanValidationQuickFixTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/template/BeanValidationQuickFixTemplate.java
@@ -16,8 +16,12 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
+import org.eclipse.reddeer.common.wait.TimePeriod;
+import org.eclipse.reddeer.common.wait.WaitWhile;
 import org.eclipse.reddeer.eclipse.ui.navigator.resources.ProjectExplorer;
 import org.eclipse.reddeer.eclipse.ui.problems.Problem;
+import org.eclipse.reddeer.swt.impl.menu.ContextMenuItem;
+import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
 import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.reddeer.CDIConstants;
 import org.jboss.tools.cdi.reddeer.annotation.ValidationType;
@@ -182,6 +186,11 @@ public class BeanValidationQuickFixTemplate extends CDITestBase {
 	
 	private void createBean(String className, String content){
 		beansHelper.createBean(className, getPackageName(), false, false, false, false, false, false, false, null, null);
+		ProjectExplorer pe = new ProjectExplorer();
+		pe.activate();
+		pe.selectAllProjects();
+		new ContextMenuItem("Refresh").select();
+		new WaitWhile(new JobIsRunning(), TimePeriod.MEDIUM);
 		editResourceUtil.replaceClassContentByResource(className+".java", readFile(content), false);
 		editResourceUtil.replaceInEditor(className+".java","BeanComponent", className);		
 	}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi20/BeansXMLDiscoveryModesTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi20/BeansXMLDiscoveryModesTestCDI20.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.bot.test.beansxml.cdi20;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
+import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
+import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
+import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
+import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
+import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
+import org.jboss.tools.cdi.bot.test.beansxml.template.BeansXMLDiscoveryModesTemplate;
+
+/**
+*
+* @author zcervink@redhat.com
+*
+*/
+@JRE(cleanup=true)
+@OpenPerspective(JavaEEPerspective.class)
+@JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
+public class BeansXMLDiscoveryModesTestCDI20 extends BeansXMLDiscoveryModesTemplate {
+
+	@RequirementRestriction
+	public static Collection<RequirementMatcher> getRestrictionMatcher() {
+		if (isJavaLE8()) {
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
+		} else {
+			return Arrays.asList(
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
+		}
+	}
+
+	public BeansXMLDiscoveryModesTestCDI20() {
+		CDIVersion = "2.0";
+	}
+}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/completion/cdi20/BeansXMLCompletionTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/completion/cdi20/BeansXMLCompletionTestCDI20.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package org.jboss.tools.cdi.bot.test.beansxml.completion.cdi20;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
+import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
+import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
+import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
+import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
+import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
+import org.jboss.tools.cdi.bot.test.beansxml.completion.template.BeansXMLCompletionTemplate;
+import org.junit.Before;
+
+/**
+*
+* @author zcervink@redhat.com
+*
+*/
+@JRE(cleanup=true)
+@JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
+@OpenPerspective(JavaEEPerspective.class)
+public class BeansXMLCompletionTestCDI20 extends BeansXMLCompletionTemplate {
+
+	@RequirementRestriction
+	public static Collection<RequirementMatcher> getRestrictionMatcher() {
+		if (isJavaLE8()) {
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
+		} else {
+			return Arrays.asList(
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
+		}
+	}
+
+	public BeansXMLCompletionTestCDI20() {
+		CDIVersion = "2.0";
+	}
+
+	@Before
+	public void changeDiscoveryMode(){
+		prepareBeanXml("all", true);
+		setBeansXmlTags(Arrays.asList("alternatives", "decorators", "interceptors","scan", "trim"));
+	}
+}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/template/BeansXMLDiscoveryModesTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/template/BeansXMLDiscoveryModesTemplate.java
@@ -76,7 +76,13 @@ public class BeansXMLDiscoveryModesTemplate extends CDITestBase{
 		new WaitUntil(new EditorHasValidationMarkers(ed, 7));
 		markers = ed.getMarkers();
 		assertEquals(1,markers.size());
-		assertEquals("No bean is eligible for injection to the injection point [JSR-346 §5.2.2]",markers.get(0).getText());
+		if ("2.0".equals(CDIVersion)) {
+			assertEquals("No bean is eligible for injection to the injection point [JSR-365 §5.2.2]",
+					markers.get(0).getText());
+		} else {
+			assertEquals("No bean is eligible for injection to the injection point [JSR-346 §5.2.2]",
+					markers.get(0).getText());
+		}
 		assertEquals(7,markers.get(0).getLineNumber());
 		
 		ed = new TextEditor("Bean2.java");
@@ -118,7 +124,13 @@ public class BeansXMLDiscoveryModesTemplate extends CDITestBase{
 		new WaitUntil(new EditorHasValidationMarkers(ed,7));
 		markers = ed.getMarkers();
 		assertEquals(1,markers.size());
-		assertEquals("No bean is eligible for injection to the injection point [JSR-346 §5.2.2]",markers.get(0).getText());
+		if ("2.0".equals(CDIVersion)) {
+			assertEquals("No bean is eligible for injection to the injection point [JSR-365 §5.2.2]",
+					markers.get(0).getText());
+		} else {
+			assertEquals("No bean is eligible for injection to the injection point [JSR-346 §5.2.2]",
+					markers.get(0).getText());
+		}
 		assertEquals(7,markers.get(0).getLineNumber());
 		
 		ed = new TextEditor("Bean2.java");

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/validation/cdi20/CDIValidatorTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/validation/cdi20/CDIValidatorTestCDI20.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.bot.test.validation.cdi20;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
+import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
+import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
+import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
+import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
+import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
+import org.jboss.tools.cdi.bot.test.validation.template.CDIValidatorTemplate;
+import org.junit.Before;
+
+/**
+*
+* @author zcervink@redhat.com
+*
+*/
+@JRE(cleanup=true)
+@JBossServer(state = ServerRequirementState.PRESENT, cleanup=false)
+@OpenPerspective(JavaEEPerspective.class)
+public class CDIValidatorTestCDI20 extends CDIValidatorTemplate{
+
+	@RequirementRestriction
+	public static Collection<RequirementMatcher> getRestrictionMatcher() {
+		if (isJavaLE8()) {
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
+		} else {
+			return Arrays.asList(
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
+		}
+	}
+
+	public CDIValidatorTestCDI20() {
+		CDIVersion = "2.0";
+	}
+
+	@Before
+	public void changeDiscoveryMode(){
+		prepareBeanXml("all", true);
+	}
+
+}


### PR DESCRIPTION
**JBIDE-24963-3 - update CDI to 2.0; adds those classes:**
- BeanValidationQuickFixTestCDI20.class
- BeansXMLCompletionTestCDI20.class
- CDIValidatorTestCDI20.class
- BeansXMLDiscoveryModesTestCDI20.class

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>

Jenkins: https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cdi20.itests/29/
Jira: https://issues.jboss.org/browse/JBIDE-24963
