### PR TITLE
JBIDE-26558 - Update WildFly to version 17 in examples.itests

### DIFF
--- a/tests/org.jboss.tools.examples.ui.bot.test/README.md
+++ b/tests/org.jboss.tools.examples.ui.bot.test/README.md
@@ -3,18 +3,18 @@ Executing tests:
 mvn clean install -P{profile} -Dswtbot.test.skip=true -Dusage_reporting_enable=false -DdeployOnServer=true
 
 Where
-	${profile} select maven profile: WildFly14, EAP7, JavaEE7, SmokeTestsEAP7, SmokeTestsWildFly14, SmokeTestsJavaEE7 (WildFly14 profile is selected, if you don't specify profile)
+	${profile} select maven profile: WildFly, EAP7, JavaEE7, SmokeTestsEAP7, SmokeTestsWildFly, SmokeTestsJavaEE7 (WildFly profile is selected, if you don't specify profile)
 	
 You can specify other parameters as well(depending on profile you have selected):
 WildFly profile:
--PWildFly14
+-PWildFly
 -DquickstartsURLWildFly=${quickstartsURLWildFly}		-	URL for WildFly Quickstarts
 -DexamplesFolderWildFly=${examplesFolderWildFly}		-	examples folder of WildFly Quickstarts
 
 G.e.
 
 ```
-mvn clean verify -DexamplesFolderWildFly=quickstart-14.0.1.Final -DquickstartsURLWildFly=https://github.com/wildfly/quickstart/archive/14.0.1.Final.zip -PWildFly14 -DspecificQuickstarts=helloworld-jms
+mvn clean verify -DexamplesFolderWildFly=quickstart-17.0.0.Final -DquickstartsURLWildFly=https://github.com/wildfly/quickstart/archive/17.0.0.Final.zip -PWildFly -DspecificQuickstarts=helloworld-jms
 ```
 
 EAP profile:

--- a/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
@@ -16,16 +16,16 @@
 		<!-- <systemProperties>${integrationTestsSystemProperties} -->
 		<!-- -DimportTestDefinition=${importTestDefinition}</systemProperties> -->
 		<systemProperties>${integrationTestsSystemProperties} -DexamplesLocation=${project.build.directory}/${examplesFolder} -Dmaven.settings.path=${maven.settings.path} -Drd.config=${reddeer.config} -DspecificQuickstarts=${specificQuickstarts} -DdeployOnServer=${deployOnServer}</systemProperties>
-		<quickstartsURLWildFly>https://github.com/wildfly/quickstart/archive/14.0.1.Final.zip</quickstartsURLWildFly>
+		<quickstartsURLWildFly>https://github.com/wildfly/quickstart/archive/17.0.0.Final.zip</quickstartsURLWildFly>
 		<quickstartsURLEAP>http://download.eng.brq.redhat.com/released/JBoss-middleware/eap7/7.2.1/jboss-eap-7.2.1-quickstarts.zip</quickstartsURLEAP>
 		<quickstartsURLJavaEE>https://github.com/javaee-samples/javaee7-samples/archive/master.zip</quickstartsURLJavaEE>
 		<maven.settings.path>${project.build.directory}/classes/settings.xml</maven.settings.path>
-		<reddeer.config.wildfly14>${project.build.directory}/classes/servers/wildfly-14.json</reddeer.config.wildfly14>
+		<reddeer.config.wildfly>${project.build.directory}/classes/servers/wildfly-17.json</reddeer.config.wildfly>
 		<reddeer.config.eap7>${project.build.directory}/classes/servers/eap-7.json</reddeer.config.eap7>
-		<examplesFolderWildFly>quickstart-14.0.1.Final</examplesFolderWildFly>
+		<examplesFolderWildFly>quickstart-17.0.0.Final</examplesFolderWildFly>
 		<examplesFolderEAP>jboss-eap-7.2.1.GA-quickstarts</examplesFolderEAP>
 		<examplesFolderJavaEE>javaee7-samples-master</examplesFolderJavaEE>
-		<jbosstools.test.wildfly14.home>${requirementsDirectory}/wildfly-14.0.1.Final</jbosstools.test.wildfly14.home>
+		<jbosstools.test.wildfly.home>${requirementsDirectory}/wildfly-17.0.0.Final</jbosstools.test.wildfly.home>
 		<jbosstools.test.eap7.home>${requirementsDirectory}/jboss-eap-7.2</jbosstools.test.eap7.home>
 		<jbosstools.test.jboss-eap-7.x.url>http://download.eng.brq.redhat.com/released/JBoss-middleware/eap7/7.2.1/jboss-eap-7.2.1-full-build.zip</jbosstools.test.jboss-eap-7.x.url>
 		<surefire.timeout>18000</surefire.timeout>
@@ -107,13 +107,13 @@
 
 	<profiles>
 		<profile>
-			<id>WildFly14</id>
+			<id>WildFly</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>
 			<properties>
 				<test.class>org.jboss.tools.examples.ui.bot.test.integration.WildFlyImportQuickstartsTest</test.class>
-				<reddeer.config>${project.build.directory}/classes/servers/wildfly-14.json</reddeer.config>
+				<reddeer.config>${project.build.directory}/classes/servers/wildfly-17.json</reddeer.config>
 				<examplesLocation>${project.build.directory}/${examplesFolder}</examplesLocation>
 				<examplesFolder>${examplesFolderWildFly}</examplesFolder>
 			</properties>
@@ -152,7 +152,7 @@
 										<artifactItem>
 											<groupId>org.wildfly</groupId>
 											<artifactId>wildfly-dist</artifactId>
-											<version>14.0.1.Final</version>
+											<version>17.0.0.Final</version>
 											<type>zip</type>
 										</artifactItem>
 									</artifactItems>
@@ -224,7 +224,7 @@
 			<id>JavaEE7</id>
 			<properties>
 				<test.class>org.jboss.tools.examples.ui.bot.test.integration.WildFlyImportQuickstartsTest</test.class>
-				<reddeer.config>${project.build.directory}/classes/servers/wildfly-14.json</reddeer.config>
+				<reddeer.config>${project.build.directory}/classes/servers/wildfly-17.json</reddeer.config>
 				<examplesLocation>${project.build.directory}/${examplesFolder}</examplesLocation>
 				<examplesFolder>${examplesFolderJavaEE}</examplesFolder>
 			</properties>
@@ -263,7 +263,7 @@
 										<artifactItem>
 											<groupId>org.wildfly</groupId>
 											<artifactId>wildfly-dist</artifactId>
-											<version>14.0.1.Final</version>
+											<version>17.0.0.Final</version>
 											<type>zip</type>
 										</artifactItem>
 									</artifactItems>
@@ -311,10 +311,10 @@
 			</repositories>
 		</profile>
 		<profile>
-			<id>SmokeTestsWildFly14</id>
+			<id>SmokeTestsWildFly</id>
 			<properties>
 				<test.class>org.jboss.tools.examples.ui.bot.test.integration.WildFlyImportQuickstartsTest</test.class>
-				<reddeer.config>${project.build.directory}/classes/servers/wildfly-14.json</reddeer.config>
+				<reddeer.config>${project.build.directory}/classes/servers/wildfly-17.json</reddeer.config>
 				<examplesLocation>${project.build.directory}/${examplesFolder}</examplesLocation>
 				<examplesFolder>${examplesFolderWildFly}</examplesFolder>
 				<specificQuickstarts>temperature-converter,xml-dom4j,helloworld-ws,websocket-hello,helloworld</specificQuickstarts>
@@ -370,7 +370,7 @@
 										<artifactItem>
 											<groupId>org.wildfly</groupId>
 											<artifactId>wildfly-dist</artifactId>
-											<version>14.0.1.Final</version>
+											<version>17.0.0.Final</version>
 											<type>zip</type>
 										</artifactItem>
 									</artifactItems>
@@ -443,7 +443,7 @@
 			<id>SmokeTestsJavaEE7</id>
 			<properties>
 				<test.class>org.jboss.tools.examples.ui.bot.test.integration.WildFlyImportQuickstartsTest</test.class>
-				<reddeer.config>${project.build.directory}/classes/servers/wildfly-14.json</reddeer.config>
+				<reddeer.config>${project.build.directory}/classes/servers/wildfly-17.json</reddeer.config>
 				<examplesLocation>${project.build.directory}/${examplesFolder}</examplesLocation>
 				<examplesFolder>${examplesFolderJavaEE}</examplesFolder>
 				<specificQuickstarts>util,test-utils,jta</specificQuickstarts>
@@ -483,7 +483,7 @@
 										<artifactItem>
 											<groupId>org.wildfly</groupId>
 											<artifactId>wildfly-dist</artifactId>
-											<version>14.0.1.Final</version>
+											<version>17.0.0.Final</version>
 											<type>zip</type>
 										</artifactItem>
 									</artifactItems>
@@ -590,6 +590,12 @@
 			<groupId>com.googlecode.json-simple</groupId>
 			<artifactId>json-simple</artifactId>
 			<version>1.1.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-checkstyle-plugin</artifactId>
+			<version>3.1.0</version>
+			<type>maven-plugin</type>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>

--- a/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/wildfly-17.json
+++ b/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/wildfly-17.json
@@ -1,8 +1,8 @@
 {
 	"org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer": [
 		{
-			"runtime": "${jbosstools.test.wildfly14.home}",
-			"version": "14",
+			"runtime": "${jbosstools.test.wildfly.home}",
+			"version": "17",
 			"family": "WILDFLY"
 		}
 	]

--- a/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/wildfly-blacklist-test-errors-regexes.json
+++ b/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/wildfly-blacklist-test-errors-regexes.json
@@ -1,10 +1,6 @@
 {
 	"jts": [
-		".*Invalid content was found starting with element 'iiop:ejb-name'.*",
-		".*Referenced file contains errors.*jboss-ejb3-spec-2_0\\.xsd.*"
-	],
-	"ejb-security-interceptors": [
-		".*Invalid content was found starting with element 'jee:interceptor-binding'.*",
+		".*Invalid content was found starting with element.*",
 		".*Referenced file contains errors.*jboss-ejb3-spec-2_0\\.xsd.*"
 	],
 	"messaging-clustering-singleton": [
@@ -13,19 +9,71 @@
 		".*Referenced file contains errors.*jboss-ejb3-spec-2_0\\.xsd.*"
 	],
 	"jaxws-retail": [
-		".*Customer cannot be resolved to a type.*",
-		".*DiscountRequest cannot be resolved to a type.*",
-		".*DiscountResponse cannot be resolved to a type.*",
-		".*ProfileMgmt cannot be resolved to a type.*",
-		".*The import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.Customer cannot be resolved.*",
-		".*The import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.DiscountRequest cannot be resolved.*",
-		".*The import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.DiscountResponse cannot be resolved.*",
-		".*The import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.ProfileMgmt cannot be resolved.*",
-		".*Type mismatch: cannot convert from ProfileMgmt to ProfileMgmt.*"
+		".*Missing artifact com.sun.xml.messaging.saaj:saaj-impl:jar:1.3.16-jbossorg-1.*",
+		".*Missing artifact org.slf4j:slf4j-api:jar:1.7.22.jbossorg-1.*",
+		".*The container 'Maven Dependencies' references non existing library '.*slf4j-api-1.7.22.jbossorg-1.jar'.*",
+		".*The project cannot be built until build path errors are resolved.*"
 	],
-	"jsf":[
-		".*Element 'value' must have no element.*",
-		".*Value 'param1 flow1 value' is not facet-valid with respect to pattern.*",
-		".*Invalid content was found starting with elemen 'flow-call'.*"
+	"spring-greeter":[
+		".*Can not find the tag library descriptor for \"http://java.sun.com/jsp/jstl/core\".*",
+		".*Missing artifact org.apache.taglibs:taglibs-standard-impl:jar:1.2.6-RC1.*",
+		".*Missing artifact org.apache.taglibs:taglibs-standard-spec:jar:1.2.6-RC1.*",
+		".*The superclass \"javax.servlet.http.HttpServlet\" was not found on the Java Build Path.*",
+		".*The container 'Maven Dependencies' references non existing library.*",
+		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*",
+		".*The project cannot be built until build path errors are resolved.*"
+	],
+	"helloworld-jms":[
+		".*Missing artifact org.slf4j:jcl-over-slf4j:jar:1.7.22.jbossorg-1.*",
+		".*Missing artifact org.slf4j:slf4j-api:jar:1.7.22.jbossorg-1.*",
+		".*The project cannot be built until build path errors are resolved.*",
+		".*The container 'Maven Dependencies' references non existing library.*"
+	],
+	"jaxws-addressing":[
+		".*Missing artifact org.slf4j:slf4j-api:jar:1.7.22.jbossorg-1.*",
+		".*The container 'Maven Dependencies' references non existing library.*",
+		".*The project cannot be built until build path errors are resolved.*"
+	],
+	"jaxws-ejb":[
+		".*Missing artifact org.slf4j:slf4j-api:jar:1.7.22.jbossorg-1.*",
+		".*The container 'Maven Dependencies' references non existing library.*",
+		".*The project cannot be built until build path errors are resolved.*"
+	],
+	"jaxws-pojo":[
+		".*Missing artifact org.slf4j:slf4j-api:jar:1.7.22.jbossorg-1.*",
+		".*The container 'Maven Dependencies' references non existing library.*",
+		".*The project cannot be built until build path errors are resolved.*"
+	],
+	"kitchensink-jsp":[
+		".*Can not find the tag library descriptor for \"http://java.sun.com/jsp/jstl/core\".*",
+		".*Missing artifact org.apache.taglibs:taglibs-standard-impl:jar:1.2.6-RC1.*",
+		".*Missing artifact org.apache.taglibs:taglibs-standard-spec:jar:1.2.6-RC1.*",
+		".*The container 'Maven Dependencies' references non existing library.*",
+		".*The project cannot be built until build path errors are resolved.*"
+	],
+	"spring-kitchensink-basic":[
+		".*Can not find the tag library descriptor for \"http://java.sun.com/jsp/jstl/core\".*",
+		".*Missing artifact org.apache.taglibs:taglibs-standard-impl:jar:1.2.6-RC1.*",
+		".*Missing artifact org.apache.taglibs:taglibs-standard-spec:jar:1.2.6-RC1.*",
+		".*The container 'Maven Dependencies' references non existing library.*",
+		".*The project cannot be built until build path errors are resolved.*",
+		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
+	],
+	"spring-kitchensink-springmvctest":[
+		".*Can not find the tag library descriptor for \"http://java.sun.com/jsp/jstl/core\".*",
+		".*Missing artifact org.apache.taglibs:taglibs-standard-impl:jar:1.2.6-RC1.*",
+		".*Missing artifact org.apache.taglibs:taglibs-standard-spec:jar:1.2.6-RC1.*",
+		".*Missing artifact org.slf4j:slf4j-api:jar:1.7.22.jbossorg-1.*",
+		".*The container 'Maven Dependencies' references non existing library.*",
+		".*The project cannot be built until build path errors are resolved.*",
+		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
+	],
+	"contacts-jquerymobile":[
+		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
+	],
+	"wicket-war":[
+		".*Missing artifact org.slf4j:slf4j-api:jar:1.7.22.jbossorg-1.*",
+		".*The container 'Maven Dependencies' references non existing library.*",
+		".*The project cannot be built until build path errors are resolved.*"
 	]
 }


### PR DESCRIPTION
JBIDE-26558 - Update WildFly to version 17 in examples.itests.

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>

**Jenkins:** https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/examples.wildfly.it.weekly/545/
**Jira:** https://issues.jboss.org/browse/JBIDE-26558

