### PR TITLE
JBIDE-24963-9 - add new testclasses for CDI 2.0

### DIFF
--- a/plugins/org.jboss.tools.cdi.reddeer/src/org/jboss/tools/cdi/reddeer/validators/ScopeValidationProviderCDI20.java
+++ b/plugins/org.jboss.tools.cdi.reddeer/src/org/jboss/tools/cdi/reddeer/validators/ScopeValidationProviderCDI20.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package org.jboss.tools.cdi.reddeer.validators;
+
+import java.util.Arrays;
+
+import org.eclipse.reddeer.eclipse.ui.views.markers.ProblemsView.ProblemType;
+import org.jboss.tools.cdi.reddeer.annotation.ValidationType;
+
+/** 
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
+public class ScopeValidationProviderCDI20 extends AbstractValidationProvider {
+	
+	private static final String JSR = "JSR-365"; 
+
+	public ScopeValidationProviderCDI20() {
+		super();
+	}
+	
+	@Override
+	void init() {
+		
+		problems.add(new ValidationProblem(ProblemType.WARNING, ValidationType.RETENTION, 
+				"Scope annotation type must be annotated with @Retention(RUNTIME)",JSR,
+				Arrays.asList("to @Retention(RUNTIME)")));
+		
+		problems.add(new ValidationProblem(ProblemType.WARNING, ValidationType.NO_RETENTION, 
+				"Scope annotation type must be annotated with @Retention(RUNTIME)",JSR,
+				Arrays.asList("Add annotation @Retention(RUNTIME) to class")));
+		
+		problems.add(new ValidationProblem(ProblemType.WARNING, ValidationType.TARGET,
+				"Scope annotation type must be annotated with @Target({TYPE, METHOD, FIELD})",JSR,null));
+		
+		problems.add(new ValidationProblem(ProblemType.WARNING, ValidationType.NO_TARGET,
+				"Scope annotation type must be annotated with @Target({TYPE, METHOD, FIELD})",JSR,null));
+		
+			
+	}
+	
+}

--- a/plugins/org.jboss.tools.cdi.reddeer/src/org/jboss/tools/cdi/reddeer/validators/StereotypeValidationProviderCDI20.java
+++ b/plugins/org.jboss.tools.cdi.reddeer/src/org/jboss/tools/cdi/reddeer/validators/StereotypeValidationProviderCDI20.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package org.jboss.tools.cdi.reddeer.validators;
+
+import java.util.Arrays;
+
+import org.eclipse.reddeer.eclipse.ui.views.markers.ProblemsView.ProblemType;
+import org.jboss.tools.cdi.reddeer.annotation.ValidationType;
+
+/** 
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
+public class StereotypeValidationProviderCDI20 extends AbstractValidationProvider {
+	
+	private static final String JSR = "JSR-365"; 
+	
+	public StereotypeValidationProviderCDI20() {
+		super();
+	}
+	
+	@Override
+	void init() {
+		
+		problems.add(new ValidationProblem(ProblemType.WARNING, ValidationType.TARGET, 
+				"Stereotype annotation type must be annotated with one of", JSR, null));
+		
+		problems.add(new ValidationProblem(ProblemType.WARNING, ValidationType.RETENTION,
+				"Stereotype annotation type must be annotated with @Retention(RUNTIME)", JSR, 
+				Arrays.asList("to @Retention(RUNTIME)")));
+		
+		problems.add(new ValidationProblem(ProblemType.WARNING, ValidationType.NO_RETENTION,
+				"Stereotype annotation type must be annotated with @Retention(RUNTIME)", JSR, 
+				Arrays.asList("Add annotation @Retention(RUNTIME) to class")));
+		
+		problems.add(new ValidationProblem(ProblemType.WARNING, ValidationType.TYPED,
+				"A stereotype should not be annotated @Typed", JSR, Arrays.asList(
+				"Delete annotation @Typed")));
+		
+		problems.add(new ValidationProblem(ProblemType.ERROR, ValidationType.NAMED, 
+				"Stereotype declares a non-empty @Named annotation", JSR, Arrays.asList(
+				"to @Named")));
+						
+	}
+		
+}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDI20SuiteTest.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDI20SuiteTest.java
@@ -12,11 +12,14 @@ package org.jboss.tools.cdi.bot.test;
 
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.tools.cdi.bot.test.beans.bean.cdi20.AsYouTypeValidationTestCDI20;
+import org.jboss.tools.cdi.bot.test.beans.bean.cdi20.VetoedAnnotationTestCDI20;
 import org.jboss.tools.cdi.bot.test.beans.dialog.cdi20.AllAssignableDialogTestCDI20;
 import org.jboss.tools.cdi.bot.test.beans.dialog.cdi20.AssignableDialogFilterTestCDI20;
 import org.jboss.tools.cdi.bot.test.beans.named.cdi20.NamedComponentsSearchingTestCDI20;
 import org.jboss.tools.cdi.bot.test.beans.openon.cdi20.BeanInjectOpenOnTestCDI20;
 import org.jboss.tools.cdi.bot.test.beans.openon.cdi20.FindObserverEventTestCDI20;
+import org.jboss.tools.cdi.bot.test.beans.scope.cdi20.ScopeValidationQuickFixTestCDI20;
+import org.jboss.tools.cdi.bot.test.beans.stereotype.cdi20.StereotypeValidationQuickFixTestCDI20;
 import org.jboss.tools.cdi.bot.test.beansxml.annotation.cdi20.BeanParametersAnnotationTestCDI20;
 import org.jboss.tools.cdi.bot.test.beansxml.cdi20.BeansXMLBeansEditorTestCDI20;
 import org.jboss.tools.cdi.bot.test.beansxml.cdi20.BeansXMLUITestCDI20;
@@ -27,6 +30,7 @@ import org.jboss.tools.cdi.bot.test.beansxml.openon.cdi20.BeansXMLOpenOnTestCDI2
 import org.jboss.tools.cdi.bot.test.beansxml.validation.cdi20.BeansXMLAsYouTypeValidationTestCDI20;
 import org.jboss.tools.cdi.bot.test.beansxml.validation.cdi20.BeansXMLValidationQuickFixTestCDI20;
 import org.jboss.tools.cdi.bot.test.wizard.cdi20.CDIWebProjectWizardTestCDI20;
+import org.jboss.tools.cdi.bot.test.wizard.cdi20.UtilityProjectWithCDITestCDI20;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite.SuiteClasses;
 
@@ -53,6 +57,10 @@ import org.junit.runners.Suite.SuiteClasses;
 	BeanDiscoveryInExplicitArchivesTestCDI20.class,
 	BeanDiscoveryInImplicitArchivesTestCDI20.class,
 	BeanParametersAnnotationTestCDI20.class,
+	ScopeValidationQuickFixTestCDI20.class,
+	StereotypeValidationQuickFixTestCDI20.class,
+	UtilityProjectWithCDITestCDI20.class,
+	VetoedAnnotationTestCDI20.class,
 })
 public class CDI20SuiteTest {
 

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi20/VetoedAnnotationTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi20/VetoedAnnotationTestCDI20.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.bot.test.beans.bean.cdi20;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
+import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
+import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
+import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
+import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
+import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
+import org.jboss.tools.cdi.bot.test.beans.bean.template.VetoedAnnotationTemplate;
+
+/** 
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
+@JRE(cleanup=true)
+@JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
+@OpenPerspective(JavaEEPerspective.class)
+public class VetoedAnnotationTestCDI20 extends VetoedAnnotationTemplate{
+
+	@RequirementRestriction
+	public static Collection<RequirementMatcher> getRestrictionMatcher() {
+		if (isJavaLE8()) { 
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
+		} else {
+			return Arrays.asList(
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
+		}
+	}
+	
+	public VetoedAnnotationTestCDI20() {
+		CDIVersion = "2.0";
+	}
+}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/template/VetoedAnnotationTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/template/VetoedAnnotationTemplate.java
@@ -49,7 +49,7 @@ public class VetoedAnnotationTemplate extends CDITestBase{
 		TextEditor te = new TextEditor("Injector.java");
 		AbstractWait.sleep(TimePeriod.DEFAULT);
 		String warning = "org.eclipse.ui.workbench.texteditor.warning";
-		String noInjection = "No bean is eligible for injection to the injection point [JSR-346 §5.2.2]";
+		String noInjection = CDIVersion.equals("2.0") ? "No bean is eligible for injection to the injection point [JSR-365 §5.2.2]" : "No bean is eligible for injection to the injection point [JSR-346 §5.2.2]";
 		List<Marker> markers = te.getMarkers();
 		assertEquals(5, markers.size());
 		for(Marker m: te.getMarkers()){

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/scope/cdi20/ScopeValidationQuickFixTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/scope/cdi20/ScopeValidationQuickFixTestCDI20.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.bot.test.beans.scope.cdi20;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
+import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
+import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
+import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
+import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
+import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
+import org.jboss.tools.cdi.bot.test.beans.scope.template.ScopeValidationQuickFixTemplate;
+import org.jboss.tools.cdi.reddeer.validators.ScopeValidationProviderCDI20;
+import org.junit.Before;
+
+/** 
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
+@JRE(cleanup=true)
+@JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
+@OpenPerspective(JavaEEPerspective.class)
+public class ScopeValidationQuickFixTestCDI20 extends ScopeValidationQuickFixTemplate{
+
+	@RequirementRestriction
+	public static Collection<RequirementMatcher> getRestrictionMatcher() {
+		if (isJavaLE8()) { 
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
+		} else {
+			return Arrays.asList(
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
+		}
+	}
+	
+	public ScopeValidationQuickFixTestCDI20() {
+		CDIVersion = "2.0";
+	}
+	
+	@Before
+	public void changeDiscoveryMode(){
+		validationProvider = new ScopeValidationProviderCDI20();
+		prepareBeanXml("all", true);
+	}
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/scope/template/ScopeValidationQuickFixTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/scope/template/ScopeValidationQuickFixTemplate.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 public class ScopeValidationQuickFixTemplate extends CDITestBase {
 	
 	protected IValidationProvider validationProvider;
-	protected String CDIVersion;
 
 	public IValidationProvider validationProvider() {
 		return validationProvider;

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/stereotype/cdi20/StereotypeValidationQuickFixTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/stereotype/cdi20/StereotypeValidationQuickFixTestCDI20.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.bot.test.beans.stereotype.cdi20;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
+import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
+import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
+import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
+import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
+import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
+import org.jboss.tools.cdi.bot.test.beans.stereotype.template.StereotypeValidationQuickFixTemplate;
+import org.jboss.tools.cdi.reddeer.validators.StereotypeValidationProviderCDI20;
+import org.junit.Before;
+
+/** 
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
+@JRE(cleanup=true)
+@JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
+@OpenPerspective(JavaEEPerspective.class)
+public class StereotypeValidationQuickFixTestCDI20 extends StereotypeValidationQuickFixTemplate{
+
+	@RequirementRestriction
+	public static Collection<RequirementMatcher> getRestrictionMatcher() {
+		if (isJavaLE8()) { 
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
+		} else {
+			return Arrays.asList(
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
+		}
+	}
+	
+	public StereotypeValidationQuickFixTestCDI20() {
+		CDIVersion = "2.0";
+	}
+	
+	@Before
+	public void changeDiscoveryMode(){
+		validationProvider = new StereotypeValidationProviderCDI20();
+		prepareBeanXml("all", true);
+	}
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/stereotype/template/StereotypeValidationQuickFixTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/stereotype/template/StereotypeValidationQuickFixTemplate.java
@@ -35,8 +35,7 @@ import org.junit.Test;
  */
 public class StereotypeValidationQuickFixTemplate extends CDITestBase {
 	
-	public static IValidationProvider validationProvider;
-	protected String CDIVersion;
+	public IValidationProvider validationProvider;
 
 	public IValidationProvider validationProvider() {
 		return validationProvider;

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi20/UtilityProjectWithCDITestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi20/UtilityProjectWithCDITestCDI20.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.bot.test.wizard.cdi20;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.reddeer.eclipse.jst.j2ee.ui.project.facet.UtilityProjectFirstPage;
+import org.eclipse.reddeer.eclipse.jst.j2ee.ui.project.facet.UtilityProjectWizard;
+import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
+import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
+import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
+import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
+import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
+import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
+import org.jboss.tools.cdi.bot.test.CDITestBase;
+import org.jboss.tools.cdi.bot.test.wizard.template.ProjectWithCDITemplate;
+import org.junit.Before;
+
+/** 
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
+@JRE(cleanup=true)
+@OpenPerspective(JavaEEPerspective.class)
+@JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
+public class UtilityProjectWithCDITestCDI20 extends ProjectWithCDITemplate{
+
+	@RequirementRestriction
+	public static Collection<RequirementMatcher> getRestrictionMatcher() {
+		if (CDITestBase.isJavaLE8()) { 
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
+		} else {
+			return Arrays.asList(
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
+		}
+	}
+	
+	public UtilityProjectWithCDITestCDI20(){
+		enabledByDefault = true;
+		PROJECT_NAME = "UtilityProject";
+		CDIVersion = "2.0";
+	}
+	
+	@Before
+	public void createUtilityProject(){
+		UtilityProjectWizard uw = new UtilityProjectWizard();
+		uw.open();
+		UtilityProjectFirstPage up = new UtilityProjectFirstPage(uw);
+		up.setProjectName(PROJECT_NAME);
+		up.activateFacet("1.8", "Java");
+		uw.finish();
+	}
+
+}


### PR DESCRIPTION
JBIDE-24963-9 - Add new testclasses:
 - ScopeValidationQuickFixTestCDI20
 - StereotypeValidationQuickFixTestCDI20
 - UtilityProjectWithCDITestCDI20
 - VetoedAnnotationTestCDI20

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>

**Jenkins:** https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cdi20.itests/91/
**Jira:** https://issues.jboss.org/browse/JBIDE-24963

please review @odockal @jkopriva 
