### PR TITLE
JBIDE-26845 - Update WildFly to version 18 in examples.wildfly.itests

### DIFF
--- a/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
@@ -15,17 +15,18 @@
 	<properties>
 		<!-- <systemProperties>${integrationTestsSystemProperties} -->
 		<!-- -DimportTestDefinition=${importTestDefinition}</systemProperties> -->
+		<wildflyVersion>18.0.0.Final</wildflyVersion>
 		<systemProperties>${integrationTestsSystemProperties} -DexamplesLocation=${project.build.directory}/${examplesFolder} -Dmaven.settings.path=${maven.settings.path} -Drd.config=${reddeer.config} -DspecificQuickstarts=${specificQuickstarts} -DdeployOnServer=${deployOnServer}</systemProperties>
-		<quickstartsURLWildFly>https://github.com/wildfly/quickstart/archive/17.0.0.Final.zip</quickstartsURLWildFly>
+		<quickstartsURLWildFly>https://github.com/wildfly/quickstart/archive/${wildflyVersion}.zip</quickstartsURLWildFly>
 		<quickstartsURLEAP>http://download.eng.brq.redhat.com/released/JBoss-middleware/eap7/7.2.1/jboss-eap-7.2.1-quickstarts.zip</quickstartsURLEAP>
 		<quickstartsURLJavaEE>https://github.com/javaee-samples/javaee7-samples/archive/master.zip</quickstartsURLJavaEE>
 		<maven.settings.path>${project.build.directory}/classes/settings.xml</maven.settings.path>
-		<reddeer.config.wildfly>${project.build.directory}/classes/servers/wildfly-17.json</reddeer.config.wildfly>
+		<reddeer.config.wildfly>${project.build.directory}/classes/servers/wildfly.json</reddeer.config.wildfly>
 		<reddeer.config.eap7>${project.build.directory}/classes/servers/eap-7.json</reddeer.config.eap7>
-		<examplesFolderWildFly>quickstart-17.0.0.Final</examplesFolderWildFly>
+		<examplesFolderWildFly>quickstart-${wildflyVersion}</examplesFolderWildFly>
 		<examplesFolderEAP>jboss-eap-7.2.1.GA-quickstarts</examplesFolderEAP>
 		<examplesFolderJavaEE>javaee7-samples-master</examplesFolderJavaEE>
-		<jbosstools.test.wildfly.home>${requirementsDirectory}/wildfly-17.0.0.Final</jbosstools.test.wildfly.home>
+		<jbosstools.test.wildfly.home>${requirementsDirectory}/wildfly-${wildflyVersion}</jbosstools.test.wildfly.home>
 		<jbosstools.test.eap7.home>${requirementsDirectory}/jboss-eap-7.2</jbosstools.test.eap7.home>
 		<jbosstools.test.jboss-eap-7.x.url>http://download.eng.brq.redhat.com/released/JBoss-middleware/eap7/7.2.1/jboss-eap-7.2.1-full-build.zip</jbosstools.test.jboss-eap-7.x.url>
 		<surefire.timeout>18000</surefire.timeout>
@@ -113,7 +114,7 @@
 			</activation>
 			<properties>
 				<test.class>org.jboss.tools.examples.ui.bot.test.integration.WildFlyImportQuickstartsTest</test.class>
-				<reddeer.config>${project.build.directory}/classes/servers/wildfly-17.json</reddeer.config>
+				<reddeer.config>${project.build.directory}/classes/servers/wildfly.json</reddeer.config>
 				<examplesLocation>${project.build.directory}/${examplesFolder}</examplesLocation>
 				<examplesFolder>${examplesFolderWildFly}</examplesFolder>
 			</properties>
@@ -152,7 +153,7 @@
 										<artifactItem>
 											<groupId>org.wildfly</groupId>
 											<artifactId>wildfly-dist</artifactId>
-											<version>17.0.0.Final</version>
+											<version>${wildflyVersion}</version>
 											<type>zip</type>
 										</artifactItem>
 									</artifactItems>
@@ -224,7 +225,7 @@
 			<id>JavaEE7</id>
 			<properties>
 				<test.class>org.jboss.tools.examples.ui.bot.test.integration.WildFlyImportQuickstartsTest</test.class>
-				<reddeer.config>${project.build.directory}/classes/servers/wildfly-17.json</reddeer.config>
+				<reddeer.config>${project.build.directory}/classes/servers/wildfly.json</reddeer.config>
 				<examplesLocation>${project.build.directory}/${examplesFolder}</examplesLocation>
 				<examplesFolder>${examplesFolderJavaEE}</examplesFolder>
 			</properties>
@@ -263,7 +264,7 @@
 										<artifactItem>
 											<groupId>org.wildfly</groupId>
 											<artifactId>wildfly-dist</artifactId>
-											<version>17.0.0.Final</version>
+											<version>${wildflyVersion}</version>
 											<type>zip</type>
 										</artifactItem>
 									</artifactItems>
@@ -314,7 +315,7 @@
 			<id>SmokeTestsWildFly</id>
 			<properties>
 				<test.class>org.jboss.tools.examples.ui.bot.test.integration.WildFlyImportQuickstartsTest</test.class>
-				<reddeer.config>${project.build.directory}/classes/servers/wildfly-17.json</reddeer.config>
+				<reddeer.config>${project.build.directory}/classes/servers/wildfly.json</reddeer.config>
 				<examplesLocation>${project.build.directory}/${examplesFolder}</examplesLocation>
 				<examplesFolder>${examplesFolderWildFly}</examplesFolder>
 				<specificQuickstarts>temperature-converter,xml-dom4j,helloworld-ws,websocket-hello,helloworld</specificQuickstarts>
@@ -370,7 +371,7 @@
 										<artifactItem>
 											<groupId>org.wildfly</groupId>
 											<artifactId>wildfly-dist</artifactId>
-											<version>17.0.0.Final</version>
+											<version>${wildflyVersion}</version>
 											<type>zip</type>
 										</artifactItem>
 									</artifactItems>
@@ -443,7 +444,7 @@
 			<id>SmokeTestsJavaEE7</id>
 			<properties>
 				<test.class>org.jboss.tools.examples.ui.bot.test.integration.WildFlyImportQuickstartsTest</test.class>
-				<reddeer.config>${project.build.directory}/classes/servers/wildfly-17.json</reddeer.config>
+				<reddeer.config>${project.build.directory}/classes/servers/wildfly.json</reddeer.config>
 				<examplesLocation>${project.build.directory}/${examplesFolder}</examplesLocation>
 				<examplesFolder>${examplesFolderJavaEE}</examplesFolder>
 				<specificQuickstarts>util,test-utils,jta</specificQuickstarts>
@@ -483,7 +484,7 @@
 										<artifactItem>
 											<groupId>org.wildfly</groupId>
 											<artifactId>wildfly-dist</artifactId>
-											<version>17.0.0.Final</version>
+											<version>${wildflyVersion}</version>
 											<type>zip</type>
 										</artifactItem>
 									</artifactItems>

--- a/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/wildfly-blacklist-test-errors-regexes.json
+++ b/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/wildfly-blacklist-test-errors-regexes.json
@@ -1,4 +1,7 @@
 {
+	"*": [
+		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
+	],
 	"jts": [
 		".*Invalid content was found starting with element.*",
 		".*Referenced file contains errors.*jboss-ejb3-spec-2_0\\.xsd.*"
@@ -9,97 +12,17 @@
 		".*Referenced file contains errors.*jboss-ejb3-spec-2_0\\.xsd.*"
 	],
 	"jaxws-retail": [
-		".*Missing artifact com.sun.xml.messaging.saaj:saaj-impl:jar:1.3.16-jbossorg-1.*",
-		".*Missing artifact org.slf4j:slf4j-api:jar:1.7.22.jbossorg-1.*",
-		".*The container 'Maven Dependencies' references non existing library '.*slf4j-api-1.7.22.jbossorg-1.jar'.*",
-		".*The project cannot be built until build path errors are resolved.*"
+		".*Customer cannot be resolved to a type.*",
+		".*DiscountRequest cannot be resolved to a type.*",
+		".*DiscountResponse cannot be resolved to a type.*",
+		".*ProfileMgmt cannot be resolved to a type.*",
+		".*The import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.Customer cannot be resolved.*",
+		".*The import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.DiscountRequest cannot be resolved.*",
+		".*The import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.DiscountResponse cannot be resolved.*",
+		".*The import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.ProfileMgmt cannot be resolved.*",
+		".*Type mismatch: cannot convert from ProfileMgmt to ProfileMgmt.*"
 	],
 	"spring-greeter":[
-		".*Can not find the tag library descriptor for \"http://java.sun.com/jsp/jstl/core\".*",
-		".*Missing artifact org.apache.taglibs:taglibs-standard-impl:jar:1.2.6-RC1.*",
-		".*Missing artifact org.apache.taglibs:taglibs-standard-spec:jar:1.2.6-RC1.*",
-		".*The superclass \"javax.servlet.http.HttpServlet\" was not found on the Java Build Path.*",
-		".*The container 'Maven Dependencies' references non existing library.*",
-		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*",
-		".*The project cannot be built until build path errors are resolved.*"
-	],
-	"helloworld-jms":[
-		".*Missing artifact org.slf4j:jcl-over-slf4j:jar:1.7.22.jbossorg-1.*",
-		".*Missing artifact org.slf4j:slf4j-api:jar:1.7.22.jbossorg-1.*",
-		".*The project cannot be built until build path errors are resolved.*",
-		".*The container 'Maven Dependencies' references non existing library.*"
-	],
-	"jaxws-addressing":[
-		".*Missing artifact org.slf4j:slf4j-api:jar:1.7.22.jbossorg-1.*",
-		".*The container 'Maven Dependencies' references non existing library.*",
-		".*The project cannot be built until build path errors are resolved.*"
-	],
-	"jaxws-ejb":[
-		".*Missing artifact org.slf4j:slf4j-api:jar:1.7.22.jbossorg-1.*",
-		".*The container 'Maven Dependencies' references non existing library.*",
-		".*The project cannot be built until build path errors are resolved.*"
-	],
-	"jaxws-pojo":[
-		".*Missing artifact org.slf4j:slf4j-api:jar:1.7.22.jbossorg-1.*",
-		".*The container 'Maven Dependencies' references non existing library.*",
-		".*The project cannot be built until build path errors are resolved.*"
-	],
-	"kitchensink-jsp":[
-		".*Can not find the tag library descriptor for \"http://java.sun.com/jsp/jstl/core\".*",
-		".*Missing artifact org.apache.taglibs:taglibs-standard-impl:jar:1.2.6-RC1.*",
-		".*Missing artifact org.apache.taglibs:taglibs-standard-spec:jar:1.2.6-RC1.*",
-		".*The container 'Maven Dependencies' references non existing library.*",
-		".*The project cannot be built until build path errors are resolved.*"
-	],
-	"deltaspike-beanbuilder":[
-		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
-	],
-	"kitchensink":[
-		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
-	],
-	"kitchensink-angularjs":[
-		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
-	],	
-	"kitchensink-ml":[
-		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
-	],	
-	"kitchensink-ear":[
-		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
-	],
-	"tasks-jsf":[
-		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
-	],	
-	"tasks-rs":[
-		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
-	],
-	"spring-kitchensink-basic":[
-		".*Can not find the tag library descriptor for \"http://java.sun.com/jsp/jstl/core\".*",
-		".*Missing artifact org.apache.taglibs:taglibs-standard-impl:jar:1.2.6-RC1.*",
-		".*Missing artifact org.apache.taglibs:taglibs-standard-spec:jar:1.2.6-RC1.*",
-		".*The container 'Maven Dependencies' references non existing library.*",
-		".*The project cannot be built until build path errors are resolved.*",
-		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
-	],
-	"spring-kitchensink-springmvctest":[
-		".*Can not find the tag library descriptor for \"http://java.sun.com/jsp/jstl/core\".*",
-		".*Missing artifact org.apache.taglibs:taglibs-standard-impl:jar:1.2.6-RC1.*",
-		".*Missing artifact org.apache.taglibs:taglibs-standard-spec:jar:1.2.6-RC1.*",
-		".*Missing artifact org.slf4j:slf4j-api:jar:1.7.22.jbossorg-1.*",
-		".*The container 'Maven Dependencies' references non existing library.*",
-		".*The project cannot be built until build path errors are resolved.*",
-		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
-	],
-	"contacts-jquerymobile":[
-		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
-	],
-	"wicket-war":[
-		".*Missing artifact org.slf4j:slf4j-api:jar:1.7.22.jbossorg-1.*",
-		".*The container 'Maven Dependencies' references non existing library.*",
-		".*The project cannot be built until build path errors are resolved.*"
-	],
-	"wildfly-wicket-ear-parent":[
-		".*Missing artifact org.slf4j:slf4j-api:jar:1.7.22.jbossorg-1.*",
-		".*The container 'Maven Dependencies' references non existing library.*",
-		".*The project cannot be built until build path errors are resolved.*"
+		".*The superclass \"javax.servlet.http.HttpServlet\" was not found on the Java Build Path.*"
 	]
 }

--- a/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/wildfly.json
+++ b/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/wildfly.json
@@ -2,7 +2,7 @@
 	"org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer": [
 		{
 			"runtime": "${jbosstools.test.wildfly.home}",
-			"version": "17",
+			"version": "18",
 			"family": "WILDFLY"
 		}
 	]


### PR DESCRIPTION
JBIDE-26845 - Update WildFly to version 18 in examples.wildfly.itests and check and update entries in the wildfly-blacklist and wildfly-blacklist-test-errors-regexes.json files

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>

Please review @odockal @jkopriva 

**Jira:** https://issues.jboss.org/browse/JBIDE-26845
**Jenkins:** soon in a comment below
