### PR TITLE
Add missing profile for cdi 2.0 smoke suite to the pom.xml

### DIFF
--- a/tests/org.jboss.tools.cdi.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.bot.test/pom.xml
@@ -42,6 +42,12 @@
 			</properties>
 		</profile>
 		<profile>
+			<id>cdi20-smoke-tests</id>
+			<properties>
+				<suiteClass>org.jboss.tools.cdi.bot.test.CDI20SmokeSuite</suiteClass>
+			</properties>
+		</profile>
+		<profile>
 			<id>all-bot-tests</id>
 			<properties>
 				<suiteClass>org.jboss.tools.cdi.bot.test.CDIAllBotTests</suiteClass>


### PR DESCRIPTION
Add missing profile for cdi 2.0 smoke suite to the pom.xml. Jenkins run includes the build and run using the newly added profile.

<img width="783" alt="Snímek obrazovky 2020-03-08 v 10" src="https://user-images.githubusercontent.com/43820055/76166181-e24ffd80-615c-11ea-95de-78f4a049feb3.png">


**Jira:** https://issues.redhat.com/browse/JBIDE-27087
**Jenkins:** https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cdi20.itests/490/



Please review @jkopriva @odockal 