### PR TITLE
JBIDE-27118 - Update WildFly version in cdi.itests to version 19

### DIFF
--- a/tests/org.jboss.tools.cdi.bot.test/pom.xml
+++ b/tests/org.jboss.tools.cdi.bot.test/pom.xml
@@ -17,7 +17,7 @@
 		<surefire.timeout>14400</surefire.timeout>
 		<jbosstools.test.jboss-as-7.1.home>${requirementsDirectory}/jboss-as-7.1.1.Final</jbosstools.test.jboss-as-7.1.home>
 		<jbosstools.test.wildfly.13.home>${requirementsDirectory}/wildfly-13.0.0.Final</jbosstools.test.wildfly.13.home>
-		<jbosstools.test.wildfly.18.home>${requirementsDirectory}/wildfly-18.0.0.Final</jbosstools.test.wildfly.18.home>
+		<jbosstools.test.wildfly.19.home>${requirementsDirectory}/wildfly-19.0.0.Final</jbosstools.test.wildfly.19.home>
 		<jbosstools.test.weld-se.home>${requirementsDirectory}/weld/se/</jbosstools.test.weld-se.home>
 		<jbosstools.test.weld-api.home>${requirementsDirectory}/weld/api/</jbosstools.test.weld-api.home>
 	</properties>
@@ -138,7 +138,7 @@
 						</configuration>
 					</execution>
 					<execution>
-						<id>wildfly18</id>
+						<id>wildfly19</id>
 						<phase>pre-integration-test</phase>
 						<goals>
 							<goal>unpack</goal>
@@ -149,7 +149,7 @@
 								<artifactItem>
 									<groupId>org.wildfly</groupId>
 									<artifactId>wildfly-dist</artifactId>
-									<version>18.0.0.Final</version>
+									<version>19.0.0.Final</version>
 									<type>zip</type>
 								</artifactItem>
 							</artifactItems>

--- a/tests/org.jboss.tools.cdi.bot.test/resources/servers/requirements.json
+++ b/tests/org.jboss.tools.cdi.bot.test/resources/servers/requirements.json
@@ -1,8 +1,8 @@
 {
 	"org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer": [
 		{
-			"runtime": "${jbosstools.test.wildfly.18.home}",
-			"version": "18",
+			"runtime": "${jbosstools.test.wildfly.19.home}",
+			"version": "19",
 			"family": "WILDFLY",
 			"runtimeEnvironment": "JavaSE-11"
 		},

--- a/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDITestBase.java
+++ b/tests/org.jboss.tools.cdi.bot.test/src/org/jboss/tools/cdi/bot/test/CDITestBase.java
@@ -122,7 +122,7 @@ public class CDITestBase {
 
 	protected static Collection<RequirementMatcher> getRestrictionMatcherCDI20() {
 		return Arrays.asList(new RequirementMatcher(JBossServer.class, FAMILY, ServerMatcher.WildFly()),
-				new RequirementMatcher(JBossServer.class, VERSION, "18"),
+				new RequirementMatcher(JBossServer.class, VERSION, "19"),
 				new RequirementMatcher(JRE.class, VERSION, "11"));
 
 	}


### PR DESCRIPTION
JBIDE-27118 - Update WildFly version in cdi.itests to version 19

**Jira:** https://issues.redhat.com/browse/JBIDE-27118
**Jenkins - first run - CDI 1.2 OK, CDI 2.0 blocked by JBIDE-27147:** 
https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cdi12.itests/768/
https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cdi20.itests/503/

Current state - CDI 2.0 issue (JBIDE-27147) reported and fixed in this PR. Tests passed on localhost, all Jenkins runs are blocked by mysterious Jenkins issue - JBIDE-27148.

@odockal @jkopriva I suggest resolve the mystery blocker and then rerun the tests on Jenkins. After that we can merge.