### PR TITLE
JBIDE-24963-5 - add new testclasses for CDI 2.0

### DIFF
--- a/plugins/org.jboss.tools.cdi.reddeer/src/org/jboss/tools/cdi/reddeer/validators/BeansXmlUIValidationProvider.java
+++ b/plugins/org.jboss.tools.cdi.reddeer/src/org/jboss/tools/cdi/reddeer/validators/BeansXmlUIValidationProvider.java
@@ -13,12 +13,13 @@ package org.jboss.tools.cdi.reddeer.validators;
 import org.eclipse.reddeer.eclipse.ui.views.markers.ProblemsView.ProblemType;
 import org.jboss.tools.cdi.reddeer.annotation.ValidationType;
 
-public class BeansXmlUIValidationProviderCDI11 extends AbstractValidationProvider {
+public class BeansXmlUIValidationProvider extends AbstractValidationProvider {
 	
-	private final String jsr = "JSR-346";
-	
-	public BeansXmlUIValidationProviderCDI11() {
+	private String jsr;
+
+	public BeansXmlUIValidationProvider(String jsrVersion) {
 		super();
+		jsr = jsrVersion;
 	}
 
 	@Override

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDI20SuiteTest.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDI20SuiteTest.java
@@ -18,7 +18,10 @@ import org.jboss.tools.cdi.bot.test.beans.named.cdi20.NamedComponentsSearchingTe
 import org.jboss.tools.cdi.bot.test.beans.openon.cdi20.BeanInjectOpenOnTestCDI20;
 import org.jboss.tools.cdi.bot.test.beans.openon.cdi20.FindObserverEventTestCDI20;
 import org.jboss.tools.cdi.bot.test.beansxml.cdi20.BeansXMLBeansEditorTestCDI20;
+import org.jboss.tools.cdi.bot.test.beansxml.cdi20.BeansXMLUITestCDI20;
 import org.jboss.tools.cdi.bot.test.beansxml.cdi20.BeansXMLValidationTestCDI20;
+import org.jboss.tools.cdi.bot.test.beansxml.openon.cdi20.BeansXMLOpenOnTestCDI20;
+import org.jboss.tools.cdi.bot.test.beansxml.validation.cdi20.BeansXMLAsYouTypeValidationTestCDI20;
 import org.jboss.tools.cdi.bot.test.beansxml.validation.cdi20.BeansXMLValidationQuickFixTestCDI20;
 import org.jboss.tools.cdi.bot.test.wizard.cdi20.CDIWebProjectWizardTestCDI20;
 import org.junit.runner.RunWith;
@@ -41,6 +44,9 @@ import org.junit.runners.Suite.SuiteClasses;
 	AllAssignableDialogTestCDI20.class,
 	AssignableDialogFilterTestCDI20.class,
 	AsYouTypeValidationTestCDI20.class,
+	BeansXMLAsYouTypeValidationTestCDI20.class,
+	BeansXMLOpenOnTestCDI20.class,
+	BeansXMLUITestCDI20.class,
 })
 public class CDI20SuiteTest {
 

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi20/BeansXMLUITestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi20/BeansXMLUITestCDI20.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -8,7 +8,7 @@
  * Contributor:
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package org.jboss.tools.cdi.bot.test.beansxml.cdi11;
+package org.jboss.tools.cdi.bot.test.beansxml.cdi20;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -21,31 +21,40 @@ import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequireme
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
 import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
+import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.beansxml.template.BeansXMLUITemplate;
 import org.jboss.tools.cdi.reddeer.validators.BeansXmlUIValidationProvider;
 import org.junit.Before;
 
+/** 
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
 @JRE(cleanup=true)
 @OpenPerspective(JavaEEPerspective.class)
 @JBossServer(state = ServerRequirementState.PRESENT, cleanup = false)
-public class BeansXMLUITestCDI11 extends BeansXMLUITemplate {
+public class BeansXMLUITestCDI20 extends BeansXMLUITemplate {
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
+		if (CDITestBase.isJavaLE8()) { 
 			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
 		} else {
 			return Arrays.asList(
 					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
 					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
+	}
+	
+	public BeansXMLUITestCDI20() {
+		CDIVersion = "2.0";
 	}
 
 	@Before
 	public void setCDIVersion() {
-		CDIVersion = "1.1";
-		validationProvider = new BeansXmlUIValidationProvider("JSR-346");
+		validationProvider = new BeansXmlUIValidationProvider("JSR-365");
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/openon/cdi20/BeansXMLOpenOnTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/openon/cdi20/BeansXMLOpenOnTestCDI20.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -8,7 +8,7 @@
  * Contributor:
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package org.jboss.tools.cdi.bot.test.beansxml.cdi11;
+package org.jboss.tools.cdi.bot.test.beansxml.openon.cdi20;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -21,31 +21,33 @@ import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequireme
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
 import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.beansxml.template.BeansXMLUITemplate;
-import org.jboss.tools.cdi.reddeer.validators.BeansXmlUIValidationProvider;
-import org.junit.Before;
+import org.jboss.tools.cdi.bot.test.CDITestBase;
+import org.jboss.tools.cdi.bot.test.beansxml.openon.template.BeansXMLOpenOnTemplate;
 
+/** 
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
 @JRE(cleanup=true)
+@JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
 @OpenPerspective(JavaEEPerspective.class)
-@JBossServer(state = ServerRequirementState.PRESENT, cleanup = false)
-public class BeansXMLUITestCDI11 extends BeansXMLUITemplate {
+public class BeansXMLOpenOnTestCDI20 extends BeansXMLOpenOnTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
+		if (CDITestBase.isJavaLE8()) { 
 			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
 		} else {
 			return Arrays.asList(
 					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
 					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
-
-	@Before
-	public void setCDIVersion() {
-		CDIVersion = "1.1";
-		validationProvider = new BeansXmlUIValidationProvider("JSR-346");
+	
+	public BeansXMLOpenOnTestCDI20() {
+		CDIVersion = "2.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/template/BeansXMLUITemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/template/BeansXMLUITemplate.java
@@ -35,7 +35,6 @@ import org.junit.Test;
 public class BeansXMLUITemplate extends CDITestBase {
 
 	private static final Logger logger = Logger.getLogger(BeansXMLUITemplate.class);
-	protected String CDIVersion = null;
 	protected IValidationProvider validationProvider = null;
 
 	@After

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi20/BeansXMLAsYouTypeValidationTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi20/BeansXMLAsYouTypeValidationTestCDI20.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2018 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -8,7 +8,7 @@
  * Contributor:
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package org.jboss.tools.cdi.bot.test.beansxml.cdi11;
+package org.jboss.tools.cdi.bot.test.beansxml.validation.cdi20;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -21,31 +21,40 @@ import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequireme
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
 import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.beansxml.template.BeansXMLUITemplate;
-import org.jboss.tools.cdi.reddeer.validators.BeansXmlUIValidationProvider;
+import org.jboss.tools.cdi.bot.test.CDITestBase;
+import org.jboss.tools.cdi.bot.test.beansxml.validation.template.BeansXMLAsYouTypeValidationTemplate;
 import org.junit.Before;
 
+/** 
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
 @JRE(cleanup=true)
+@JBossServer(state = ServerRequirementState.PRESENT, cleanup=false)
 @OpenPerspective(JavaEEPerspective.class)
-@JBossServer(state = ServerRequirementState.PRESENT, cleanup = false)
-public class BeansXMLUITestCDI11 extends BeansXMLUITemplate {
+public class BeansXMLAsYouTypeValidationTestCDI20 extends BeansXMLAsYouTypeValidationTemplate {
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
+		if (CDITestBase.isJavaLE8()) { 
 			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
 		} else {
 			return Arrays.asList(
 					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
 					new RequirementMatcher(JRE.class, VERSION, "1.8"));
 		}
 	}
-
-	@Before
-	public void setCDIVersion() {
-		CDIVersion = "1.1";
-		validationProvider = new BeansXmlUIValidationProvider("JSR-346");
+	
+	public BeansXMLAsYouTypeValidationTestCDI20() {
+		CDIVersion = "2.0";
 	}
+	
+	@Before
+	public void prepareBeans() {
+		prepareBeanXml("all", true);
+	}
+
 }


### PR DESCRIPTION
**JBIDE-24963-5 - add new testclasses for CDI 2.0:** 
 - BeansXMLAsYouTypeValidationTestCDI20.class
 - BeansXMLOpenOnTestCDI20.class
 - BeansXMLUITestCDI20.class

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>

**Jenkins:** https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cdi20.itests/98/
**Jira:** https://issues.jboss.org/browse/JBIDE-24963

