### PR TITLE
JBIDE-26750 Update CDI.itests to run on Java 11 and make several fixes.

### DIFF
--- a/plugins/org.jboss.tools.cdi.reddeer/src/org/jboss/tools/cdi/reddeer/uiutils/ProjectHelper.java
+++ b/plugins/org.jboss.tools.cdi.reddeer/src/org/jboss/tools/cdi/reddeer/uiutils/ProjectHelper.java
@@ -29,12 +29,13 @@ import org.eclipse.reddeer.swt.impl.button.PushButton;
 import org.eclipse.reddeer.swt.impl.menu.ContextMenu;
 import org.eclipse.reddeer.swt.impl.shell.DefaultShell;
 import org.eclipse.reddeer.swt.impl.tab.DefaultTabItem;
+import org.eclipse.reddeer.swt.impl.tree.DefaultTree;
 import org.eclipse.reddeer.swt.impl.tree.DefaultTreeItem;
 import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
 
 public class ProjectHelper {
 	
-	public void addLibrariesIntoProject(String projectName, String libDir) {
+	public void addLibrariesIntoProject(String projectName, String libDir, boolean isJava11FacetActivated) {
 
 		File[] libraries = addLibraryIntoProjectFolder(projectName, new File(libDir));
 		if (libraries == null)
@@ -51,7 +52,10 @@ public class ProjectHelper {
 		new DefaultShell("Properties for "+projectName);
 		new DefaultTreeItem("Java Build Path").select();
 		new DefaultTabItem("Libraries").activate();
-
+		if (isJava11FacetActivated) {
+			new DefaultTree(1).getItem("Classpath").select();
+		}
+		
 		for (File library : libraries) {
 			new PushButton("Add JARs...").click();
 			new DefaultShell("JAR Selection");

--- a/tests/org.jboss.tools.cdi.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.bot.test/pom.xml
@@ -12,11 +12,12 @@
     <packaging>eclipse-test-plugin</packaging>
 	<properties>
 		<jbosstools.test.jre.8>${NATIVE_TOOLS}${SEP}${OPENJDK18}</jbosstools.test.jre.8>
-		<systemProperties>${integrationTestsSystemProperties} -Drd.config=target/classes/servers/requirements.json -Djbosstools.test.weld-se.home=${jbosstools.test.weld-se.home} -Djbosstools.test.weld-api.home=${jbosstools.test.weld-api.home} -Djbosstools.test.jre.8=${jbosstools.test.jre.8}</systemProperties>
+		<jbosstools.test.jre.11>${NATIVE_TOOLS}${SEP}${OPENJDK11}</jbosstools.test.jre.11>
+		<systemProperties>${integrationTestsSystemProperties} -Drd.config=target/classes/servers/requirements.json -Djbosstools.test.weld-se.home=${jbosstools.test.weld-se.home} -Djbosstools.test.weld-api.home=${jbosstools.test.weld-api.home} -Djbosstools.test.jre.8=${jbosstools.test.jre.8} -Djbosstools.test.jre.11=${jbosstools.test.jre.11}</systemProperties>
 		<surefire.timeout>14400</surefire.timeout>
 		<jbosstools.test.jboss-as-7.1.home>${requirementsDirectory}/jboss-as-7.1.1.Final</jbosstools.test.jboss-as-7.1.home>
 		<jbosstools.test.wildfly.13.home>${requirementsDirectory}/wildfly-13.0.0.Final</jbosstools.test.wildfly.13.home>
-		<jbosstools.test.wildfly.16.home>${requirementsDirectory}/wildfly-16.0.0.Final</jbosstools.test.wildfly.16.home>
+		<jbosstools.test.wildfly.18.home>${requirementsDirectory}/wildfly-18.0.0.Final</jbosstools.test.wildfly.18.home>
 		<jbosstools.test.weld-se.home>${requirementsDirectory}/weld/se/</jbosstools.test.weld-se.home>
 		<jbosstools.test.weld-api.home>${requirementsDirectory}/weld/api/</jbosstools.test.weld-api.home>
 	</properties>
@@ -131,7 +132,7 @@
 						</configuration>
 					</execution>
 					<execution>
-						<id>wildfly16</id>
+						<id>wildfly18</id>
 						<phase>pre-integration-test</phase>
 						<goals>
 							<goal>unpack</goal>
@@ -142,7 +143,7 @@
 								<artifactItem>
 									<groupId>org.wildfly</groupId>
 									<artifactId>wildfly-dist</artifactId>
-									<version>16.0.0.Final</version>
+									<version>18.0.0.Final</version>
 									<type>zip</type>
 								</artifactItem>
 							</artifactItems>

--- a/tests/org.jboss.tools.cdi.bot.test/resources/servers/requirements.json
+++ b/tests/org.jboss.tools.cdi.bot.test/resources/servers/requirements.json
@@ -1,10 +1,10 @@
 {
 	"org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer": [
 		{
-			"runtime": "${jbosstools.test.wildfly.16.home}",
-			"version": "16",
+			"runtime": "${jbosstools.test.wildfly.18.home}",
+			"version": "18",
 			"family": "WILDFLY",
-			"runtimeEnvironment": "JavaSE-1.8"
+			"runtimeEnvironment": "JavaSE-11"
 		},
 		{
 			"runtime": "${jbosstools.test.wildfly.13.home}",
@@ -24,6 +24,11 @@
 			"name": "openjdk-1.8",
 			"version": "1.8",
 			"path": "${jbosstools.test.jre.8}"
+		},
+		{
+			"name": "openjdk-11",
+			"version": "11",
+			"path": "${jbosstools.test.jre.11}"
 		}
 	]
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi10/AsYouTypeValidationTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi10/AsYouTypeValidationTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.bean.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
+
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.bean.template.AsYouTypeValidationTemplate;
 
@@ -30,12 +29,10 @@ public class AsYouTypeValidationTestCDI10 extends AsYouTypeValidationTemplate {
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
+	}
+	
+	public AsYouTypeValidationTestCDI10() {
+		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi10/BeanValidationQuickFixTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi10/BeanValidationQuickFixTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.bean.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.bean.template.BeanValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.BeanValidationProvider;
@@ -32,16 +30,14 @@ public class BeanValidationQuickFixTestCDI10 extends BeanValidationQuickFixTempl
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
 	} 
 	@Before
 	public void setProvider(){
 		validationProvider = new BeanValidationProvider("JSR-299");
+	}
+	
+	public BeanValidationQuickFixTestCDI10() {
+		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi10/NullValuesInjectionTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi10/NullValuesInjectionTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.bean.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.bean.template.NullValuesInjectionTemplate;
 
@@ -30,13 +28,7 @@ public class NullValuesInjectionTestCDI10 extends NullValuesInjectionTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
 	}
 	
 	public NullValuesInjectionTestCDI10(){

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi11/AsYouTypeValidationTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi11/AsYouTypeValidationTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.bean.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.bean.template.AsYouTypeValidationTemplate;
 import org.junit.Before;
@@ -31,15 +29,11 @@ public class AsYouTypeValidationTestCDI11 extends AsYouTypeValidationTemplate {
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public AsYouTypeValidationTestCDI11() {
+		CDIVersion = "1.2";
 	}
 
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi11/BeanValidationQuickFixTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi11/BeanValidationQuickFixTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.bean.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.bean.template.BeanValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.BeanValidationProvider;
@@ -32,15 +30,11 @@ public class BeanValidationQuickFixTestCDI11 extends BeanValidationQuickFixTempl
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public BeanValidationQuickFixTestCDI11() {
+		CDIVersion = "1.2";
 	}
 
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi11/NullValuesInjectionTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi11/NullValuesInjectionTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.bean.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.bean.template.NullValuesInjectionTemplate;
 import org.junit.Before;
@@ -31,19 +29,11 @@ public class NullValuesInjectionTestCDI11 extends NullValuesInjectionTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
 	}
 	
 	public NullValuesInjectionTestCDI11() {
-		CDIVersion = "1.1";
+		CDIVersion = "1.2";
 	}
 	
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi11/VetoedAnnotationTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi11/VetoedAnnotationTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.bean.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.bean.template.VetoedAnnotationTemplate;
 
@@ -30,15 +28,10 @@ public class VetoedAnnotationTestCDI11 extends VetoedAnnotationTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
 	}
 	
+	public VetoedAnnotationTestCDI11(){
+		CDIVersion = "1.2";
+	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi20/AsYouTypeValidationTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi20/AsYouTypeValidationTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.bean.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.bean.template.AsYouTypeValidationTemplate;
 import org.junit.Before;
@@ -31,15 +29,7 @@ public class AsYouTypeValidationTestCDI20 extends AsYouTypeValidationTemplate {
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public AsYouTypeValidationTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi20/BeanValidationQuickFixTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi20/BeanValidationQuickFixTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.bean.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.bean.template.BeanValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.BeanValidationProvider;
@@ -37,15 +35,7 @@ public class BeanValidationQuickFixTestCDI20 extends BeanValidationQuickFixTempl
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) {
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 
 	public BeanValidationQuickFixTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi20/NullValuesInjectionTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi20/NullValuesInjectionTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.bean.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.bean.template.NullValuesInjectionTemplate;
 import org.junit.Before;
@@ -36,15 +34,7 @@ public class NullValuesInjectionTestCDI20 extends NullValuesInjectionTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public NullValuesInjectionTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi20/VetoedAnnotationTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/cdi20/VetoedAnnotationTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.bean.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.bean.template.VetoedAnnotationTemplate;
 
@@ -35,15 +33,7 @@ public class VetoedAnnotationTestCDI20 extends VetoedAnnotationTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public VetoedAnnotationTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/template/VetoedAnnotationTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/bean/template/VetoedAnnotationTemplate.java
@@ -53,6 +53,12 @@ public class VetoedAnnotationTemplate extends CDITestBase{
 		List<Marker> markers = te.getMarkers();
 		assertEquals(5, markers.size());
 		for(Marker m: te.getMarkers()){
+			
+			// JBIDE-26664
+			if (CDIVersion.equals("1.2")) {
+				noInjection = "No bean is eligible for injection to the injection point [JSR-365 §5.2.2]";
+			}
+			
 			assertTrue((m.getLineNumber() == 17 && m.getType().equals(warning) && m.getText().equals(noInjection)) ||
 					(m.getLineNumber() == 20 && m.getType().equals(warning) && m.getText().equals(noInjection)) ||
 					(m.getLineNumber() == 26 && m.getType().equals(warning) && m.getText().equals(noInjection)) ||

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi10/DecoratorFromWebBeanTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi10/DecoratorFromWebBeanTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.decorator.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.decorator.template.DecoratorFromWebBeanTemplate;
 
@@ -30,12 +28,10 @@ public class DecoratorFromWebBeanTestCDI10 extends DecoratorFromWebBeanTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
+	}
+	
+	public DecoratorFromWebBeanTestCDI10() {
+		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi10/DecoratorValidationQuickFixTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi10/DecoratorValidationQuickFixTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.decorator.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.decorator.template.DecoratorValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.DecoratorValidationProvider;
@@ -32,18 +30,16 @@ public class DecoratorValidationQuickFixTestCDI10 extends DecoratorValidationQui
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
 	}
 	
 	@Before
 	public void setProvider(){
 		validationProvider = new DecoratorValidationProvider("JSR-299");
+	}
+	
+	public DecoratorValidationQuickFixTestCDI10(){
+		CDIVersion = "1.0";
 	}
 
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi11/DecoratorFromWebBeanTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi11/DecoratorFromWebBeanTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.decorator.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.decorator.template.DecoratorFromWebBeanTemplate;
 import org.junit.Before;
@@ -31,15 +29,11 @@ public class DecoratorFromWebBeanTestCDI11 extends DecoratorFromWebBeanTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public DecoratorFromWebBeanTestCDI11() {
+		CDIVersion = "1.2";
 	}
 	
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi11/DecoratorValidationQuickFixTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi11/DecoratorValidationQuickFixTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.decorator.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.decorator.template.DecoratorValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.DecoratorValidationProvider;
@@ -32,15 +30,11 @@ public class DecoratorValidationQuickFixTestCDI11 extends DecoratorValidationQui
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public DecoratorValidationQuickFixTestCDI11() {
+		CDIVersion = "1.2";
 	}
 	
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi20/DecoratorFromWebBeanTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi20/DecoratorFromWebBeanTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.decorator.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.decorator.template.DecoratorFromWebBeanTemplate;
 import org.junit.Before;
@@ -36,15 +34,7 @@ public class DecoratorFromWebBeanTestCDI20 extends DecoratorFromWebBeanTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public DecoratorFromWebBeanTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi20/DecoratorValidationQuickFixTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/cdi20/DecoratorValidationQuickFixTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.decorator.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.decorator.template.DecoratorValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.DecoratorValidationProvider;
@@ -37,15 +35,7 @@ public class DecoratorValidationQuickFixTestCDI20 extends DecoratorValidationQui
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public DecoratorValidationQuickFixTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/template/DecoratorFromWebBeanTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/template/DecoratorFromWebBeanTemplate.java
@@ -65,7 +65,7 @@ public abstract class DecoratorFromWebBeanTemplate extends CDITestBase {
 
 	@After
 	public void deleteProjects() {
-		deleteAllProjects();
+		cleanUp();
 	}
 	
 	@Test

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/template/DecoratorValidationQuickFixTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/decorator/template/DecoratorValidationQuickFixTemplate.java
@@ -45,7 +45,7 @@ public class DecoratorValidationQuickFixTemplate extends CDITestBase {
 	
 	@After
 	public void deleteProjects() {
-		deleteAllProjects();
+		cleanUp();
 	}
 	
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi10/AllAssignableDialogTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi10/AllAssignableDialogTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.dialog.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.dialog.template.AllAssignableDialogTemplate;
 
@@ -30,12 +28,10 @@ public class AllAssignableDialogTestCDI10 extends AllAssignableDialogTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
+	}
+	
+	public AllAssignableDialogTestCDI10() {
+		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi10/AssignableDialogFilterTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi10/AssignableDialogFilterTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.dialog.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.dialog.template.AssignableDialogFilterTemplate;
 
@@ -30,12 +28,10 @@ public class AssignableDialogFilterTestCDI10 extends AssignableDialogFilterTempl
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
+	}
+	
+	public AssignableDialogFilterTestCDI10() {
+		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi11/AllAssignableDialogTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi11/AllAssignableDialogTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.dialog.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.dialog.template.AllAssignableDialogTemplate;
 import org.junit.Before;
@@ -31,15 +29,11 @@ public class AllAssignableDialogTestCDI11 extends AllAssignableDialogTemplate {
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public AllAssignableDialogTestCDI11() {
+		CDIVersion = "1.2";
 	}
 	
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi11/AssignableDialogFilterTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi11/AssignableDialogFilterTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.dialog.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.dialog.template.AssignableDialogFilterTemplate;
 import org.junit.Before;
@@ -31,15 +29,11 @@ public class AssignableDialogFilterTestCDI11 extends AssignableDialogFilterTempl
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public AssignableDialogFilterTestCDI11() {
+		CDIVersion = "1.2";
 	}
 		
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi20/AllAssignableDialogTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi20/AllAssignableDialogTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.dialog.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.dialog.template.AllAssignableDialogTemplate;
 import org.junit.Before;
@@ -31,15 +29,7 @@ public class AllAssignableDialogTestCDI20 extends AllAssignableDialogTemplate {
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public AllAssignableDialogTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi20/AssignableDialogFilterTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/cdi20/AssignableDialogFilterTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.dialog.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.dialog.template.AssignableDialogFilterTemplate;
 import org.junit.Before;
@@ -31,15 +29,7 @@ public class AssignableDialogFilterTestCDI20 extends AssignableDialogFilterTempl
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public AssignableDialogFilterTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/template/AssignableDialogFilterTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/dialog/template/AssignableDialogFilterTemplate.java
@@ -40,7 +40,7 @@ public class AssignableDialogFilterTemplate extends CDITestBase {
 	
 	@After
 	public void deleteAll(){
-		deleteAllProjects();
+		cleanUp();
 	}
 	
 	private void createWithContent(String name){

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/ibinding/cdi10/IBindingValidationQuickFixTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/ibinding/cdi10/IBindingValidationQuickFixTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.ibinding.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.ibinding.template.IBindingValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.InterceptorBindingValidationProvider;
@@ -32,18 +30,16 @@ public class IBindingValidationQuickFixTestCDI10 extends IBindingValidationQuick
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
 	}
 	
 	@Before
 	public void setProvider(){
 		validationProvider = new InterceptorBindingValidationProvider("JSR-299");
 	}
-
+	
+	public IBindingValidationQuickFixTestCDI10() {
+		CDIVersion = "1.0";
+	}
+	
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/ibinding/cdi11/IBindingValidationQuickFixTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/ibinding/cdi11/IBindingValidationQuickFixTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.ibinding.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.ibinding.template.IBindingValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.InterceptorBindingValidationProvider;
@@ -32,15 +30,11 @@ public class IBindingValidationQuickFixTestCDI11 extends IBindingValidationQuick
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public IBindingValidationQuickFixTestCDI11() {
+		CDIVersion = "1.2";
 	}
 		
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/ibinding/cdi20/IBindingValidationQuickFixTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/ibinding/cdi20/IBindingValidationQuickFixTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.ibinding.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.ibinding.template.IBindingValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.InterceptorBindingValidationProvider;
@@ -37,15 +35,7 @@ public class IBindingValidationQuickFixTestCDI20 extends IBindingValidationQuick
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public IBindingValidationQuickFixTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/interceptor/cdi10/InterceptorValidationQuickFixTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/interceptor/cdi10/InterceptorValidationQuickFixTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.interceptor.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.interceptor.template.InterceptorValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.InterceptorValidationProvider;
@@ -32,13 +30,7 @@ public class InterceptorValidationQuickFixTestCDI10 extends InterceptorValidatio
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
 	}
 	
 	@Before
@@ -46,4 +38,8 @@ public class InterceptorValidationQuickFixTestCDI10 extends InterceptorValidatio
 		validationProvider = new InterceptorValidationProvider("JSR-299");
 	}
 
+	public InterceptorValidationQuickFixTestCDI10() {
+		CDIVersion = "1.0";
+	}
+	
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/interceptor/cdi11/InterceptorValidationQuickFixTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/interceptor/cdi11/InterceptorValidationQuickFixTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.interceptor.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.interceptor.template.InterceptorValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.InterceptorValidationProvider;
@@ -32,15 +30,11 @@ public class InterceptorValidationQuickFixTestCDI11 extends InterceptorValidatio
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public InterceptorValidationQuickFixTestCDI11() {
+		CDIVersion = "1.2";
 	}
 	
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/interceptor/cdi20/InterceptorValidationQuickFixTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/interceptor/cdi20/InterceptorValidationQuickFixTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.interceptor.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.interceptor.template.InterceptorValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.InterceptorValidationProvider;
@@ -37,15 +35,7 @@ public class InterceptorValidationQuickFixTestCDI20 extends InterceptorValidatio
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public InterceptorValidationQuickFixTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi10/NamedComponentsSearchingTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi10/NamedComponentsSearchingTestCDI10.java
@@ -11,7 +11,6 @@
 
 package org.jboss.tools.cdi.bot.test.beans.named.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -20,7 +19,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.named.teplate.NamedComponentsSearchingTemplate;
 
@@ -37,12 +35,10 @@ public class NamedComponentsSearchingTestCDI10 extends NamedComponentsSearchingT
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
+	}
+	
+	public NamedComponentsSearchingTestCDI10() {
+		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi10/NamedRefactoringTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi10/NamedRefactoringTestCDI10.java
@@ -11,7 +11,6 @@
 
 package org.jboss.tools.cdi.bot.test.beans.named.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -20,7 +19,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.named.teplate.NamedRefactoringTemplate;
 
@@ -37,12 +35,10 @@ public class NamedRefactoringTestCDI10 extends NamedRefactoringTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
+	}
+	
+	public NamedRefactoringTestCDI10() {
+		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi11/NamedComponentsSearchingTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi11/NamedComponentsSearchingTestCDI11.java
@@ -11,7 +11,6 @@
 
 package org.jboss.tools.cdi.bot.test.beans.named.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -20,7 +19,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.named.teplate.NamedComponentsSearchingTemplate;
 import org.junit.Before;
@@ -38,15 +36,11 @@ public class NamedComponentsSearchingTestCDI11 extends NamedComponentsSearchingT
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public NamedComponentsSearchingTestCDI11() {
+		CDIVersion = "1.2";
 	}
 		
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi11/NamedRefactoringTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi11/NamedRefactoringTestCDI11.java
@@ -11,7 +11,6 @@
 
 package org.jboss.tools.cdi.bot.test.beans.named.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -20,7 +19,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.named.teplate.NamedRefactoringTemplate;
 import org.junit.Before;
@@ -38,15 +36,11 @@ public class NamedRefactoringTestCDI11 extends NamedRefactoringTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public NamedRefactoringTestCDI11() {
+		CDIVersion = "1.2";
 	}
 	
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi20/NamedComponentsSearchingTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi20/NamedComponentsSearchingTestCDI20.java
@@ -11,7 +11,6 @@
 
 package org.jboss.tools.cdi.bot.test.beans.named.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -20,7 +19,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.named.teplate.NamedComponentsSearchingTemplate;
 import org.junit.Before;
@@ -37,15 +35,7 @@ public class NamedComponentsSearchingTestCDI20 extends NamedComponentsSearchingT
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public NamedComponentsSearchingTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi20/NamedRefactoringTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/cdi20/NamedRefactoringTestCDI20.java
@@ -11,7 +11,6 @@
 
 package org.jboss.tools.cdi.bot.test.beans.named.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -20,7 +19,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.named.teplate.NamedRefactoringTemplate;
 import org.junit.Before;
@@ -38,15 +36,7 @@ public class NamedRefactoringTestCDI20 extends NamedRefactoringTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public NamedRefactoringTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/teplate/NamedRefactoringTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/named/teplate/NamedRefactoringTemplate.java
@@ -44,7 +44,7 @@ public abstract class NamedRefactoringTemplate extends CDITestBase {//extends JS
 
 	@After
 	public void waitForJobs() {
-		deleteAllProjects();
+		cleanUp();
 	}
 	
 	@Test

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cd10/BeanInjectOpenOnTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cd10/BeanInjectOpenOnTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.openon.cd10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.openon.template.BeanInjectOpenOnTemplate;
 
@@ -30,12 +28,10 @@ public class BeanInjectOpenOnTestCDI10 extends BeanInjectOpenOnTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
+	}
+	
+	public BeanInjectOpenOnTestCDI10() {
+		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cd10/FindObserverEventTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cd10/FindObserverEventTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.openon.cd10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.openon.template.FindObserverEventTemplate;
 
@@ -30,12 +28,10 @@ public class FindObserverEventTestCDI10 extends FindObserverEventTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
+	}
+	
+	public FindObserverEventTestCDI10() {
+		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cdi11/BeanInjectOpenOnTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cdi11/BeanInjectOpenOnTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.openon.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.openon.template.BeanInjectOpenOnTemplate;
 import org.junit.Before;
@@ -31,15 +29,11 @@ public class BeanInjectOpenOnTestCDI11 extends BeanInjectOpenOnTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public BeanInjectOpenOnTestCDI11() {
+		CDIVersion = "1.2";
 	}
 		
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cdi11/FindObserverEventTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cdi11/FindObserverEventTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.openon.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.openon.template.FindObserverEventTemplate;
 import org.junit.Before;
@@ -31,15 +29,11 @@ public class FindObserverEventTestCDI11 extends FindObserverEventTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public FindObserverEventTestCDI11() {
+		CDIVersion = "1.2";
 	}
 		
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cdi20/BeanInjectOpenOnTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cdi20/BeanInjectOpenOnTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.openon.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.openon.template.BeanInjectOpenOnTemplate;
 import org.junit.Before;
@@ -36,15 +34,7 @@ public class BeanInjectOpenOnTestCDI20 extends BeanInjectOpenOnTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public BeanInjectOpenOnTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cdi20/FindObserverEventTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/cdi20/FindObserverEventTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.openon.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.openon.template.FindObserverEventTemplate;
 import org.junit.Before;
@@ -36,15 +34,7 @@ public class FindObserverEventTestCDI20 extends FindObserverEventTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public FindObserverEventTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/template/FindObserverEventTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/openon/template/FindObserverEventTemplate.java
@@ -72,7 +72,7 @@ public abstract class FindObserverEventTemplate extends CDITestBase {
 	
 	@After
 	public void clean(){
-		deleteAllProjects();
+		cleanUp();
 	}
 	
 	@Test

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/qualifier/cdi10/QualifierValidationQuickFixTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/qualifier/cdi10/QualifierValidationQuickFixTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.qualifier.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.qualifier.template.QualifierValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.QualifierValidationProvider;
@@ -32,18 +30,15 @@ public class QualifierValidationQuickFixTestCDI10 extends QualifierValidationQui
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
 	}
 	
 	@Before
 	public void setProvider(){
 		validationProvider = new QualifierValidationProvider("JSR-299");
+	}
+	
+	public QualifierValidationQuickFixTestCDI10() {
 		CDIVersion = "1.0";
 	}
 

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/qualifier/cdi11/QualifierValidationQuickFixTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/qualifier/cdi11/QualifierValidationQuickFixTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.qualifier.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.qualifier.template.QualifierValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.QualifierValidationProvider;
@@ -32,22 +30,17 @@ public class QualifierValidationQuickFixTestCDI11 extends QualifierValidationQui
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public QualifierValidationQuickFixTestCDI11() {
+		CDIVersion = "1.2";
 	}
 	
 	@Before
 	public void changeDiscoveryMode(){
 		validationProvider = new QualifierValidationProvider("JSR-346");
 		prepareBeanXml("all", true);
-		CDIVersion = "1.1";
 	}
 
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/qualifier/cdi20/QualifierValidationQuickFixTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/qualifier/cdi20/QualifierValidationQuickFixTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.qualifier.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.qualifier.template.QualifierValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.QualifierValidationProvider;
@@ -37,15 +35,7 @@ public class QualifierValidationQuickFixTestCDI20 extends QualifierValidationQui
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public QualifierValidationQuickFixTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/scope/cdi10/ScopeValidationQuickFixTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/scope/cdi10/ScopeValidationQuickFixTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.scope.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.scope.template.ScopeValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.ScopeValidationProviderCDI10;
@@ -32,18 +30,15 @@ public class ScopeValidationQuickFixTestCDI10 extends ScopeValidationQuickFixTem
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
 	}
 	
 	@Before
 	public void setProvider(){
 		validationProvider = new ScopeValidationProviderCDI10();
+	}
+	
+	public ScopeValidationQuickFixTestCDI10() {
 		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/scope/cdi11/ScopeValidationQuickFixTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/scope/cdi11/ScopeValidationQuickFixTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.scope.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.scope.template.ScopeValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.ScopeValidationProviderCDI11;
@@ -32,22 +30,17 @@ public class ScopeValidationQuickFixTestCDI11 extends ScopeValidationQuickFixTem
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public ScopeValidationQuickFixTestCDI11() {
+		CDIVersion = "1.2";
 	}
 	
 	@Before
 	public void changeDiscoveryMode(){
 		validationProvider = new ScopeValidationProviderCDI11();
 		prepareBeanXml("all", true);
-		CDIVersion = "1.1";
 	}
 
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/scope/cdi20/ScopeValidationQuickFixTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/scope/cdi20/ScopeValidationQuickFixTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.scope.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.scope.template.ScopeValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.ScopeValidationProviderCDI20;
@@ -37,15 +35,7 @@ public class ScopeValidationQuickFixTestCDI20 extends ScopeValidationQuickFixTem
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public ScopeValidationQuickFixTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/stereotype/cdi10/StereotypeValidationQuickFixTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/stereotype/cdi10/StereotypeValidationQuickFixTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.stereotype.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.stereotype.template.StereotypeValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.StereotypeValidationProviderCDI10;
@@ -32,18 +30,15 @@ public class StereotypeValidationQuickFixTestCDI10 extends StereotypeValidationQ
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
 	}
 	
 	@Before
 	public void setProvider(){
 		validationProvider = new StereotypeValidationProviderCDI10();
+	}
+	
+	public StereotypeValidationQuickFixTestCDI10() {
 		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/stereotype/cdi11/StereotypeValidationQuickFixTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/stereotype/cdi11/StereotypeValidationQuickFixTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.stereotype.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.stereotype.template.StereotypeValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.StereotypeValidationProviderCDI11;
@@ -32,22 +30,17 @@ public class StereotypeValidationQuickFixTestCDI11 extends StereotypeValidationQ
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public StereotypeValidationQuickFixTestCDI11() {
+		CDIVersion = "1.2";
 	}
 	
 	@Before
 	public void changeDiscoveryMode(){
 		validationProvider = new StereotypeValidationProviderCDI11();
 		prepareBeanXml("all", true);
-		CDIVersion = "1.1";
 	}
 
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/stereotype/cdi20/StereotypeValidationQuickFixTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/stereotype/cdi20/StereotypeValidationQuickFixTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beans.stereotype.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beans.stereotype.template.StereotypeValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.StereotypeValidationProviderCDI20;
@@ -37,15 +35,7 @@ public class StereotypeValidationQuickFixTestCDI20 extends StereotypeValidationQ
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public StereotypeValidationQuickFixTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/stereotype/template/StereotypeValidationQuickFixTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beans/stereotype/template/StereotypeValidationQuickFixTemplate.java
@@ -43,7 +43,7 @@ public class StereotypeValidationQuickFixTemplate extends CDITestBase {
 	
 	@After
 	public void deleteProjects(){
-		deleteAllProjects();
+		cleanUp();
 	}
 	
 	// https://issues.jboss.org/browse/JBIDE-7630

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/annotation/cdi11/BeanParametersAnnotationTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/annotation/cdi11/BeanParametersAnnotationTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.annotation.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.annotation.template.BeanParametersAnnotationTemplate;
 
@@ -35,14 +33,10 @@ public class BeanParametersAnnotationTestCDI11 extends BeanParametersAnnotationT
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public BeanParametersAnnotationTestCDI11(){
+		CDIVersion = "1.2";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/annotation/cdi20/BeanParametersAnnotationTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/annotation/cdi20/BeanParametersAnnotationTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.annotation.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,9 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.beansxml.annotation.template.BeanParametersAnnotationTemplate;
 
 /**
@@ -36,15 +33,7 @@ public class BeanParametersAnnotationTestCDI20 extends BeanParametersAnnotationT
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public BeanParametersAnnotationTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/annotation/template/BeanParametersAnnotationTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/annotation/template/BeanParametersAnnotationTemplate.java
@@ -49,7 +49,7 @@ public class BeanParametersAnnotationTemplate extends CDITestBase {
 
 	@After
 	public void clean() {
-		deleteAllProjects();
+		cleanUp();
 	}
 
 	@Test
@@ -76,7 +76,13 @@ public class BeanParametersAnnotationTemplate extends CDITestBase {
 		if ("2.0".equals(CDIVersion)) {
 			assertTrue(validation.getDescription()
 					.contains("No bean is eligible for injection to the injection point [JSR-365 §5.2.2]"));
-		} else {
+		}
+		// JBIDE-26664
+		else if ("1.2".equals(CDIVersion)) {
+			assertTrue(validation.getDescription()
+					.contains("No bean is eligible for injection to the injection point [JSR-365 §5.2.2]"));
+		}
+		else {
 			assertTrue(validation.getDescription()
 					.contains("No bean is eligible for injection to the injection point [JSR-346 §5.2.2]"));
 		}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/bean/cdi11/ExcludeBeanTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/bean/cdi11/ExcludeBeanTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.bean.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.bean.template.ExcludeBeanTemplate;
 import org.jboss.tools.cdi.reddeer.common.model.ui.editor.EditorPartWrapper;
@@ -33,15 +31,11 @@ public class ExcludeBeanTestCDI11 extends ExcludeBeanTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public ExcludeBeanTestCDI11(){
+		CDIVersion = "1.2";
 	}
 	
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/bean/cdi20/ExcludeBeanTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/bean/cdi20/ExcludeBeanTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.bean.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.bean.template.ExcludeBeanTemplate;
 import org.jboss.tools.cdi.reddeer.common.model.ui.editor.EditorPartWrapper;
@@ -38,15 +36,7 @@ public class ExcludeBeanTestCDI20 extends ExcludeBeanTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public ExcludeBeanTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/bean/template/ExcludeBeanTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/bean/template/ExcludeBeanTemplate.java
@@ -91,12 +91,18 @@ public class ExcludeBeanTemplate extends CDITestBase{
 		
 		for(Marker m: ed.getMarkers()){
 			
+			// JBIDE-26664
+			String expectedJSRVersion = expected.getJSR();
+			if (CDIVersion.equals("1.2")) {
+				expectedJSRVersion = "JSR-365";
+			}
+			
 			assertTrue((m.getLineNumber() == 16 && m.getType().equals(warning) && m.getText().contains(expected.getMessage())
-					&& m.getText().contains(expected.getJSR())) ||
+					&& m.getText().contains(expectedJSRVersion)) ||
 					(m.getLineNumber() == 18 && m.getType().equals(warning) && m.getText().contains(expected.getMessage())
-					&& m.getText().contains(expected.getJSR())) ||
+					&& m.getText().contains(expectedJSRVersion)) ||
 					(m.getLineNumber() == 19 && m.getType().equals(warning) && m.getText().contains(expected.getMessage())
-					&& m.getText().contains(expected.getJSR())) );
+					&& m.getText().contains(expectedJSRVersion)) );
 		}
 		
 		ProblemsView pw = new ProblemsView();

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi10/BeansXMLBeansEditorTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi10/BeansXMLBeansEditorTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.template.BeansXMLBeansEditorTemplate;
 
@@ -30,12 +28,10 @@ public class BeansXMLBeansEditorTestCDI10 extends BeansXMLBeansEditorTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
+	}
+	
+	public BeansXMLBeansEditorTestCDI10() {
+		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi10/BeansXMLValidationTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi10/BeansXMLValidationTestCDI10.java
@@ -11,7 +11,6 @@
 
 package org.jboss.tools.cdi.bot.test.beansxml.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -20,7 +19,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.template.BeansXMLValidationTemplate;
 import org.jboss.tools.cdi.reddeer.common.model.ui.editor.EditorPartWrapper;
@@ -41,13 +39,7 @@ public class BeansXMLValidationTestCDI10 extends BeansXMLValidationTemplate {
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
 	}
 
 	@Before
@@ -58,5 +50,9 @@ public class BeansXMLValidationTestCDI10 extends BeansXMLValidationTemplate {
 		beansEditor.activateSourcePage();
 		new EditorResourceHelper().replaceInEditor("/>", "></beans>", true);
 		beansEditor.close();
+	}
+	
+	public BeansXMLValidationTestCDI10() {
+		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi11/BeansXMLBeansEditorTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi11/BeansXMLBeansEditorTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.template.BeansXMLBeansEditorTemplate;
 import org.junit.Before;
@@ -31,15 +29,11 @@ public class BeansXMLBeansEditorTestCDI11 extends BeansXMLBeansEditorTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public BeansXMLBeansEditorTestCDI11() {
+		CDIVersion = "1.2";
 	}
 	
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi11/BeansXMLDiscoveryModesTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi11/BeansXMLDiscoveryModesTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.template.BeansXMLDiscoveryModesTemplate;
 
@@ -30,14 +28,10 @@ public class BeansXMLDiscoveryModesTestCDI11 extends BeansXMLDiscoveryModesTempl
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public BeansXMLDiscoveryModesTestCDI11(){
+		CDIVersion = "1.2";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi11/BeansXMLUITestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi11/BeansXMLUITestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.template.BeansXMLUITemplate;
 import org.jboss.tools.cdi.reddeer.validators.BeansXmlUIValidationProvider;
@@ -32,20 +30,15 @@ public class BeansXMLUITestCDI11 extends BeansXMLUITemplate {
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public BeansXMLUITestCDI11(){
+		CDIVersion = "1.2";
 	}
 
 	@Before
 	public void setCDIVersion() {
-		CDIVersion = "1.1";
 		validationProvider = new BeansXmlUIValidationProvider("JSR-346");
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi11/BeansXMLValidationTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi11/BeansXMLValidationTestCDI11.java
@@ -11,7 +11,6 @@
 
 package org.jboss.tools.cdi.bot.test.beansxml.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -20,7 +19,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.template.BeansXMLValidationTemplate;
 import org.jboss.tools.cdi.reddeer.validators.BeansXmlValidationProviderCDI11;
@@ -39,15 +37,11 @@ public class BeansXMLValidationTestCDI11 extends BeansXMLValidationTemplate {
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public BeansXMLValidationTestCDI11() {
+		CDIVersion = "1.2";
 	}
 	
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi20/BeansXMLBeansEditorTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi20/BeansXMLBeansEditorTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.template.BeansXMLBeansEditorTemplate;
 import org.junit.Before;
@@ -36,15 +34,7 @@ public class BeansXMLBeansEditorTestCDI20 extends BeansXMLBeansEditorTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 
 	public BeansXMLBeansEditorTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi20/BeansXMLDiscoveryModesTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi20/BeansXMLDiscoveryModesTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.template.BeansXMLDiscoveryModesTemplate;
 
@@ -35,15 +33,7 @@ public class BeansXMLDiscoveryModesTestCDI20 extends BeansXMLDiscoveryModesTempl
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) {
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 
 	public BeansXMLDiscoveryModesTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi20/BeansXMLUITestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi20/BeansXMLUITestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,9 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.beansxml.template.BeansXMLUITemplate;
 import org.jboss.tools.cdi.reddeer.validators.BeansXmlUIValidationProvider;
 import org.junit.Before;
@@ -38,15 +35,7 @@ public class BeansXMLUITestCDI20 extends BeansXMLUITemplate {
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public BeansXMLUITestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi20/BeansXMLValidationTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/cdi20/BeansXMLValidationTestCDI20.java
@@ -11,7 +11,6 @@
 
 package org.jboss.tools.cdi.bot.test.beansxml.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -20,7 +19,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.template.BeansXMLValidationTemplate;
 import org.jboss.tools.cdi.reddeer.validators.BeansXmlValidationProviderCDI20;
@@ -38,15 +36,7 @@ public class BeansXMLValidationTestCDI20 extends BeansXMLValidationTemplate {
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 
 	public BeansXMLValidationTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/completion/cdi10/BeansXMLCompletionTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/completion/cdi10/BeansXMLCompletionTestCDI10.java
@@ -21,7 +21,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.completion.template.BeansXMLCompletionTemplate;
 import org.junit.Before;
@@ -39,18 +38,16 @@ public class BeansXMLCompletionTestCDI10 extends BeansXMLCompletionTemplate {
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
 	}
 	
 	@Before
 	public void changeBeansXml(){
 		setBeansXmlTags(Arrays.asList("alternatives", "decorators", "interceptors"));
+	}
+	
+	public BeansXMLCompletionTestCDI10() {
+		CDIVersion = "1.0";
 	}
 	
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/completion/cdi11/BeansXMLCompletionTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/completion/cdi11/BeansXMLCompletionTestCDI11.java
@@ -20,7 +20,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.completion.template.BeansXMLCompletionTemplate;
 import org.junit.Before;
@@ -38,15 +37,11 @@ public class BeansXMLCompletionTestCDI11 extends BeansXMLCompletionTemplate {
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public BeansXMLCompletionTestCDI11() {
+		CDIVersion = "1.2";
 	}
 	
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/completion/cdi20/BeansXMLCompletionTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/completion/cdi20/BeansXMLCompletionTestCDI20.java
@@ -20,10 +20,10 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.completion.template.BeansXMLCompletionTemplate;
 import org.junit.Before;
+import org.junit.Test;
 
 /**
 *
@@ -37,15 +37,7 @@ public class BeansXMLCompletionTestCDI20 extends BeansXMLCompletionTemplate {
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) {
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 
 	public BeansXMLCompletionTestCDI20() {
@@ -56,5 +48,20 @@ public class BeansXMLCompletionTestCDI20 extends BeansXMLCompletionTemplate {
 	public void changeDiscoveryMode(){
 		prepareBeanXml("all", true);
 		setBeansXmlTags(Arrays.asList("alternatives", "decorators", "interceptors","scan", "trim"));
+	}
+	
+	@Test
+	public void trimUiSupportTest() {
+		super.testTrimUiSupport();
+	}
+	
+	@Test
+	public void trimDiscoverAllScopeAnnotationsTest() {
+		super.testTrimDiscoverAllScopeAnnotations();
+	}
+	
+	@Test
+	public void trimDiscoverAllBeanDefinitionAnnotationsTest() {
+		super.testTrimDiscoverAllBeanDefinitionAnnotations();
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/completion/template/BeansXMLCompletionTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/completion/template/BeansXMLCompletionTemplate.java
@@ -68,7 +68,7 @@ public abstract class BeansXMLCompletionTemplate extends CDITestBase {
 	
 	@After
 	public void cleanup(){
-		deleteAllProjects();
+		cleanUp();
 	}
 	
 	protected void setBeansXmlTags(List<String> tags){
@@ -197,8 +197,7 @@ public abstract class BeansXMLCompletionTemplate extends CDITestBase {
 
 	}
 	
-	@Test
-	public void testTrimUiSupport() {
+	protected void testTrimUiSupport() {
 		addTheTrimTagToBeansXmlFile();
 
 		ProblemsView pv = new ProblemsView();
@@ -214,8 +213,7 @@ public abstract class BeansXMLCompletionTemplate extends CDITestBase {
 		beansEditor.close();
 	}
 	
-	@Test
-	public void testTrimDiscoverAllScopeAnnotations() {
+	protected void testTrimDiscoverAllScopeAnnotations() {
 		addTheTrimTagToBeansXmlFile();
 
 		String[] annotationsThatShouldBeDiscovered = { "ApplicationScoped", "SessionScoped", "ConversationScoped",
@@ -235,8 +233,7 @@ public abstract class BeansXMLCompletionTemplate extends CDITestBase {
 		}
 	}
 	
-	@Test
-	public void testTrimDiscoverAllBeanDefinitionAnnotations() {
+	protected void testTrimDiscoverAllBeanDefinitionAnnotations() {
 		addTheTrimTagToBeansXmlFile();
 
 		createNewClass(PROJECT_NAME, TEST_PACKAGE_NAME, "Test");

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/discovery/cdi11/BeanDiscoveryInExplicitArchivesTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/discovery/cdi11/BeanDiscoveryInExplicitArchivesTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.discovery.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.discovery.template.BeanDiscoveryInArchivesTemplate;
 import org.junit.Test;
@@ -36,14 +34,7 @@ public class BeanDiscoveryInExplicitArchivesTestCDI11 extends BeanDiscoveryInArc
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
 	}
 	
 	public BeanDiscoveryInExplicitArchivesTestCDI11() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/discovery/cdi11/BeanDiscoveryInImplicitArchivesTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/discovery/cdi11/BeanDiscoveryInImplicitArchivesTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.discovery.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.discovery.template.BeanDiscoveryInArchivesTemplate;
 import org.junit.Test;
@@ -36,15 +34,7 @@ public class BeanDiscoveryInImplicitArchivesTestCDI11 extends BeanDiscoveryInArc
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
 	}
 	
 	public BeanDiscoveryInImplicitArchivesTestCDI11() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/discovery/cdi20/BeanDiscoveryInExplicitArchivesTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/discovery/cdi20/BeanDiscoveryInExplicitArchivesTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.discovery.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,9 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.beansxml.discovery.template.BeanDiscoveryInArchivesTemplate;
 import org.junit.Test;
 
@@ -37,15 +34,7 @@ public class BeanDiscoveryInExplicitArchivesTestCDI20 extends BeanDiscoveryInArc
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public BeanDiscoveryInExplicitArchivesTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/discovery/cdi20/BeanDiscoveryInImplicitArchivesTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/discovery/cdi20/BeanDiscoveryInImplicitArchivesTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.discovery.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,9 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.beansxml.discovery.template.BeanDiscoveryInArchivesTemplate;
 import org.junit.Test;
 
@@ -37,15 +34,7 @@ public class BeanDiscoveryInImplicitArchivesTestCDI20 extends BeanDiscoveryInArc
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public BeanDiscoveryInImplicitArchivesTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/discovery/template/BeanDiscoveryInArchivesTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/discovery/template/BeanDiscoveryInArchivesTemplate.java
@@ -45,7 +45,7 @@ public class BeanDiscoveryInArchivesTemplate extends CDITestBase {
 	
 	@After
 	public void clean() {
-		deleteAllProjects();
+		cleanUp();
 	}
 	
 	public void validationOfBeanDiscoveryInExplicitArchives() {
@@ -65,7 +65,13 @@ public class BeanDiscoveryInArchivesTemplate extends CDITestBase {
 		assertEquals(1, markers.size());
 		Marker validation = markers.get(0);
 		assertEquals(validation.getLineNumber(), 8);
-		String jsrVersion = "2.0".equals(CDIVersion) ? "JSR-365" : "JSR-346";
+		String jsrVersion = "2.0".equals(CDIVersion) ? JSR_365 : "JSR-346";
+		
+		// JBIDE-26664
+		if (CDIVersion.equals("1.2")) {
+			jsrVersion = JSR_365;
+		}
+		
 		assertTrue(validation.getText().contains("No bean is eligible for injection to the injection point [" + jsrVersion + " §5.2.2]"));
 	}
 	
@@ -84,7 +90,13 @@ public class BeanDiscoveryInArchivesTemplate extends CDITestBase {
 		assertEquals(1, markers.size());
 		Marker validation = markers.get(0);
 		assertEquals(validation.getLineNumber(), 7);
-		String jsrVersion = "2.0".equals(CDIVersion) ? "JSR-365" : "JSR-346";
+		String jsrVersion = "2.0".equals(CDIVersion) ? JSR_365 : "JSR-346";
+		
+		// JBIDE-26664
+		if (CDIVersion.equals("1.2")) {
+			jsrVersion = JSR_365;
+		}
+		
 		assertTrue(validation.getText().contains("No bean is eligible for injection to the injection point [" + jsrVersion + " §5.2.2]"));
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/openon/cdi10/BeansXMLOpenOnTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/openon/cdi10/BeansXMLOpenOnTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.openon.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.openon.template.BeansXMLOpenOnTemplate;
 
@@ -30,12 +28,10 @@ public class BeansXMLOpenOnTestCDI10 extends BeansXMLOpenOnTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
+	}
+	
+	public BeansXMLOpenOnTestCDI10() {
+		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/openon/cdi11/BeansXMLOpenOnTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/openon/cdi11/BeansXMLOpenOnTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.openon.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.openon.template.BeansXMLOpenOnTemplate;
 
@@ -30,14 +28,10 @@ public class BeansXMLOpenOnTestCDI11 extends BeansXMLOpenOnTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public BeansXMLOpenOnTestCDI11() {
+		CDIVersion = "1.2";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/openon/cdi20/BeansXMLOpenOnTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/openon/cdi20/BeansXMLOpenOnTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.openon.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,9 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.beansxml.openon.template.BeansXMLOpenOnTemplate;
 
 /** 
@@ -36,15 +33,7 @@ public class BeansXMLOpenOnTestCDI20 extends BeansXMLOpenOnTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public BeansXMLOpenOnTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/template/BeansXMLBeansEditorTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/template/BeansXMLBeansEditorTemplate.java
@@ -39,7 +39,7 @@ public abstract class BeansXMLBeansEditorTemplate extends CDITestBase {
 	
 	@After
 	public void cleanup(){
-		deleteAllProjects();
+		cleanUp();
 	}
 			
 	@Test

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/template/BeansXMLDiscoveryModesTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/template/BeansXMLDiscoveryModesTemplate.java
@@ -11,6 +11,7 @@
 package org.jboss.tools.cdi.bot.test.beansxml.template;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 import java.util.List;
@@ -48,7 +49,7 @@ public class BeansXMLDiscoveryModesTemplate extends CDITestBase{
 	
 	@After
 	public void clean(){
-		deleteAllProjects();
+		cleanUp();
 	}
 	
 	@Test
@@ -80,8 +81,13 @@ public class BeansXMLDiscoveryModesTemplate extends CDITestBase{
 			assertEquals("No bean is eligible for injection to the injection point [JSR-365 §5.2.2]",
 					markers.get(0).getText());
 		} else {
-			assertEquals("No bean is eligible for injection to the injection point [JSR-346 §5.2.2]",
-					markers.get(0).getText());
+			// JBIDE-26664
+			assertFalse("Issue JBIDE-26664 seems to be fixed.", markers.get(0).getText().contains("[JSR-346 §5.2.2]"));
+			
+			
+			// Uncomment the following code when the issue JBIDE-26664 is resolved
+			//assertEquals("No bean is eligible for injection to the injection point [JSR-346 §5.2.2]",
+			//		markers.get(0).getText());
 		}
 		assertEquals(7,markers.get(0).getLineNumber());
 		
@@ -128,8 +134,13 @@ public class BeansXMLDiscoveryModesTemplate extends CDITestBase{
 			assertEquals("No bean is eligible for injection to the injection point [JSR-365 §5.2.2]",
 					markers.get(0).getText());
 		} else {
-			assertEquals("No bean is eligible for injection to the injection point [JSR-346 §5.2.2]",
-					markers.get(0).getText());
+			// JBIDE-26664
+			assertFalse("Issue JBIDE-26664 seems to be fixed.", markers.get(0).getText().contains("[JSR-346 §5.2.2]"));
+			
+			
+			// Uncomment the following code when the issue JBIDE-26664 is resolved
+			//assertEquals("No bean is eligible for injection to the injection point [JSR-346 §5.2.2]",
+			//		markers.get(0).getText());
 		}
 		assertEquals(7,markers.get(0).getLineNumber());
 		

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/template/BeansXMLUITemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/template/BeansXMLUITemplate.java
@@ -39,7 +39,7 @@ public class BeansXMLUITemplate extends CDITestBase {
 
 	@After
 	public void cleanup() {
-		deleteAllProjects();
+		cleanUp();
 	}
 
 	@Test
@@ -82,7 +82,13 @@ public class BeansXMLUITemplate extends CDITestBase {
 	public void testBeansVersion() {
 		EditorPartWrapper beans = beansXMLHelper.openBeansXml(PROJECT_NAME);
 		beans.activateTreePage();
-		assertEquals(CDIVersion, beans.getVersion());
+		
+		// JBIDE-26947
+		if (CDIVersion.equals("1.2")) {
+			assertEquals("1.1", beans.getVersion());
+		} else {
+			assertEquals(CDIVersion, beans.getVersion());
+		}
 	}
 
 	@Test

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/template/BeansXMLValidationTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/template/BeansXMLValidationTemplate.java
@@ -59,7 +59,7 @@ public abstract class BeansXMLValidationTemplate extends CDITestBase {
 	
 	@After
 	public void cleanup(){
-		deleteAllProjects();
+		cleanUp();
 	}
 	
 	@Test

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi10/BeansXMLAsYouTypeValidationTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi10/BeansXMLAsYouTypeValidationTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.validation.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.validation.template.BeansXMLAsYouTypeValidationTemplate;
 
@@ -30,12 +28,10 @@ public class BeansXMLAsYouTypeValidationTestCDI10 extends BeansXMLAsYouTypeValid
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
+	}
+	
+	public BeansXMLAsYouTypeValidationTestCDI10() {
+		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi10/BeansXMLValidationQuickFixTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi10/BeansXMLValidationQuickFixTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.validation.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.validation.template.BeansXMLValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.BeansXmlValidationProviderCDI10;
@@ -32,17 +30,15 @@ public class BeansXMLValidationQuickFixTestCDI10 extends BeansXMLValidationQuick
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
 	}
 	
 	@Before
 	public void setValidationProvider(){
 		validationProvider = new BeansXmlValidationProviderCDI10();
+	}
+	
+	public BeansXMLValidationQuickFixTestCDI10() {
+		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi11/BeansXMLAsYouTypeValidationTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi11/BeansXMLAsYouTypeValidationTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.validation.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.validation.template.BeansXMLAsYouTypeValidationTemplate;
 import org.junit.Before;
@@ -31,15 +29,11 @@ public class BeansXMLAsYouTypeValidationTestCDI11 extends BeansXMLAsYouTypeValid
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public BeansXMLAsYouTypeValidationTestCDI11() {
+		CDIVersion = "1.2";
 	}
 	
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi11/BeansXMLValidationQuickFixTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi11/BeansXMLValidationQuickFixTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.validation.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.common.wait.WaitWhile;
@@ -21,7 +20,6 @@ import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
 import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.validation.template.BeansXMLValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.BeansXmlValidationProviderCDI11;
@@ -34,15 +32,11 @@ public class BeansXMLValidationQuickFixTestCDI11 extends BeansXMLValidationQuick
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public BeansXMLValidationQuickFixTestCDI11() {
+		CDIVersion = "1.2";
 	}
 	
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi20/BeansXMLAsYouTypeValidationTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi20/BeansXMLAsYouTypeValidationTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.validation.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,9 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.beansxml.validation.template.BeansXMLAsYouTypeValidationTemplate;
 import org.junit.Before;
 
@@ -37,15 +34,7 @@ public class BeansXMLAsYouTypeValidationTestCDI20 extends BeansXMLAsYouTypeValid
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public BeansXMLAsYouTypeValidationTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi20/BeansXMLValidationQuickFixTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/cdi20/BeansXMLValidationQuickFixTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.beansxml.validation.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.common.wait.WaitWhile;
@@ -21,7 +20,6 @@ import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
 import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.beansxml.validation.template.BeansXMLValidationQuickFixTemplate;
 import org.jboss.tools.cdi.reddeer.validators.BeansXmlValidationProviderCDI20;
@@ -39,15 +37,7 @@ public class BeansXMLValidationQuickFixTestCDI20 extends BeansXMLValidationQuick
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 
 	public BeansXMLValidationQuickFixTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/template/BeansXMLValidationQuickFixTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/beansxml/validation/template/BeansXMLValidationQuickFixTemplate.java
@@ -58,7 +58,7 @@ public class BeansXMLValidationQuickFixTemplate extends CDITestBase {
 
 	@After
 	public void cleanup() {
-		deleteAllProjects();
+		cleanUp();
 	}
 	
 	@Test

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/validation/cdi10/CDIValidatorTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/validation/cdi10/CDIValidatorTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.validation.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.validation.template.CDIValidatorTemplate;
 
@@ -30,12 +28,10 @@ public class CDIValidatorTestCDI10 extends CDIValidatorTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
+	}
+	
+	public CDIValidatorTestCDI10() {
+		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/validation/cdi11/CDIValidatorTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/validation/cdi11/CDIValidatorTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.validation.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.validation.template.CDIValidatorTemplate;
 import org.junit.Before;
@@ -31,15 +29,11 @@ public class CDIValidatorTestCDI11 extends CDIValidatorTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public CDIValidatorTestCDI11() {
+		CDIVersion = "1.2";
 	}
 	
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/validation/cdi20/CDIValidatorTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/validation/cdi20/CDIValidatorTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.validation.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.validation.template.CDIValidatorTemplate;
 import org.junit.Before;
@@ -36,15 +34,7 @@ public class CDIValidatorTestCDI20 extends CDIValidatorTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) {
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 
 	public CDIValidatorTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi10/WeldBuiltInContextsTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi10/WeldBuiltInContextsTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.weld.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.weld.template.WeldBuiltInContextsTemplate;
 
@@ -30,13 +28,7 @@ public class WeldBuiltInContextsTestCDI10 extends WeldBuiltInContextsTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
 	}
 	
 	public WeldBuiltInContextsTestCDI10() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi10/WeldExcludeTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi10/WeldExcludeTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.weld.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.weld.template.WeldExcludeTemplate;
 import org.jboss.tools.cdi.reddeer.validators.BeanValidationProvider;
@@ -32,18 +30,16 @@ public class WeldExcludeTestCDI10 extends WeldExcludeTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
 	}
 	
 	@Before
 	public void setValidationProvider(){
 		validationProvider = new BeanValidationProvider("JSR-299");
+	}
+	
+	public WeldExcludeTestCDI10() {
+		CDIVersion = "1.0";
 	}
 
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi10/WeldParametersAnnotationTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi10/WeldParametersAnnotationTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.weld.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.weld.template.WeldParametersAnnotationTemplate;
 
@@ -30,12 +28,10 @@ public class WeldParametersAnnotationTestCDI10 extends WeldParametersAnnotationT
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
+	}
+	
+	public WeldParametersAnnotationTestCDI10() {
+		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi10/WeldScanTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi10/WeldScanTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.weld.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.weld.template.WeldScanTemplate;
 
@@ -30,12 +28,10 @@ public class WeldScanTestCDI10 extends WeldScanTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
+	}
+	
+	public WeldScanTestCDI10() {
+		CDIVersion = "1.0";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi11/WeldBuiltInContextsTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi11/WeldBuiltInContextsTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.weld.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.weld.template.WeldBuiltInContextsTemplate;
 
@@ -30,15 +28,11 @@ public class WeldBuiltInContextsTestCDI11 extends WeldBuiltInContextsTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public WeldBuiltInContextsTestCDI11() {
+		CDIVersion = "1.2";
 	}
 	
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi11/WeldExcludeTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi11/WeldExcludeTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.weld.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.weld.template.WeldExcludeTemplate;
 import org.jboss.tools.cdi.reddeer.validators.BeanValidationProvider;
@@ -32,15 +30,11 @@ public class WeldExcludeTestCDI11 extends WeldExcludeTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public WeldExcludeTestCDI11() {
+		CDIVersion = "1.2";
 	}
 	
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi11/WeldParametersAnnotationTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi11/WeldParametersAnnotationTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.weld.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.weld.template.WeldParametersAnnotationTemplate;
 import org.junit.Before;
@@ -31,15 +29,11 @@ public class WeldParametersAnnotationTestCDI11 extends WeldParametersAnnotationT
 	
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public WeldParametersAnnotationTestCDI11() {
+		CDIVersion = "1.2";
 	}
 	
 	@Before

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi11/WeldScanTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi11/WeldScanTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.weld.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.weld.template.WeldScanTemplate;
 
@@ -30,14 +28,10 @@ public class WeldScanTestCDI11 extends WeldScanTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
+	}
+	
+	public WeldScanTestCDI11() {
+		CDIVersion = "1.2";
 	}
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi20/WeldBuiltInContextsTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi20/WeldBuiltInContextsTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.weld.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.weld.template.WeldBuiltInContextsTemplate;
 
@@ -35,15 +33,7 @@ public class WeldBuiltInContextsTestCDI20 extends WeldBuiltInContextsTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public WeldBuiltInContextsTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi20/WeldExcludeTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi20/WeldExcludeTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.weld.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.weld.template.WeldExcludeTemplate;
 import org.jboss.tools.cdi.reddeer.validators.BeanValidationProvider;
@@ -37,15 +35,7 @@ public class WeldExcludeTestCDI20 extends WeldExcludeTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public WeldExcludeTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi20/WeldParametersAnnotationTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi20/WeldParametersAnnotationTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.weld.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.weld.template.WeldParametersAnnotationTemplate;
 import org.junit.Before;
@@ -36,15 +34,7 @@ public class WeldParametersAnnotationTestCDI20 extends WeldParametersAnnotationT
 	
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public WeldParametersAnnotationTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi20/WeldScanTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/cdi20/WeldScanTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.weld.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,7 +18,6 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.cdi.bot.test.weld.template.WeldScanTemplate;
 
@@ -35,15 +33,7 @@ public class WeldScanTestCDI20 extends WeldScanTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public WeldScanTestCDI20() {

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/template/WeldBuiltInContextsTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/template/WeldBuiltInContextsTemplate.java
@@ -46,7 +46,7 @@ public class WeldBuiltInContextsTemplate extends CDITestBase{
 		jp.setPackage("test");
 		jp.setName("BuiltInContexts");
 		jd.finish();
-		projectHelper.addLibrariesIntoProject(PROJECT_NAME, WELD_API_JAR);
+		projectHelper.addLibrariesIntoProject(PROJECT_NAME, WELD_API_JAR, isJava11FacetActivated);
 		editResourceUtil.replaceClassContentByResource("BuiltInContexts.java", readFile("resources/cdi11/BuiltInContexts.jav_"), false);
 	}
 	
@@ -61,6 +61,9 @@ public class WeldBuiltInContextsTemplate extends CDITestBase{
 			String JSRspec = "[JSR-346 §5.2.2]";
 			if("1.0".equals(CDIVersion)){
 				JSRspec = "[JSR-299 §5.2.1]";
+			} else if ("1.2".equals(CDIVersion)) {
+				// JBIDE-26664
+				JSRspec = "[JSR-365 §5.2.2]";
 			} else if ("2.0".equals(CDIVersion)) {
 				JSRspec = "[JSR-365 §5.2.2]";
 			}

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/template/WeldExcludeTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/template/WeldExcludeTemplate.java
@@ -96,14 +96,20 @@ public class WeldExcludeTemplate extends CDITestBase{
 		
 		for(Marker m: ed.getMarkers()){
 			
+			// JBIDE-26664
+			String expectedJSRVersion = expected.getJSR();
+			if (CDIVersion.equals("1.2")) {
+				expectedJSRVersion = "JSR-365";
+			}
+			
 			assertTrue((m.getLineNumber() == 14 && m.getType().equals(warning) && m.getText().contains(expected.getMessage())
-					&& m.getText().contains(expected.getJSR())) ||
+					&& m.getText().contains(expectedJSRVersion)) ||
 					(m.getLineNumber() == 16 && m.getType().equals(warning) && m.getText().contains(expected.getMessage())
-					&& m.getText().contains(expected.getJSR())) ||
+					&& m.getText().contains(expectedJSRVersion)) ||
 					(m.getLineNumber() == 18 && m.getType().equals(warning) && m.getText().contains(expected.getMessage())
-					&& m.getText().contains(expected.getJSR())) ||
+					&& m.getText().contains(expectedJSRVersion)) ||
 					(m.getLineNumber() == 19 && m.getType().equals(warning) && m.getText().contains(expected.getMessage())
-					&& m.getText().contains(expected.getJSR())) );
+					&& m.getText().contains(expectedJSRVersion)) );
 		}
 		
 		List<Problem> foundProblems = validationHelper.findProblems(expected);

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/template/WeldParametersAnnotationTemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/weld/template/WeldParametersAnnotationTemplate.java
@@ -34,7 +34,7 @@ public class WeldParametersAnnotationTemplate extends CDITestBase{
 	
 	@Before
 	public void addLibs(){
-		projectHelper.addLibrariesIntoProject(PROJECT_NAME, WELD_SE_JAR);
+		projectHelper.addLibrariesIntoProject(PROJECT_NAME, WELD_SE_JAR, isJava11FacetActivated);
 		ProjectExplorer pe = new ProjectExplorer();
 		pe.open();
 		pe.getProject(PROJECT_NAME).select();

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi10/CDIWebProjectWizardTestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi10/CDIWebProjectWizardTestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.wizard.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,9 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.wizard.template.CDIWebProjectWizardTemplate;
 
 @JRE(cleanup=true)
@@ -31,13 +28,7 @@ public class CDIWebProjectWizardTestCDI10 extends CDIWebProjectWizardTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
 	}
 	
 	public CDIWebProjectWizardTestCDI10(){

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi10/DynamicWebProjectWithCDITestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi10/DynamicWebProjectWithCDITestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.wizard.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,9 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.wizard.template.ProjectWithCDITemplate;
 import org.junit.Before;
 
@@ -32,23 +29,24 @@ public class DynamicWebProjectWithCDITestCDI10 extends ProjectWithCDITemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
 	}
 	
 	public DynamicWebProjectWithCDITestCDI10(){
+		CDIVersion = "1.0";
 		enabledByDefault = false;
 		expectedProblemAdded = "Missing beans.xml file in the project";
 	}
 	
+	/*
+	 * Override of @Before annotation is needed because tests requires another type
+	 * of project to be created (not the same type of project which is created in
+	 * the CDITestBase @Before method)
+	 */
 	@Before
-	public void createWebProjectBeforeClass() {
-		super.createWebProject();
+	@Override
+	public void prepareWorkspace() {
+		super.createDynamicWebProject();
 	}
 
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi10/EjbProjectWithCDITestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi10/EjbProjectWithCDITestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.wizard.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,9 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.wizard.template.ProjectWithCDITemplate;
 import org.junit.Before;
 
@@ -32,24 +29,25 @@ public class EjbProjectWithCDITestCDI10 extends ProjectWithCDITemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
 	}
 	
 	public EjbProjectWithCDITestCDI10(){
+		CDIVersion = "1.0";
 		enabledByDefault = false;
 		PROJECT_NAME = "EjbProject";
 		ignoredProblem = "An EJB module must contain one or more enterprise beans";
 		expectedProblemAdded = "Missing beans.xml file in the project";
 	}
 	
+	/*
+	 * Override of @Before annotation is needed because tests requires another type
+	 * of project to be created (not the same type of project which is created in
+	 * the CDITestBase @Before method)
+	 */
 	@Before
-	public void createEjbProjectBeforeClass() {
+	@Override
+	public void prepareWorkspace() {
 		super.createEjbProject();
 	}
 	

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi10/UtilityProjectWithCDITestCDI10.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi10/UtilityProjectWithCDITestCDI10.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.wizard.cdi10;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,9 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.wizard.template.ProjectWithCDITemplate;
 import org.junit.Before;
 
@@ -32,23 +29,24 @@ public class UtilityProjectWithCDITestCDI10 extends ProjectWithCDITemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.AS()),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI10();
 	}
 	
 	public UtilityProjectWithCDITestCDI10(){
+		CDIVersion = "1.0";
 		enabledByDefault = true;
 		PROJECT_NAME = "UtilityProject";
 		expectedProblemAdded = "Missing beans.xml file in the project";
 	}
 	
+	/*
+	 * Override of @Before annotation is needed because tests requires another type
+	 * of project to be created (not the same type of project which is created in
+	 * the CDITestBase @Before method)
+	 */
 	@Before
-	public void createUtilityProjectBeforeClass() {
+	@Override
+	public void prepareWorkspace() {
 		super.createUtilityProject();
 	}
 

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/CDIWebProjectWizardTestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/CDIWebProjectWizardTestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.wizard.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,9 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.wizard.template.CDIWebProjectWizardTemplate;
 
 @JRE(cleanup=true)
@@ -31,15 +28,7 @@ public class CDIWebProjectWizardTestCDI11 extends CDIWebProjectWizardTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
 	}
 	
 	public CDIWebProjectWizardTestCDI11(){

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/DynamicWebProjectWithCDITestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/DynamicWebProjectWithCDITestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.wizard.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,9 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.wizard.template.ProjectWithCDITemplate;
 import org.junit.Before;
 
@@ -32,24 +29,23 @@ public class DynamicWebProjectWithCDITestCDI11 extends ProjectWithCDITemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
 	}
 	
 	public DynamicWebProjectWithCDITestCDI11(){
 		enabledByDefault = true;
+		CDIVersion = "1.2";
 	}
 	
+	/*
+	 * Override of @Before annotation is needed because tests requires another type
+	 * of project to be created (not the same type of project which is created in
+	 * the CDITestBase @Before method)
+	 */
 	@Before
-	public void createWebProjectBeforeClass() {
-		super.createWebProject();
+	@Override
+	public void prepareWorkspace() {
+		super.createDynamicWebProject();
 	}
 
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/EjbProjectWithCDITestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/EjbProjectWithCDITestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.wizard.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,9 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.wizard.template.ProjectWithCDITemplate;
 import org.junit.Before;
 
@@ -32,24 +29,23 @@ public class EjbProjectWithCDITestCDI11 extends ProjectWithCDITemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
 	}
 	
 	public EjbProjectWithCDITestCDI11(){
 		enabledByDefault = true;
 		PROJECT_NAME = "EjbProject";
+		CDIVersion = "1.2";
 	}
 	
+	/*
+	 * Override of @Before annotation is needed because tests requires another type
+	 * of project to be created (not the same type of project which is created in
+	 * the CDITestBase @Before method)
+	 */
 	@Before
-	public void createEjbProjectBeforeClass() {
+	@Override
+	public void prepareWorkspace() {
 		super.createEjbProject();
 	}
 

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/UtilityProjectWithCDITestCDI11.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi11/UtilityProjectWithCDITestCDI11.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.wizard.cdi11;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,9 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.wizard.template.ProjectWithCDITemplate;
 import org.junit.Before;
 
@@ -32,24 +29,23 @@ public class UtilityProjectWithCDITestCDI11 extends ProjectWithCDITemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "13"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI11();
 	}
 	
 	public UtilityProjectWithCDITestCDI11(){
 		enabledByDefault = true;
 		PROJECT_NAME = "UtilityProject";
+		CDIVersion = "1.2";
 	}
 	
+	/*
+	 * Override of @Before annotation is needed because tests requires another type
+	 * of project to be created (not the same type of project which is created in
+	 * the CDITestBase @Before method)
+	 */
 	@Before
-	public void createUtilityProjectBeforeClass() {
+	@Override
+	public void prepareWorkspace() {
 		super.createUtilityProject();
 	}
 

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi20/CDIWebProjectWizardTestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi20/CDIWebProjectWizardTestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.wizard.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,9 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.wizard.template.CDIWebProjectWizardTemplate;
 
 /**
@@ -36,15 +33,7 @@ public class CDIWebProjectWizardTestCDI20 extends CDIWebProjectWizardTemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public CDIWebProjectWizardTestCDI20(){

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi20/DynamicWebProjectWithCDITestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi20/DynamicWebProjectWithCDITestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.wizard.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,9 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.wizard.template.ProjectWithCDITemplate;
 import org.junit.Before;
 
@@ -37,15 +34,7 @@ public class DynamicWebProjectWithCDITestCDI20 extends ProjectWithCDITemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public DynamicWebProjectWithCDITestCDI20(){
@@ -53,9 +42,15 @@ public class DynamicWebProjectWithCDITestCDI20 extends ProjectWithCDITemplate{
 		CDIVersion = "2.0";
 	}
 	
+	/*
+	 * Override of @Before annotation is needed because tests requires another type
+	 * of project to be created (not the same type of project which is created in
+	 * the CDITestBase @Before method)
+	 */
 	@Before
-	public void createWebProjectBeforeClass() {
-		super.createWebProject();
+	@Override
+	public void prepareWorkspace() {
+		super.createDynamicWebProject();
 	}
 
 }

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi20/EjbProjectWithCDITestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi20/EjbProjectWithCDITestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.wizard.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,9 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.wizard.template.ProjectWithCDITemplate;
 import org.junit.Before;
 
@@ -37,15 +34,7 @@ public class EjbProjectWithCDITestCDI20 extends ProjectWithCDITemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public EjbProjectWithCDITestCDI20(){
@@ -54,8 +43,14 @@ public class EjbProjectWithCDITestCDI20 extends ProjectWithCDITemplate{
 		CDIVersion = "2.0";
 	}
 	
+	/*
+	 * Override of @Before annotation is needed because tests requires another type
+	 * of project to be created (not the same type of project which is created in
+	 * the CDITestBase @Before method)
+	 */
 	@Before
-	public void createEjbProjectBeforeClass() {
+	@Override
+	public void prepareWorkspace() {
 		super.createEjbProject();
 	}
 

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi20/UtilityProjectWithCDITestCDI20.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/cdi20/UtilityProjectWithCDITestCDI20.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.bot.test.wizard.cdi20;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
@@ -19,9 +18,7 @@ import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
-import org.jboss.ide.eclipse.as.reddeer.server.family.ServerMatcher;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
-import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.bot.test.wizard.template.ProjectWithCDITemplate;
 import org.junit.Before;
 
@@ -37,15 +34,7 @@ public class UtilityProjectWithCDITestCDI20 extends ProjectWithCDITemplate{
 
 	@RequirementRestriction
 	public static Collection<RequirementMatcher> getRestrictionMatcher() {
-		if (CDITestBase.isJavaLE8()) { 
-			return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"));
-		} else {
-			return Arrays.asList(
-					new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-					new RequirementMatcher(JBossServer.class, VERSION, "16"),
-					new RequirementMatcher(JRE.class, VERSION, "1.8"));
-		}
+		return getRestrictionMatcherCDI20();
 	}
 	
 	public UtilityProjectWithCDITestCDI20(){
@@ -54,8 +43,14 @@ public class UtilityProjectWithCDITestCDI20 extends ProjectWithCDITemplate{
 		CDIVersion = "2.0";
 	}
 	
+	/*
+	 * Override of @Before annotation is needed because tests requires another type
+	 * of project to be created (not the same type of project which is created in
+	 * the CDITestBase @Before method)
+	 */
 	@Before
-	public void createUtilityProjectBeforeClass() {
+	@Override
+	public void prepareWorkspace() {
 		super.createUtilityProject();
 	}
 

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/template/ProjectWithCDITemplate.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/wizard/template/ProjectWithCDITemplate.java
@@ -20,61 +20,45 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.reddeer.common.exception.WaitTimeoutExpiredException;
-import org.eclipse.reddeer.common.wait.AbstractWait;
 import org.eclipse.reddeer.common.wait.TimePeriod;
 import org.eclipse.reddeer.common.wait.WaitUntil;
 import org.eclipse.reddeer.common.wait.WaitWhile;
 import org.eclipse.reddeer.eclipse.condition.ProblemExists;
-import org.eclipse.reddeer.eclipse.core.resources.Project;
 import org.eclipse.reddeer.eclipse.jst.ejb.ui.project.facet.EjbProjectFirstPage;
 import org.eclipse.reddeer.eclipse.jst.ejb.ui.project.facet.EjbProjectWizard;
 import org.eclipse.reddeer.eclipse.jst.j2ee.ui.project.facet.UtilityProjectFirstPage;
 import org.eclipse.reddeer.eclipse.jst.j2ee.ui.project.facet.UtilityProjectWizard;
 import org.eclipse.reddeer.eclipse.jst.servlet.ui.project.facet.WebProjectFirstPage;
 import org.eclipse.reddeer.eclipse.jst.servlet.ui.project.facet.WebProjectWizard;
+import org.eclipse.reddeer.eclipse.selectionwizard.NewMenuWizard;
 import org.eclipse.reddeer.eclipse.ui.navigator.resources.ProjectExplorer;
 import org.eclipse.reddeer.eclipse.ui.problems.Problem;
 import org.eclipse.reddeer.eclipse.ui.views.markers.ProblemsView;
 import org.eclipse.reddeer.eclipse.ui.views.markers.ProblemsView.ProblemType;
+import org.eclipse.reddeer.eclipse.wst.web.ui.wizards.DataModelFacetCreationWizardPage;
+import org.eclipse.reddeer.requirements.cleanworkspace.CleanWorkspaceRequirement.CleanWorkspace;
 import org.eclipse.reddeer.swt.condition.ShellIsAvailable;
 import org.eclipse.reddeer.swt.impl.button.LabeledCheckBox;
 import org.eclipse.reddeer.swt.impl.button.PushButton;
 import org.eclipse.reddeer.swt.impl.menu.ContextMenu;
 import org.eclipse.reddeer.swt.impl.shell.DefaultShell;
 import org.eclipse.reddeer.swt.impl.tree.DefaultTreeItem;
-import org.eclipse.reddeer.workbench.handler.EditorHandler;
 import org.hamcrest.core.StringContains;
+import org.jboss.tools.cdi.bot.test.CDITestBase;
 import org.jboss.tools.cdi.reddeer.condition.SpecificProblemExists;
 import org.junit.After;
 import org.junit.Test;
 
-public class ProjectWithCDITemplate{
+@CleanWorkspace
+public class ProjectWithCDITemplate extends CDITestBase {
 	
-	protected String CDIVersion;
-	
-	protected String PROJECT_NAME = "CDIProject";
 	protected boolean enabledByDefault = true;
 	protected String ignoredProblem;
 	protected String expectedProblemAdded;
-	
-	protected static final String VERSION = "version";
-	protected static final String FAMILY = "family";
 
 	@After
-	public void cleanUp() {
-		EditorHandler.getInstance().closeAll(false);
-		ProjectExplorer pe = new ProjectExplorer();
-		pe.open();
-		for(Project p: pe.getProjects()){
-			try{
-				org.eclipse.reddeer.direct.project.Project.delete(p.getName(), true, true);
-			} catch (Exception ex) {
-				AbstractWait.sleep(TimePeriod.DEFAULT);
-				if(!p.getTreeItem().isDisposed()){
-					org.eclipse.reddeer.direct.project.Project.delete(p.getName(), true, true);
-				}
-			}
-		}
+	public void cleanUpTheWorkspace() {
+		cleanUp();
 	}
 	
 	@Test
@@ -205,30 +189,21 @@ public class ProjectWithCDITemplate{
 	}
 	
 	public void createUtilityProject() {
-		UtilityProjectWizard uw = new UtilityProjectWizard();
-		uw.open();
-		UtilityProjectFirstPage up = new UtilityProjectFirstPage(uw);
-		up.setProjectName(PROJECT_NAME);
-		up.activateFacet("1.8", "Java");
-		uw.finish();
+		NewMenuWizard pw = new UtilityProjectWizard();
+		DataModelFacetCreationWizardPage fp = new UtilityProjectFirstPage(pw);
+		createProject(pw, fp);
 	}
 
-	public void createWebProject() {
-		WebProjectWizard dw = new WebProjectWizard();
-		dw.open();
-		WebProjectFirstPage fp = new WebProjectFirstPage(dw);
-		fp.setProjectName(PROJECT_NAME);
-		fp.activateFacet("1.8", "Java");
-		dw.finish();
+	public void createDynamicWebProject() {
+		NewMenuWizard pw = new WebProjectWizard();
+		DataModelFacetCreationWizardPage fp = new WebProjectFirstPage(pw);
+		createProject(pw, fp);
 	}
 	
 	public void createEjbProject() {
-		EjbProjectWizard dw = new EjbProjectWizard();
-		dw.open();
-		EjbProjectFirstPage fp = new EjbProjectFirstPage(dw);
-		fp.setProjectName(PROJECT_NAME);
-		fp.activateFacet("1.8", "Java");
-		dw.finish();
+		NewMenuWizard pw = new EjbProjectWizard();
+		DataModelFacetCreationWizardPage fp = new EjbProjectFirstPage(pw);
+		createProject(pw, fp);
 	}
 
 }


### PR DESCRIPTION
Perform the following tasks:

 - Update cdi pom.xml for WF 18 and Java 11, extend the requirements.json file
 - Perform necessary refactoring
 - Add missing constructors for several class
 - Fix several failing tests

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>


**JIRA:** https://issues.jboss.org/browse/JBIDE-26750
**JENKINS jobs:**
- https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cdi10.itests/578/
- https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cdi11.itests/677/
- https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cdi20.itests/297/

please review @odockal @jkopriva 

