### PR TITLE
JBIDE-24963-10 - add new testclasses for CDI 2.0

### DIFF
--- a/plugins/org.jboss.tools.cdi.reddeer/src/org/jboss/tools/cdi/reddeer/validators/BeanValidationProvider.java
+++ b/plugins/org.jboss.tools.cdi.reddeer/src/org/jboss/tools/cdi/reddeer/validators/BeanValidationProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Red Hat, Inc.
+ * Copyright (c) 2010-2019 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDI20SuiteTest.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDI20SuiteTest.java
@@ -37,6 +37,10 @@ import org.jboss.tools.cdi.bot.test.beansxml.discovery.cdi20.BeanDiscoveryInImpl
 import org.jboss.tools.cdi.bot.test.beansxml.openon.cdi20.BeansXMLOpenOnTestCDI20;
 import org.jboss.tools.cdi.bot.test.beansxml.validation.cdi20.BeansXMLAsYouTypeValidationTestCDI20;
 import org.jboss.tools.cdi.bot.test.beansxml.validation.cdi20.BeansXMLValidationQuickFixTestCDI20;
+import org.jboss.tools.cdi.bot.test.weld.cdi20.WeldBuiltInContextsTestCDI20;
+import org.jboss.tools.cdi.bot.test.weld.cdi20.WeldExcludeTestCDI20;
+import org.jboss.tools.cdi.bot.test.weld.cdi20.WeldParametersAnnotationTestCDI20;
+import org.jboss.tools.cdi.bot.test.weld.cdi20.WeldScanTestCDI20;
 import org.jboss.tools.cdi.bot.test.wizard.cdi20.CDIWebProjectWizardTestCDI20;
 import org.jboss.tools.cdi.bot.test.wizard.cdi20.DynamicWebProjectWithCDITestCDI20;
 import org.jboss.tools.cdi.bot.test.wizard.cdi20.EjbProjectWithCDITestCDI20;
@@ -81,6 +85,10 @@ import org.junit.runners.Suite.SuiteClasses;
 	NamedRefactoringTestCDI20.class,
 	NullValuesInjectionTestCDI20.class,
 	QualifierValidationQuickFixTestCDI20.class,
+	WeldBuiltInContextsTestCDI20.class,
+	WeldExcludeTestCDI20.class,
+	WeldParametersAnnotationTestCDI20.class,
+	WeldScanTestCDI20.class,
 })
 public class CDI20SuiteTest {
 

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi20/WeldBuiltInContextsTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi20/WeldBuiltInContextsTestCDI20.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.bot.test.weld.cdi20;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
+import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
+import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
+import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
+import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
+import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
+import org.jboss.tools.cdi.bot.test.weld.template.WeldBuiltInContextsTemplate;
+
+/** 
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
+@JRE(cleanup=true)
+@OpenPerspective(JavaEEPerspective.class)
+@JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
+public class WeldBuiltInContextsTestCDI20 extends WeldBuiltInContextsTemplate{
+
+	@RequirementRestriction
+	public static Collection<RequirementMatcher> getRestrictionMatcher() {
+		if (isJavaLE8()) { 
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
+		} else {
+			return Arrays.asList(
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
+		}
+	}
+	
+	public WeldBuiltInContextsTestCDI20() {
+		CDIVersion = "2.0";
+	}	
+}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi20/WeldExcludeTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi20/WeldExcludeTestCDI20.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.bot.test.weld.cdi20;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
+import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
+import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
+import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
+import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
+import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
+import org.jboss.tools.cdi.bot.test.weld.template.WeldExcludeTemplate;
+import org.jboss.tools.cdi.reddeer.validators.BeanValidationProvider;
+import org.junit.Before;
+
+/** 
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
+@JRE(cleanup=true)
+@OpenPerspective(JavaEEPerspective.class)
+@JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
+public class WeldExcludeTestCDI20 extends WeldExcludeTemplate{
+
+	@RequirementRestriction
+	public static Collection<RequirementMatcher> getRestrictionMatcher() {
+		if (isJavaLE8()) { 
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
+		} else {
+			return Arrays.asList(
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
+		}
+	}
+	
+	public WeldExcludeTestCDI20() {
+		CDIVersion = "2.0";
+	}
+	
+	@Before
+	public void setValidationProvider(){
+		validationProvider = new BeanValidationProvider("JSR-365");
+		prepareBeanXml("all", false);
+	}
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi20/WeldParametersAnnotationTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi20/WeldParametersAnnotationTestCDI20.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.bot.test.weld.cdi20;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
+import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
+import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
+import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
+import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
+import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
+import org.jboss.tools.cdi.bot.test.weld.template.WeldParametersAnnotationTemplate;
+import org.junit.Before;
+
+/** 
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
+@JRE(cleanup=true)
+@OpenPerspective(JavaEEPerspective.class)
+@JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
+public class WeldParametersAnnotationTestCDI20 extends WeldParametersAnnotationTemplate{
+	
+	@RequirementRestriction
+	public static Collection<RequirementMatcher> getRestrictionMatcher() {
+		if (isJavaLE8()) { 
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
+		} else {
+			return Arrays.asList(
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
+		}
+	}
+	
+	public WeldParametersAnnotationTestCDI20() {
+		CDIVersion = "2.0";
+	}	
+	
+	@Before
+	public void prepareBeansXML(){
+		prepareBeanXml("all", true);
+	}
+
+}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi20/WeldScanTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi20/WeldScanTestCDI20.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.bot.test.weld.cdi20;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
+import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
+import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
+import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
+import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
+import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
+import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
+import org.jboss.tools.cdi.bot.test.weld.template.WeldScanTemplate;
+
+/** 
+ * 
+ * @author zcervink@redhat.com
+ * 
+ */
+@JRE(cleanup=true)
+@OpenPerspective(JavaEEPerspective.class)
+@JBossServer(state=ServerRequirementState.PRESENT, cleanup=false)
+public class WeldScanTestCDI20 extends WeldScanTemplate{
+
+	@RequirementRestriction
+	public static Collection<RequirementMatcher> getRestrictionMatcher() {
+		if (isJavaLE8()) { 
+			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"));
+		} else {
+			return Arrays.asList(
+					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
+					new RequirementMatcher(JBossServer.class, VERSION, "16"),
+					new RequirementMatcher(JRE.class, VERSION, "1.8"));
+		}
+	}
+	
+	public WeldScanTestCDI20() {
+		CDIVersion = "2.0";
+	}	
+}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/template/WeldBuiltInContextsTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/template/WeldBuiltInContextsTemplate.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 public class WeldBuiltInContextsTemplate extends CDITestBase{
 	
 	public static final String WELD_API_JAR=System.getProperty("jbosstools.test.weld-api.home");
-	protected String CDIVersion;
 	
 	@Before
 	public void addLibs(){
@@ -62,6 +61,8 @@ public class WeldBuiltInContextsTemplate extends CDITestBase{
 			String JSRspec = "[JSR-346 §5.2.2]";
 			if("1.0".equals(CDIVersion)){
 				JSRspec = "[JSR-299 §5.2.1]";
+			} else if ("2.0".equals(CDIVersion)) {
+				JSRspec = "[JSR-365 §5.2.2]";
 			}
 			assertEquals("Multiple beans are eligible for injection to the injection point "+JSRspec, m.getText());
 			assertTrue(m.getLineNumber() == 70 || m.getLineNumber() == 73 || m.getLineNumber() == 76);

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/template/WeldExcludeTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/template/WeldExcludeTemplate.java
@@ -111,7 +111,14 @@ public class WeldExcludeTemplate extends CDITestBase{
 		
 		ProblemsView pw = new ProblemsView();
 		pw.open();
-		assertEquals(4,pw.getProblems(ProblemType.ALL).size());
+		// JBIDE-26793
+		if (CDIVersion.equals("2.0")) {
+			assertEquals(4, pw.getProblems(ProblemType.WARNING).size());
+			assertTrue("Issue JBIDE-26793 seems to be fixed.", pw.getProblems(ProblemType.ERROR).size() == 1
+					&& pw.getProblems(ProblemType.ERROR).get(0).toString().contains("cvc-complex-type.2.4.a: Invalid content was found starting with element 'weld:scan'."));
+		} else {
+			assertEquals(4, pw.getProblems(ProblemType.ALL).size());
+		}
 	}
 	
 	


### PR DESCRIPTION
**JBIDE-24963-10 - Add new testclasses:**
 - WeldBuiltInContextsTestCDI20
 - WeldExcludeTestCDI20
 - WeldParametersAnnotationTestCDI20
 - WeldScanTestCDI20

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>


**Jenkins:** https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cdi20.itests/107/
**Jira:** https://issues.jboss.org/browse/JBIDE-24963