### PR TITLE
JBIDE-27313 - Update WildFly version in maven.itests to version 20

### DIFF
--- a/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.maven.ui.bot.test/pom.xml
@@ -12,7 +12,7 @@
 
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
-		<wildflyVersion>19.0.0.Final</wildflyVersion>
+		<wildflyVersion>20.0.0.Final</wildflyVersion>
 		<requirementsDirectory>${project.build.directory}/requirements</requirementsDirectory>
 		<jbosstools.test.wildfly.home>${requirementsDirectory}/wildfly-${wildflyVersion}</jbosstools.test.wildfly.home>
 		<systemProperties>${integrationTestsSystemProperties} -Drd.config=${project.build.directory}/classes/servers/wildfly.json -Djbosstools.test.seam.2.1.0.home=${requirementsDirectory}/jboss-seam-2.1.2 -Djbosstools.test.seam.2.3.0.home=${requirementsDirectory}/jboss-seam-2.3.0.Final -Djbosstools.test.seam.2.2.0.home=${requirementsDirectory}/jboss-seam-2.2.0.GA -Dproject.build.directory=${project.build.directory} -Dmaven.settings.path=target/classes/usersettings/settings.xml -Dscope=${scope} -Djbosstools.test.wildfly.home=${jbosstools.test.wildfly.home}</systemProperties>

--- a/tests/org.jboss.tools.maven.ui.bot.test/resources/servers/wildfly.json
+++ b/tests/org.jboss.tools.maven.ui.bot.test/resources/servers/wildfly.json
@@ -2,7 +2,7 @@
 	"org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer": [
 		{
 			"runtime": "${jbosstools.test.wildfly.home}",
-			"version": "19",
+			"version": "20",
 			"family": "WILDFLY"
 		}
 	]


### PR DESCRIPTION
Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>

**Jenkins:** https://studio-jenkins-csb-codeready.cloud.paas.psi.redhat.com/job/Studio/job/Quality/job/Integration-tests/job/maven-itests/21/
**Jira:** https://issues.redhat.com/browse/JBIDE-27313

**Issues in jenkins run:**
- https://issues.redhat.com/browse/JBIDE-27348 (caused by update of WF to version 20)
- https://issues.redhat.com/browse/JBIDE-27145 (caused by testing something, that does not hase to be tested; found when updating WF to version 19)

Please review @jkopriva 