### PR TITLE
JBIDE-26882 - Fix the central.itests failing due not blacklisted issue

### DIFF
--- a/tests/org.jboss.tools.central.ui.bot.test/resources/blacklist-launcher-application-errors-regexes.json
+++ b/tests/org.jboss.tools.central.ui.bot.test/resources/blacklist-launcher-application-errors-regexes.json
@@ -1,5 +1,5 @@
 {
 	"LauncherApplicationTest": [
-		".*The element type \"p\" must be terminated by the matching end-tag \"</p>\".*"
+		".*Expected name at.*"
 	]
 }


### PR DESCRIPTION
Fix the central.itests failing due not blacklisted issue in Launcher Application project. The 
Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>

**Jenkins:** https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/central.itests/574/
**Jira:** https://issues.jboss.org/browse/JBIDE-26882

Please review @jkopriva @odockal 
