### PR TITLE
JBIDE-27086 - Update WildFly version in examples.itests to version 19

### DIFF
--- a/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.examples.ui.bot.test/pom.xml
@@ -15,7 +15,7 @@
 	<properties>
 		<!-- <systemProperties>${integrationTestsSystemProperties} -->
 		<!-- -DimportTestDefinition=${importTestDefinition}</systemProperties> -->
-		<wildflyVersion>18.0.0.Final</wildflyVersion>
+		<wildflyVersion>19.0.0.Final</wildflyVersion>
 		<systemProperties>${integrationTestsSystemProperties} -DexamplesLocation=${project.build.directory}/${examplesFolder} -Dmaven.settings.path=${maven.settings.path} -Drd.config=${reddeer.config} -DspecificQuickstarts=${specificQuickstarts} -DdeployOnServer=${deployOnServer}</systemProperties>
 		<quickstartsURLWildFly>https://github.com/wildfly/quickstart/archive/${wildflyVersion}.zip</quickstartsURLWildFly>
 		<quickstartsURLEAP>http://download.eng.brq.redhat.com/released/JBoss-middleware/eap7/7.2.1/jboss-eap-7.2.1-quickstarts.zip</quickstartsURLEAP>

--- a/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/wildfly-blacklist-test-errors-regexes.json
+++ b/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/wildfly-blacklist-test-errors-regexes.json
@@ -2,14 +2,8 @@
 	"*": [
 		".*Checkstyle execution failed due to an internal error. Please check the error log for details.*"
 	],
-	"jts": [
-		".*Invalid content was found starting with element.*",
-		".*Referenced file contains errors.*jboss-ejb3-spec-2_0\\.xsd.*"
-	],
-	"messaging-clustering-singleton": [
-		".*Referenced file contains errors.*jboss-ejb-delivery-active_1_1\\.xsd.*",
-		".*Referenced file contains errors.*jboss-ejb3-2_0\\.xsd.*",
-		".*Referenced file contains errors.*jboss-ejb3-spec-2_0\\.xsd.*"
+	"country-client": [
+		".*Multiple JAX-RS Activators are defined for the project.*"
 	],
 	"jaxws-retail": [
 		".*Customer cannot be resolved to a type.*",
@@ -22,7 +16,28 @@
 		".*The import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.ProfileMgmt cannot be resolved.*",
 		".*Type mismatch: cannot convert from ProfileMgmt to ProfileMgmt.*"
 	],
-	"spring-greeter":[
+	"microprofile-config":[
 		".*The superclass \"javax.servlet.http.HttpServlet\" was not found on the Java Build Path.*"
+	],
+	"ejb-security":[
+		".*Missing artifact org.wildfly.quickstarts:ejb-throws-exception.*",
+		".*The container 'Maven Dependencies' references non existing library '.*jar'.*",
+		".*The project cannot be built until build path errors are resolved.*"
+	],
+	"jsonp":[
+		".*Customer cannot be resolved to a type.*",
+		".*DiscountRequest cannot be resolved to a type.*",
+		".*DiscountResponse cannot be resolved to a type.*",
+		".*ProfileMgmt cannot be resolved to a type.*",
+		".*The import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.* cannot be resolved.*",
+		".*Type mismatch: cannot convert from ProfileMgmt to ProfileMgmt.*"
+	],
+	"hibernate":[
+		".*Customer cannot be resolved to a type.*",
+		".*DiscountRequest cannot be resolved to a type.*",
+		".*DiscountResponse cannot be resolved to a type.*",
+		".*ProfileMgmt cannot be resolved to a type.*",
+		".*The import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.* cannot be resolved.*",
+		".*Type mismatch: cannot convert from ProfileMgmt to ProfileMgmt.*"
 	]
 }

--- a/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/wildfly.json
+++ b/tests/org.jboss.tools.examples.ui.bot.test/resources/servers/wildfly.json
@@ -2,7 +2,7 @@
 	"org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer": [
 		{
 			"runtime": "${jbosstools.test.wildfly.home}",
-			"version": "18",
+			"version": "19",
 			"family": "WILDFLY"
 		}
 	]

--- a/tests/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/AbstractImportQuickstartsTest.java
+++ b/tests/org.jboss.tools.examples.ui.bot.test/src/org/jboss/tools/examples/ui/bot/test/integration/AbstractImportQuickstartsTest.java
@@ -442,6 +442,12 @@ public abstract class AbstractImportQuickstartsTest {
 			case "helloworld-classfiletransformer":
 				quickstartBaseNameJB = "helloworld-classfiletransformers";
 				break;
+			case "microprofile-openapi":
+				quickstartBaseNameJB = "microprofile-openapi-quickstart";
+				break;
+			case "microprofile-rest-client":
+				quickstartBaseNameJB = "country-client";
+				break;
 			default:
 				quickstartBaseNameJB = "jboss-" + quickstartBaseName;
 				break;


### PR DESCRIPTION
JBIDE-27086 - Update WildFly version in examples.itests to version 19

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>

Jenkins: https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/DSL%20Jobs%20seed/job/Studio/job/Quality/job/Integration-tests/job/examples-wildfly-itests/103/
JIRA: https://issues.redhat.com/browse/JBIDE-27086

Please review @odockal @jkopriva 