### PR TITLE
JBIDE-24963-4 - add new testclasses for CDI 2.0

### DIFF
--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDI20SuiteTest.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDI20SuiteTest.java
@@ -11,6 +11,9 @@
 package org.jboss.tools.cdi.bot.test;
 
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.tools.cdi.bot.test.beans.bean.cdi20.AsYouTypeValidationTestCDI20;
+import org.jboss.tools.cdi.bot.test.beans.dialog.cdi20.AllAssignableDialogTestCDI20;
+import org.jboss.tools.cdi.bot.test.beans.dialog.cdi20.AssignableDialogFilterTestCDI20;
 import org.jboss.tools.cdi.bot.test.beans.named.cdi20.NamedComponentsSearchingTestCDI20;
 import org.jboss.tools.cdi.bot.test.beans.openon.cdi20.BeanInjectOpenOnTestCDI20;
 import org.jboss.tools.cdi.bot.test.beans.openon.cdi20.FindObserverEventTestCDI20;
@@ -35,6 +38,9 @@ import org.junit.runners.Suite.SuiteClasses;
 	BeansXMLBeansEditorTestCDI20.class,
 	BeansXMLValidationTestCDI20.class,
 	BeansXMLValidationQuickFixTestCDI20.class,
+	AllAssignableDialogTestCDI20.class,
+	AssignableDialogFilterTestCDI20.class,
+	AsYouTypeValidationTestCDI20.class,
 })
 public class CDI20SuiteTest {
 

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi20/AsYouTypeValidationTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi20/AsYouTypeValidationTestCDI20.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.bot.test.beans.bean.cdi20;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
+import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
+import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
+import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
+import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
+import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
+import org.jboss.tools.cdi.bot.test.beans.bean.template.AsYouTypeValidationTemplate;
+import org.junit.Before;
+
+@JRE(cleanup=true)
+@JBossServer(state = ServerRequirementState.PRESENT, cleanup = false)
+@OpenPerspective(JavaEEPerspective.class)
+public class AsYouTypeValidationTestCDI20 extends AsYouTypeValidationTemplate {
+
+	@RequirementRestriction
+	public static Collection<RequirementMatcher> getRestrictionMatcher() {
+		if (isJavaLE8()) { 
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
+		} else {
+			return Arrays.asList(
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
+		}
+	}
+	
+	public AsYouTypeValidationTestCDI20() {
+		CDIVersion = "2.0";
+	}
+
+	@Before
+	public void prepareBeans() {
+		prepareBeanXml("all", true);
+	}
+}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi20/AllAssignableDialogTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi20/AllAssignableDialogTestCDI20.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.bot.test.beans.dialog.cdi20;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
+import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
+import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
+import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
+import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
+import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
+import org.jboss.tools.cdi.bot.test.beans.dialog.template.AllAssignableDialogTemplate;
+import org.junit.Before;
+
+@JRE(cleanup=true)
+@JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
+@OpenPerspective(JavaEEPerspective.class)
+public class AllAssignableDialogTestCDI20 extends AllAssignableDialogTemplate {
+
+	@RequirementRestriction
+	public static Collection<RequirementMatcher> getRestrictionMatcher() {
+		if (isJavaLE8()) { 
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
+		} else {
+			return Arrays.asList(
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
+		}
+	}
+	
+	public AllAssignableDialogTestCDI20() {
+		CDIVersion = "2.0";
+	}
+	
+	@Before
+	public void prepareBeansXML() {
+		prepareBeanXml("all", true);
+	}
+	
+}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi20/AssignableDialogFilterTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi20/AssignableDialogFilterTestCDI20.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.bot.test.beans.dialog.cdi20;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
+import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
+import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
+import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
+import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
+import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
+import org.jboss.tools.cdi.bot.test.beans.dialog.template.AssignableDialogFilterTemplate;
+import org.junit.Before;
+
+@JRE(cleanup=true)
+@JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
+@OpenPerspective(JavaEEPerspective.class)
+public class AssignableDialogFilterTestCDI20 extends AssignableDialogFilterTemplate{
+
+	@RequirementRestriction
+	public static Collection<RequirementMatcher> getRestrictionMatcher() {
+		if (isJavaLE8()) { 
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
+		} else {
+			return Arrays.asList(
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
+		}
+	}
+	
+	public AssignableDialogFilterTestCDI20() {
+		CDIVersion = "2.0";
+	}
+		
+	@Before
+	public void prepareBeansXML() {
+		prepareBeanXml("all", true);
+	}
+
+}


### PR DESCRIPTION
**JBIDE-24963-4 - Add the following testclasses:** 
- AllAssignableDialogTestCDI20
 - AssignableDialogFilterTestCDI20
 - AsYouTypeValidationTestCDI20

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>

**Jenkins**: https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cdi20.itests/70/
**Jira**: https://issues.jboss.org/browse/JBIDE-24963

please review @jkopriva 
