### PR TITLE
JBIDE-26846 - update WildFly version to 18 in maven.itests.

### DIFF
--- a/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
@@ -12,9 +12,10 @@
 
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
+		<wildflyVersion>18.0.0.Final</wildflyVersion>
 		<requirementsDirectory>${project.build.directory}/requirements</requirementsDirectory>
-		<jbosstools.test.wildfly.17.home>${requirementsDirectory}/wildfly-17.0.0.Final</jbosstools.test.wildfly.17.home>
-		<systemProperties>${integrationTestsSystemProperties} -Drd.config=${project.build.directory}/classes/servers/wildfly-17.json -Djbosstools.test.seam.2.1.0.home=${requirementsDirectory}/jboss-seam-2.1.2 -Djbosstools.test.seam.2.3.0.home=${requirementsDirectory}/jboss-seam-2.3.0.Final -Djbosstools.test.seam.2.2.0.home=${requirementsDirectory}/jboss-seam-2.2.0.GA -Dproject.build.directory=${project.build.directory} -Dmaven.settings.path=target/classes/usersettings/settings.xml -Dscope=${scope} -Djbosstools.test.wildfly.17.home=${jbosstools.test.wildfly.17.home}</systemProperties>
+		<jbosstools.test.wildfly.home>${requirementsDirectory}/wildfly-${wildflyVersion}</jbosstools.test.wildfly.home>
+		<systemProperties>${integrationTestsSystemProperties} -Drd.config=${project.build.directory}/classes/servers/wildfly.json -Djbosstools.test.seam.2.1.0.home=${requirementsDirectory}/jboss-seam-2.1.2 -Djbosstools.test.seam.2.3.0.home=${requirementsDirectory}/jboss-seam-2.3.0.Final -Djbosstools.test.seam.2.2.0.home=${requirementsDirectory}/jboss-seam-2.2.0.GA -Dproject.build.directory=${project.build.directory} -Dmaven.settings.path=target/classes/usersettings/settings.xml -Dscope=${scope} -Djbosstools.test.wildfly.home=${jbosstools.test.wildfly.home}</systemProperties>
  		<scope>MavenAllBotTests</scope>
 		<surefire.timeout>18000</surefire.timeout>
 	</properties>
@@ -45,7 +46,7 @@
 								<artifactItem>
 									<groupId>org.wildfly</groupId>
 									<artifactId>wildfly-dist</artifactId>
-									<version>17.0.0.Final</version>
+									<version>${wildflyVersion}</version>
 									<type>zip</type>
 								</artifactItem>
 							</artifactItems>

--- a/tests/org.jboss.tools.maven.ui.bot.test/resources/servers/wildfly.json
+++ b/tests/org.jboss.tools.maven.ui.bot.test/resources/servers/wildfly.json
@@ -1,8 +1,8 @@
 {
 	"org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer": [
 		{
-			"runtime": "${jbosstools.test.wildfly.17.home}",
-			"version": "17",
+			"runtime": "${jbosstools.test.wildfly.home}",
+			"version": "18",
 			"family": "WILDFLY"
 		}
 	]


### PR DESCRIPTION
JBIDE-26846 - update WildFly version to 18 in maven.itests.

Please review @jkopriva @zcervink 

**Jenkins:** https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/maven.itests/847/
**Jira:** https://issues.jboss.org/browse/JBIDE-26846