### PR TITLE
JBIDE-27117 - Update WildFly version in maven.itests to version 19

### DIFF
--- a/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
@@ -12,7 +12,7 @@
 
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
-		<wildflyVersion>18.0.0.Final</wildflyVersion>
+		<wildflyVersion>19.0.0.Final</wildflyVersion>
 		<requirementsDirectory>${project.build.directory}/requirements</requirementsDirectory>
 		<jbosstools.test.wildfly.home>${requirementsDirectory}/wildfly-${wildflyVersion}</jbosstools.test.wildfly.home>
 		<systemProperties>${integrationTestsSystemProperties} -Drd.config=${project.build.directory}/classes/servers/wildfly.json -Djbosstools.test.seam.2.1.0.home=${requirementsDirectory}/jboss-seam-2.1.2 -Djbosstools.test.seam.2.3.0.home=${requirementsDirectory}/jboss-seam-2.3.0.Final -Djbosstools.test.seam.2.2.0.home=${requirementsDirectory}/jboss-seam-2.2.0.GA -Dproject.build.directory=${project.build.directory} -Dmaven.settings.path=target/classes/usersettings/settings.xml -Dscope=${scope} -Djbosstools.test.wildfly.home=${jbosstools.test.wildfly.home}</systemProperties>

--- a/tests/org.jboss.tools.maven.ui.bot.test/resources/servers/wildfly.json
+++ b/tests/org.jboss.tools.maven.ui.bot.test/resources/servers/wildfly.json
@@ -2,7 +2,7 @@
 	"org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer": [
 		{
 			"runtime": "${jbosstools.test.wildfly.home}",
-			"version": "18",
+			"version": "19",
 			"family": "WILDFLY"
 		}
 	]

--- a/tests/org.jboss.tools.maven.ui.bot.test/src/org/jboss/tools/maven/ui/bot/test/project/JSFProjectTest.java
+++ b/tests/org.jboss.tools.maven.ui.bot.test/src/org/jboss/tools/maven/ui/bot/test/project/JSFProjectTest.java
@@ -10,12 +10,16 @@
  ******************************************************************************/ 
 package org.jboss.tools.maven.ui.bot.test.project;
 
+import org.eclipse.reddeer.common.exception.WaitTimeoutExpiredException;
 import org.eclipse.reddeer.common.wait.TimePeriod;
+import org.eclipse.reddeer.common.wait.WaitUntil;
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaPerspective;
 import org.eclipse.reddeer.junit.requirement.inject.InjectRequirement;
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
+import org.eclipse.reddeer.swt.condition.ShellIsAvailable;
+import org.eclipse.reddeer.swt.impl.button.PushButton;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.jsf.reddeer.ui.JSFNewProjectFirstPage;
@@ -47,6 +51,14 @@ public class JSFProjectTest extends AbstractMavenSWTBotTest{
 	@Test
 	public void createJSFProjectTestAS7JSFv22() {
 		createJSFProject(PROJECT_NAME7_V22, "JSF 2.2", "JSFKickStartWithoutLibs", sr.getRuntimeName());
+		// issue NODE-529
+		try {
+			new WaitUntil(new ShellIsAvailable("Missing node.js"), TimePeriod.DEFAULT);
+			new PushButton("OK").click();
+		}
+		catch (WaitTimeoutExpiredException e) {
+			// issue appears randomly
+		}
 		convertToMavenProject(PROJECT_NAME7_V22, "war", true);
 		addDependency(PROJECT_NAME7_V22, GROUPID,ARTIFACTID,JSF_VERSION_2_2);
 		buildProject(PROJECT_NAME7_V22,"..Maven build...","clean package",true);

--- a/tests/org.jboss.tools.maven.ui.bot.test/src/org/jboss/tools/maven/ui/bot/test/project/SCMCheckoutProject.java
+++ b/tests/org.jboss.tools.maven.ui.bot.test/src/org/jboss/tools/maven/ui/bot/test/project/SCMCheckoutProject.java
@@ -20,6 +20,7 @@ import org.eclipse.reddeer.swt.impl.button.PushButton;
 import org.eclipse.reddeer.swt.impl.shell.DefaultShell;
 import org.eclipse.reddeer.swt.impl.tree.DefaultTree;
 import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
+import org.eclipse.reddeer.workbench.impl.menu.WorkbenchPartMenuItem;
 import org.jboss.tools.maven.ui.bot.test.AbstractMavenSWTBotTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,6 +48,7 @@ public class SCMCheckoutProject extends AbstractMavenSWTBotTest {
 		ignoreM2eConnectors();
 		ProjectExplorer pe = new ProjectExplorer();
 		pe.open();
+		new WorkbenchPartMenuItem("Projects Presentation", "Flat").select();
 		assertTrue(pe.containsProject("eclipsetutorial"));
 		assertTrue(pe.containsProject("eclipsetutorial.core"));
 		assertTrue(pe.containsProject("eclipsetutorial.feature"));


### PR DESCRIPTION
JBIDE-27117 - Update WildFly version in maven.itests to version 19

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>

**JIRA:** https://issues.redhat.com/browse/JBIDE-27117
**JENKINS: (hash before rebase)** https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/DSL%20Jobs%20seed/job/Studio/job/Quality/job/Integration-tests/job/maven-itests/44/

Please review @jkopriva @odockal 