### PR TITLE
JBIDE-26997 - Enable deploy on server by default in all example itests (EAP, WildFly and Java EE itests)

### DIFF
--- a/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
@@ -31,7 +31,7 @@
 		<jbosstools.test.jboss-eap-7.x.url>http://download.eng.brq.redhat.com/released/JBoss-middleware/eap7/7.2.1/jboss-eap-7.2.1-full-build.zip</jbosstools.test.jboss-eap-7.x.url>
 		<surefire.timeout>18000</surefire.timeout>
 		<skipTests>false</skipTests>
-		<deployOnServer>false</deployOnServer>
+		<deployOnServer>true</deployOnServer>
 	</properties>
 	<build>
 		<resources>


### PR DESCRIPTION
Set deploy on server on true as default in examples itests (in EAP, WildFly and Java EE integration tests).

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>

**Jira:** https://issues.redhat.com/browse/JBIDE-26997

Please review @jkopriva 