### PR TITLE
Update WildFly to version 19 in livereload itests

### DIFF
--- a/tests/org.jboss.tools.livereload.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.livereload.ui.bot.test/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<suiteClass>org.jboss.tools.livereload.ui.bot.test.LivereloadAllBotTests</suiteClass>
 		<systemProperties>-Drd.logCollectorEnabled=false -Drd.config=target/classes/servers/wildfly.json</systemProperties>
-		<jbosstools.test.wildfly.home>${requirementsDirectory}/wildfly-15.0.0.Final</jbosstools.test.wildfly.home>
+		<jbosstools.test.wildfly.home>${requirementsDirectory}/wildfly-19.0.0.Final</jbosstools.test.wildfly.home>
 	</properties>
 
 	<build>
@@ -43,7 +43,7 @@
 								<artifactItem>
 									<groupId>org.wildfly</groupId>
 									<artifactId>wildfly-dist</artifactId>
-									<version>15.0.0.Final</version>
+									<version>19.0.0.Final</version>
 									<type>zip</type>
 								</artifactItem>
 							</artifactItems>

--- a/tests/org.jboss.tools.livereload.ui.bot.test/resources/servers/wildfly.json
+++ b/tests/org.jboss.tools.livereload.ui.bot.test/resources/servers/wildfly.json
@@ -2,7 +2,7 @@
 	"org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer": [
 		{
 			"runtime": "${jbosstools.test.wildfly.home}",
-			"version": "15",
+			"version": "19",
 			"family": "WILDFLY"
 		}
 	]


### PR DESCRIPTION
Update WildFly to version 19 in livereload itests

**Jira:** https://issues.redhat.com/browse/JBIDE-27154
**Jenkins:** https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/DSL%20Jobs%20seed/job/Studio/job/Quality/job/Integration-tests/job/livereload-itests/17/

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>

Please review @jkopriva @odockal 