### PR TITLE
Fix the failing maven itests due to the UI changes in the Preferences dialog

### DIFF
--- a/tests/org.jboss.tools.maven.ui.bot.test/src/org/jboss/tools/maven/ui/bot/test/AbstractMavenSWTBotTest.java
+++ b/tests/org.jboss.tools.maven.ui.bot.test/src/org/jboss/tools/maven/ui/bot/test/AbstractMavenSWTBotTest.java
@@ -284,7 +284,7 @@ public abstract class AbstractMavenSWTBotTest{
 	public static void setGit(){
 		WorkbenchPreferenceDialog wd = new WorkbenchPreferenceDialog();
 		wd.open();
-		wd.select("Team","Git","Label Decorations");
+		wd.select("Version Control (Team)","Git","Label Decorations");
 		new DefaultTabItem("Text Decorations").activate();
 		if(!new LabeledText("Projects:").getText().equals("{name}")){
 			new LabeledText("Projects:").setText("{name}");


### PR DESCRIPTION
**Jenkins:** https://studio-jenkins-csb-codeready.cloud.paas.psi.redhat.com/job/Studio/job/Quality/job/Integration-tests/job/maven-itests/171/
**Jira:** https://issues.redhat.com/browse/JBIDE-27725

Please review @jkopriva 

