### PR TITLE
JBIDE-27022 - Update Java EE example.itests to use Java EE 8 repo

### DIFF
--- a/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
@@ -19,13 +19,15 @@
 		<systemProperties>${integrationTestsSystemProperties} -DexamplesLocation=${project.build.directory}/${examplesFolder} -Dmaven.settings.path=${maven.settings.path} -Drd.config=${reddeer.config} -DspecificQuickstarts=${specificQuickstarts} -DdeployOnServer=${deployOnServer}</systemProperties>
 		<quickstartsURLWildFly>https://github.com/wildfly/quickstart/archive/${wildflyVersion}.zip</quickstartsURLWildFly>
 		<quickstartsURLEAP>http://download.eng.brq.redhat.com/released/JBoss-middleware/eap7/7.2.1/jboss-eap-7.2.1-quickstarts.zip</quickstartsURLEAP>
-		<quickstartsURLJavaEE>https://github.com/javaee-samples/javaee7-samples/archive/master.zip</quickstartsURLJavaEE>
+		<quickstartsURLJavaEE7>https://github.com/javaee-samples/javaee7-samples/archive/master.zip</quickstartsURLJavaEE7>
+		<quickstartsURLJavaEE8>https://github.com/javaee-samples/javaee8-samples/archive/master.zip</quickstartsURLJavaEE8>
 		<maven.settings.path>${project.build.directory}/classes/settings.xml</maven.settings.path>
 		<reddeer.config.wildfly>${project.build.directory}/classes/servers/wildfly.json</reddeer.config.wildfly>
 		<reddeer.config.eap7>${project.build.directory}/classes/servers/eap-7.json</reddeer.config.eap7>
 		<examplesFolderWildFly>quickstart-${wildflyVersion}</examplesFolderWildFly>
 		<examplesFolderEAP>jboss-eap-7.2.1.GA-quickstarts</examplesFolderEAP>
-		<examplesFolderJavaEE>javaee7-samples-master</examplesFolderJavaEE>
+		<examplesFolderJavaEE7>javaee7-samples-master</examplesFolderJavaEE7>
+		<examplesFolderJavaEE8>javaee8-samples-master</examplesFolderJavaEE8>
 		<jbosstools.test.wildfly.home>${requirementsDirectory}/wildfly-${wildflyVersion}</jbosstools.test.wildfly.home>
 		<jbosstools.test.eap7.home>${requirementsDirectory}/jboss-eap-7.2</jbosstools.test.eap7.home>
 		<jbosstools.test.jboss-eap-7.x.url>http://download.eng.brq.redhat.com/released/JBoss-middleware/eap7/7.2.1/jboss-eap-7.2.1-full-build.zip</jbosstools.test.jboss-eap-7.x.url>
@@ -227,7 +229,7 @@
 				<test.class>org.jboss.tools.examples.ui.bot.test.integration.WildFlyImportQuickstartsTest</test.class>
 				<reddeer.config>${project.build.directory}/classes/servers/wildfly.json</reddeer.config>
 				<examplesLocation>${project.build.directory}/${examplesFolder}</examplesLocation>
-				<examplesFolder>${examplesFolderJavaEE}</examplesFolder>
+				<examplesFolder>${examplesFolderJavaEE7}</examplesFolder>
 			</properties>
 			<build>
 				<plugins>
@@ -242,7 +244,97 @@
 									<goal>wget</goal>
 								</goals>
 								<configuration>
-									<url>${quickstartsURLJavaEE}</url>
+									<url>${quickstartsURLJavaEE7}</url>
+									<unpack>true</unpack>
+									<outputDirectory>${project.build.directory}</outputDirectory>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-dependency-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>download-wildfly</id>
+								<phase>pre-integration-test</phase>
+								<goals>
+									<goal>unpack</goal>
+								</goals>
+								<configuration>
+									<artifactItems>
+										<artifactItem>
+											<groupId>org.wildfly</groupId>
+											<artifactId>wildfly-dist</artifactId>
+											<version>${wildflyVersion}</version>
+											<type>zip</type>
+										</artifactItem>
+									</artifactItems>
+									<skip>${skipTests}</skip>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-surefire-plugin</artifactId>
+						<configuration>
+							<testClass>org.jboss.tools.examples.ui.bot.test.integration.WildFlyImportQuickstartsTest</testClass>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>target-platform-configuration</artifactId>
+						<configuration>
+							<dependency-resolution>
+								<extraRequirements>
+									<requirement>
+										<type>p2-installable-unit</type>
+										<id>com.ianbrandt.tools.m2e.mdp.feature.feature.group</id>
+										<versionRange>0.0.0</versionRange>
+									</requirement>
+									<requirement>
+										<type>p2-installable-unit</type>
+										<id>com.coderplus.m2e.jaxws.feature.group</id>
+										<versionRange>0.0.0</versionRange>
+									</requirement>
+								</extraRequirements>
+							</dependency-resolution>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+			<repositories>
+				<repository>
+					<id>jaxws-repo</id>
+					<name>jaxws-repo</name>
+					<layout>p2</layout>
+					<url>https://coderplus.github.io/m2e-connector-for-jaxws-maven-plugin/</url>
+				</repository>
+			</repositories>
+		</profile>
+		<profile>
+			<id>JavaEE8</id>
+			<properties>
+				<test.class>org.jboss.tools.examples.ui.bot.test.integration.WildFlyImportQuickstartsTest</test.class>
+				<reddeer.config>${project.build.directory}/classes/servers/wildfly.json</reddeer.config>
+				<examplesLocation>${project.build.directory}/${examplesFolder}</examplesLocation>
+				<examplesFolder>${examplesFolderJavaEE8}</examplesFolder>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.googlecode.maven-download-plugin</groupId>
+						<artifactId>download-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>download-examples-javaee8</id>
+								<phase>pre-integration-test</phase>
+								<goals>
+									<goal>wget</goal>
+								</goals>
+								<configuration>
+									<url>${quickstartsURLJavaEE8}</url>
 									<unpack>true</unpack>
 									<outputDirectory>${project.build.directory}</outputDirectory>
 								</configuration>
@@ -446,7 +538,7 @@
 				<test.class>org.jboss.tools.examples.ui.bot.test.integration.WildFlyImportQuickstartsTest</test.class>
 				<reddeer.config>${project.build.directory}/classes/servers/wildfly.json</reddeer.config>
 				<examplesLocation>${project.build.directory}/${examplesFolder}</examplesLocation>
-				<examplesFolder>${examplesFolderJavaEE}</examplesFolder>
+				<examplesFolder>${examplesFolderJavaEE7}</examplesFolder>
 				<specificQuickstarts>util,test-utils,jta</specificQuickstarts>
 			</properties>
 			<build>
@@ -462,7 +554,70 @@
 									<goal>wget</goal>
 								</goals>
 								<configuration>
-									<url>${quickstartsURLJavaEE}</url>
+									<url>${quickstartsURLJavaEE7}</url>
+									<unpack>true</unpack>
+									<outputDirectory>${project.build.directory}</outputDirectory>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-dependency-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>download-wildfly</id>
+								<phase>pre-integration-test</phase>
+								<goals>
+									<goal>unpack</goal>
+								</goals>
+								<configuration>
+									<artifactItems>
+										<artifactItem>
+											<groupId>org.wildfly</groupId>
+											<artifactId>wildfly-dist</artifactId>
+											<version>${wildflyVersion}</version>
+											<type>zip</type>
+										</artifactItem>
+									</artifactItems>
+									<skip>${skipTests}</skip>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-surefire-plugin</artifactId>
+						<configuration>
+							<testClass>org.jboss.tools.examples.ui.bot.test.integration.WildFlyImportQuickstartsTest</testClass>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>SmokeTestsJavaEE8</id>
+			<properties>
+				<test.class>org.jboss.tools.examples.ui.bot.test.integration.WildFlyImportQuickstartsTest</test.class>
+				<reddeer.config>${project.build.directory}/classes/servers/wildfly.json</reddeer.config>
+				<examplesLocation>${project.build.directory}/${examplesFolder}</examplesLocation>
+				<examplesFolder>${examplesFolderJavaEE8}</examplesFolder>
+				<specificQuickstarts>util,test-utils,jta</specificQuickstarts>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.googlecode.maven-download-plugin</groupId>
+						<artifactId>download-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>download-examples-javaee8</id>
+								<phase>pre-integration-test</phase>
+								<goals>
+									<goal>wget</goal>
+								</goals>
+								<configuration>
+									<url>${quickstartsURLJavaEE8}</url>
 									<unpack>true</unpack>
 									<outputDirectory>${project.build.directory}</outputDirectory>
 								</configuration>


### PR DESCRIPTION
- pom.xml updated
- new Jenkins job created (with appropriate default parameters) - https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/examples.javaee8.it.weekly/

**Jenkins (the new job for Java EE 8):** https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/examples.javaee8.it.weekly/
**JIRA:** https://issues.redhat.com/browse/JBIDE-27022

Please review @jkopriva @odockal 