### PR TITLE
JBIDE-26758 - examples.wildfly.itests contains errors like "There is no project with name ..."

### DIFF
--- a/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/wildfly-blacklist-test-errors-regexes.json
+++ b/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/wildfly-blacklist-test-errors-regexes.json
@@ -51,6 +51,27 @@
 		".*The container 'Maven Dependencies' references non existing library.*",
 		".*The project cannot be built until build path errors are resolved.*"
 	],
+	"deltaspike-beanbuilder":[
+		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
+	],
+	"kitchensink":[
+		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
+	],
+	"kitchensink-angularjs":[
+		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
+	],	
+	"kitchensink-ml":[
+		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
+	],	
+	"kitchensink-ear":[
+		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
+	],
+	"tasks-jsf":[
+		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
+	],	
+	"tasks-rs":[
+		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
+	],
 	"spring-kitchensink-basic":[
 		".*Can not find the tag library descriptor for \"http://java.sun.com/jsp/jstl/core\".*",
 		".*Missing artifact org.apache.taglibs:taglibs-standard-impl:jar:1.2.6-RC1.*",
@@ -72,6 +93,11 @@
 		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
 	],
 	"wicket-war":[
+		".*Missing artifact org.slf4j:slf4j-api:jar:1.7.22.jbossorg-1.*",
+		".*The container 'Maven Dependencies' references non existing library.*",
+		".*The project cannot be built until build path errors are resolved.*"
+	],
+	"wildfly-wicket-ear-parent":[
 		".*Missing artifact org.slf4j:slf4j-api:jar:1.7.22.jbossorg-1.*",
 		".*The container 'Maven Dependencies' references non existing library.*",
 		".*The project cannot be built until build path errors are resolved.*"

--- a/tests/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/AbstractImportQuickstartsTest.java
+++ b/tests/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/AbstractImportQuickstartsTest.java
@@ -447,7 +447,7 @@ public abstract class AbstractImportQuickstartsTest {
 		TreeItem projectItem;
 		String quickstartBaseName = quickstart.getName();
 		String quickstartBaseNameWF = "wildfly-" + quickstartBaseName;
-		String quickstartBaseNameJB = "jboss-" + quickstartBaseName;
+		String quickstartBaseNameJB = getQuickstartBaseNameJB(quickstartBaseName);
 
 		if (pe.containsProject(quickstartBaseName)) {
 			projectItem = pe.getProject(quickstartBaseName).getTreeItem();
@@ -460,6 +460,26 @@ public abstract class AbstractImportQuickstartsTest {
 		}
 		MavenProject project = new MavenProject(projectItem);
 		project.updateMavenProject();
+	}
+	
+	// JBIDE-26758
+	private String getQuickstartBaseNameJB(String quickstartBaseName) {
+		String quickstartBaseNameJB;
+		switch (quickstartBaseName) {
+			case "dist":
+				quickstartBaseNameJB = "quickstarts-dist";
+				break;
+			case "wicket-ear":
+				quickstartBaseNameJB = "wildfly-wicket-ear-parent";
+				break;
+			case "helloworld-classfiletransformer":
+				quickstartBaseNameJB = "helloworld-classfiletransformers";
+				break;
+			default:
+				quickstartBaseNameJB = "jboss-" + quickstartBaseName;
+				break;
+		}
+		return quickstartBaseNameJB;
 	}
 
 	protected void importQuickstart(Quickstart quickstart) throws NoProjectException {


### PR DESCRIPTION
JBIDE-26758 - examples.wildfly.itests contains errors like "There is no project with name " for following projects:
 - dist
 - wicket-ear
 - helloworld-classfiletransformer

**Jenkins:** https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/examples.wildfly.it.weekly/592/
**Jira:** https://issues.jboss.org/browse/JBIDE-26758

please review @odockal @jkopriva 

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>
